### PR TITLE
ci: auto-request Copilot review on new PRs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,0 +1,21 @@
+name: Auto-request Copilot review
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: ['copilot']
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically assigns Copilot as a reviewer on every new PR
- Eliminates manual reviewer assignment — every PR gets automated code review out of the box

## Why
Ensures consistent code review coverage across all PRs without manual intervention. Demonstrates automated quality gates in the CI/CD pipeline.

## Test plan
- [ ] Open a new PR after this merges and verify Copilot is automatically assigned as reviewer