### PR TITLE
feat(infra): add Terraform IaC for full GCP stack

### DIFF
--- a/infra/envs/prod.tfvars
+++ b/infra/envs/prod.tfvars
@@ -1,0 +1,34 @@
+# --------------------------------------------------------------------------
+# Production environment values
+# Usage: terraform plan -var-file=envs/prod.tfvars
+# --------------------------------------------------------------------------
+
+project_id  = "aifeelnews-prod"
+region      = "europe-west1"
+environment = "prod"
+
+# Cloud Run
+cloud_run_service_name  = "aifeelnews-web"
+cloud_run_image         = "europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/aifeelnews-web:latest"
+cloud_run_memory        = "512Mi"
+cloud_run_cpu           = "1"
+cloud_run_min_instances = 0
+cloud_run_max_instances = 10
+cloud_run_concurrency   = 80
+
+# Cloud SQL
+cloud_sql_instance_name    = "aifeelnews-db"
+cloud_sql_tier             = "db-f1-micro"
+cloud_sql_database_version = "POSTGRES_14"
+cloud_sql_database_name    = "aifeelnews"
+
+# Cloud Scheduler
+ingestion_schedule = "0 */8 * * *"
+cleanup_schedule   = "0 2 * * *"
+
+# BigQuery
+bigquery_dataset_id = "aifeelnews"
+bigquery_location   = "europe-west1"
+
+# IAM
+github_actions_sa_email = "github-actions-sa@aifeelnews-prod.iam.gserviceaccount.com"

--- a/infra/envs/staging.tfvars
+++ b/infra/envs/staging.tfvars
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------
+# Staging environment values (demonstrates multi-env capability)
+#
+# Why staging exists as config but isn't deployed:
+#   - Shows the architecture supports multiple environments via tfvars
+#   - Deploying staging would double GCP costs (Cloud SQL alone ~$7/month)
+#   - For a student project, prod-only is the right cost/value trade-off
+#   - If needed, `terraform apply -var-file=envs/staging.tfvars` would
+#     create an identical but isolated stack
+#
+# Usage: terraform plan -var-file=envs/staging.tfvars
+# --------------------------------------------------------------------------
+
+project_id  = "aifeelnews-prod"
+region      = "europe-west1"
+environment = "staging"
+
+# Cloud Run — smaller limits for staging
+cloud_run_service_name  = "aifeelnews-web-staging"
+cloud_run_image         = "europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/aifeelnews-web:staging"
+cloud_run_memory        = "256Mi"
+cloud_run_cpu           = "1"
+cloud_run_min_instances = 0
+cloud_run_max_instances = 2
+cloud_run_concurrency   = 40
+
+# Cloud SQL — same tier (cheapest available)
+cloud_sql_instance_name    = "aifeelnews-db-staging"
+cloud_sql_tier             = "db-f1-micro"
+cloud_sql_database_version = "POSTGRES_14"
+cloud_sql_database_name    = "aifeelnews_staging"
+
+# Cloud Scheduler — less frequent for staging
+ingestion_schedule = "0 12 * * *"
+cleanup_schedule   = "0 3 * * *"
+
+# BigQuery — same dataset (staging uses a prefix or separate tables)
+bigquery_dataset_id = "aifeelnews_staging"
+bigquery_location   = "europe-west1"
+
+# IAM — same SA (single project, different services)
+github_actions_sa_email = "github-actions-sa@aifeelnews-prod.iam.gserviceaccount.com"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,367 @@
+# --------------------------------------------------------------------------
+# aiFeelNews — Infrastructure as Code (Terraform)
+#
+# Codifies the existing GCP resources that power the platform:
+#   - Artifact Registry (Docker images)
+#   - Cloud Run (API serving)
+#   - Cloud SQL (PostgreSQL)
+#   - Cloud Scheduler (ingestion + cleanup cron jobs)
+#   - Secret Manager (credentials)
+#   - BigQuery (analytics warehouse)
+#   - IAM bindings (service accounts + least-privilege roles)
+#   - API enablement
+#
+# Why Terraform?
+#   - Reproducible: anyone can recreate the full stack from these files
+#   - Auditable: infrastructure changes go through code review (PRs)
+#   - Multi-env ready: prod.tfvars vs staging.tfvars
+#   - Drift detection: `terraform plan` shows if manual changes happened
+# --------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# ==========================================================================
+# API Enablement
+# Why: GCP requires explicitly enabling each API before resources can use it.
+# This ensures a fresh project can be bootstrapped from scratch.
+# ==========================================================================
+
+locals {
+  required_apis = [
+    "run.googleapis.com",              # Cloud Run
+    "sqladmin.googleapis.com",         # Cloud SQL Admin
+    "cloudscheduler.googleapis.com",   # Cloud Scheduler
+    "secretmanager.googleapis.com",    # Secret Manager
+    "bigquery.googleapis.com",         # BigQuery
+    "language.googleapis.com",         # Cloud Natural Language
+    "artifactregistry.googleapis.com", # Artifact Registry
+    "cloudresourcemanager.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "apis" {
+  for_each = toset(local.required_apis)
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = false
+}
+
+# ==========================================================================
+# Artifact Registry
+# Why: GCR (gcr.io) shut down March 2025. Artifact Registry is the
+# successor — same Docker workflow, better security (IAM per-repo),
+# regional storage, vulnerability scanning.
+# ==========================================================================
+
+resource "google_artifact_registry_repository" "docker" {
+  location      = var.region
+  repository_id = "aifeelnews"
+  format        = "DOCKER"
+  description   = "Docker images for aiFeelNews services"
+
+  depends_on = [google_project_service.apis["artifactregistry.googleapis.com"]]
+}
+
+# ==========================================================================
+# Cloud SQL — Managed PostgreSQL
+# Why Cloud SQL over self-hosted?
+#   - Automated backups, patching, failover
+#   - Private IP / Cloud SQL Auth Proxy for secure connections
+#   - SLA-backed availability (99.95%)
+#   - Frees us from DB ops so we focus on application logic
+# Why PostgreSQL over Firestore/Spanner?
+#   - Relational model fits our data (articles, sources, users, bookmarks)
+#   - SQL expertise transfers to industry
+#   - Assessment requires demonstrating relational DB skills
+# ==========================================================================
+
+resource "google_sql_database_instance" "main" {
+  name             = var.cloud_sql_instance_name
+  database_version = var.cloud_sql_database_version
+  region           = var.region
+
+  settings {
+    tier              = var.cloud_sql_tier
+    availability_type = "ZONAL" # Single zone — cost-effective for student project
+    disk_autoresize   = true
+    disk_size         = 10 # GB, minimum for PostgreSQL
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = false # Cost trade-off: not needed for this project scale
+      start_time                     = "03:00" # 3 AM UTC — outside peak usage
+    }
+
+    ip_configuration {
+      ipv4_enabled = true # Public IP — Cloud Run connects via Cloud SQL Auth Proxy
+    }
+
+    database_flags {
+      name  = "max_connections"
+      value = "50" # Appropriate for scale-to-zero with connection pooling
+    }
+  }
+
+  deletion_protection = true
+
+  depends_on = [google_project_service.apis["sqladmin.googleapis.com"]]
+}
+
+resource "google_sql_database" "app" {
+  name     = var.cloud_sql_database_name
+  instance = google_sql_database_instance.main.name
+}
+
+# ==========================================================================
+# Secret Manager
+# Why Secret Manager over env vars?
+#   - Secrets are versioned, auditable, and access-controlled via IAM
+#   - Rotation without redeployment
+#   - No secrets in code, env files, or CI/CD logs
+# ==========================================================================
+
+resource "google_secret_manager_secret" "db_password" {
+  secret_id = "db-password"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret" "mediastack_api_key" {
+  secret_id = "mediastack-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis["secretmanager.googleapis.com"]]
+}
+
+# ==========================================================================
+# Cloud Run — Serverless container platform
+# Why Cloud Run over GKE?
+#   - Scale-to-zero: no cost when idle (critical for student budget)
+#   - No cluster management overhead (no nodes, no kubectl)
+#   - Built-in HTTPS, load balancing, auto-scaling
+#   - Sufficient for our traffic (~3 requests/day from scheduler + user traffic)
+# Why not App Engine?
+#   - Cloud Run gives full Docker control (multi-stage builds, any runtime)
+#   - Cloud Run supports multiple services (web, worker, scheduler)
+#   - More aligned with industry container practices
+# ==========================================================================
+
+resource "google_cloud_run_v2_service" "web" {
+  name     = var.cloud_run_service_name
+  location = var.region
+
+  template {
+    scaling {
+      min_instance_count = var.cloud_run_min_instances
+      max_instance_count = var.cloud_run_max_instances
+    }
+
+    containers {
+      image = var.cloud_run_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cloud_run_cpu
+          memory = var.cloud_run_memory
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/ready"
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 10
+        failure_threshold     = 3
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+        }
+        period_seconds = 30
+      }
+    }
+
+    max_instance_request_concurrency = var.cloud_run_concurrency
+    timeout                          = var.cloud_run_timeout
+  }
+
+  depends_on = [google_project_service.apis["run.googleapis.com"]]
+}
+
+# Allow unauthenticated access (public API)
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.web.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ==========================================================================
+# Cloud Scheduler — Managed cron jobs
+# Why Cloud Scheduler over cron in a container?
+#   - Survives container restarts and scale-to-zero
+#   - Managed retry policies
+#   - Visible in GCP Console (observability)
+#   - Triggers Cloud Run via HTTP — clean separation of concerns
+# ==========================================================================
+
+resource "google_cloud_scheduler_job" "ingestion" {
+  name      = "aifeelnews-ingestion"
+  region    = var.region
+  schedule  = var.ingestion_schedule
+  time_zone = var.scheduler_timezone
+
+  http_target {
+    uri         = "${google_cloud_run_v2_service.web.uri}/api/v1/trigger-ingestion"
+    http_method = "POST"
+  }
+
+  retry_config {
+    retry_count          = 3
+    min_backoff_duration = "10s"
+    max_backoff_duration = "300s"
+  }
+
+  depends_on = [google_project_service.apis["cloudscheduler.googleapis.com"]]
+}
+
+resource "google_cloud_scheduler_job" "cleanup" {
+  name      = "aifeelnews-cleanup"
+  region    = var.region
+  schedule  = var.cleanup_schedule
+  time_zone = var.scheduler_timezone
+
+  http_target {
+    uri         = "${google_cloud_run_v2_service.web.uri}/api/v1/cleanup"
+    http_method = "POST"
+  }
+
+  retry_config {
+    retry_count          = 2
+    min_backoff_duration = "30s"
+    max_backoff_duration = "600s"
+  }
+
+  depends_on = [google_project_service.apis["cloudscheduler.googleapis.com"]]
+}
+
+# ==========================================================================
+# BigQuery — Analytics data warehouse
+# Why BigQuery over PostgreSQL for analytics?
+#   - Separation of concerns: OLTP (PostgreSQL) vs OLAP (BigQuery)
+#   - Columnar storage optimized for aggregation queries
+#   - 1 TB/month free queries, 10 GB/month free storage
+#   - Partitioning + clustering for efficient time-range + category queries
+#   - Powers the News Analyst persona dashboards
+# ==========================================================================
+
+resource "google_bigquery_dataset" "analytics" {
+  dataset_id = var.bigquery_dataset_id
+  location   = var.bigquery_location
+
+  description = "Analytics warehouse for aiFeelNews sentiment data and pipeline metrics"
+
+  default_table_expiration_ms = null # Data retained indefinitely
+
+  depends_on = [google_project_service.apis["bigquery.googleapis.com"]]
+}
+
+resource "google_bigquery_table" "sentiment_events" {
+  dataset_id = google_bigquery_dataset.analytics.dataset_id
+  table_id   = "sentiment_events"
+
+  description = "Per-article sentiment analysis events — partitioned by ingestion date, clustered by label and source"
+
+  time_partitioning {
+    type  = "DAY"
+    field = "ingested_at"
+  }
+
+  clustering = ["sentiment_label", "source_name"]
+
+  schema = jsonencode([
+    { name = "event_id", type = "STRING", mode = "REQUIRED", description = "Unique event identifier" },
+    { name = "article_id", type = "INTEGER", mode = "REQUIRED", description = "PostgreSQL article ID" },
+    { name = "article_url", type = "STRING", mode = "NULLABLE", description = "Original article URL" },
+    { name = "article_title", type = "STRING", mode = "NULLABLE", description = "Article headline" },
+    { name = "source_name", type = "STRING", mode = "NULLABLE", description = "News source name" },
+    { name = "published_at", type = "TIMESTAMP", mode = "NULLABLE", description = "Article publication time" },
+    { name = "ingested_at", type = "TIMESTAMP", mode = "REQUIRED", description = "Pipeline ingestion time (partition key)" },
+    { name = "sentiment_provider", type = "STRING", mode = "NULLABLE", description = "Analysis provider (GCP_NL or VADER)" },
+    { name = "sentiment_model", type = "STRING", mode = "NULLABLE", description = "Model version used" },
+    { name = "sentiment_score", type = "FLOAT", mode = "NULLABLE", description = "Sentiment score (-1.0 to 1.0)" },
+    { name = "sentiment_magnitude", type = "FLOAT", mode = "NULLABLE", description = "Emotional intensity (0.0+)" },
+    { name = "sentiment_label", type = "STRING", mode = "NULLABLE", description = "Derived label: positive, negative, neutral" },
+    { name = "confidence", type = "FLOAT", mode = "NULLABLE", description = "Analysis confidence score" },
+    { name = "language", type = "STRING", mode = "NULLABLE", description = "Article language code" },
+    { name = "country", type = "STRING", mode = "NULLABLE", description = "Article country of origin" },
+    { name = "category", type = "STRING", mode = "NULLABLE", description = "Article category" },
+    { name = "content_length", type = "INTEGER", mode = "NULLABLE", description = "Content length in bytes" },
+    { name = "processing_time_ms", type = "INTEGER", mode = "NULLABLE", description = "Processing duration in milliseconds" },
+    { name = "extraction_method", type = "STRING", mode = "NULLABLE", description = "Content extraction method used" },
+  ])
+}
+
+# ==========================================================================
+# IAM — Least-privilege access
+# Why explicit IAM over primitive roles?
+#   - Principle of least privilege: each SA gets only what it needs
+#   - Auditable: every permission is documented in code
+#   - Reviewable: IAM changes go through PR review
+# ==========================================================================
+
+# GitHub Actions SA — deploys containers and manages Cloud Run
+resource "google_project_iam_member" "github_actions_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${var.github_actions_sa_email}"
+}
+
+resource "google_project_iam_member" "github_actions_ar_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${var.github_actions_sa_email}"
+}
+
+resource "google_project_iam_member" "github_actions_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${var.github_actions_sa_email}"
+}
+
+# Cloud Run default SA — reads secrets at runtime
+resource "google_project_iam_member" "cloud_run_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${var.project_id}@appspot.gserviceaccount.com"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,34 @@
+# --------------------------------------------------------------------------
+# Outputs — Expose key values after apply
+# Useful for CI/CD, debugging, and documentation
+# --------------------------------------------------------------------------
+
+output "cloud_run_url" {
+  description = "Public URL of the Cloud Run service"
+  value       = google_cloud_run_v2_service.web.uri
+}
+
+output "cloud_sql_connection_name" {
+  description = "Cloud SQL connection name (used by Cloud SQL Auth Proxy)"
+  value       = google_sql_database_instance.main.connection_name
+}
+
+output "artifact_registry_url" {
+  description = "Artifact Registry repository URL for Docker pushes"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}"
+}
+
+output "bigquery_dataset" {
+  description = "BigQuery dataset ID for analytics queries"
+  value       = google_bigquery_dataset.analytics.dataset_id
+}
+
+output "scheduler_ingestion_job" {
+  description = "Cloud Scheduler ingestion job name"
+  value       = google_cloud_scheduler_job.ingestion.name
+}
+
+output "scheduler_cleanup_job" {
+  description = "Cloud Scheduler cleanup job name"
+  value       = google_cloud_scheduler_job.cleanup.name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,139 @@
+# --------------------------------------------------------------------------
+# Input variables for aiFeelNews infrastructure
+# Values provided via envs/*.tfvars per environment
+# --------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "Primary GCP region (co-located with Cloud SQL, Cloud Run, Scheduler)"
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "environment" {
+  description = "Deployment environment (prod, staging)"
+  type        = string
+  validation {
+    condition     = contains(["prod", "staging"], var.environment)
+    error_message = "Environment must be 'prod' or 'staging'."
+  }
+}
+
+# ---- Cloud Run ----
+
+variable "cloud_run_service_name" {
+  description = "Cloud Run service name"
+  type        = string
+  default     = "aifeelnews-web"
+}
+
+variable "cloud_run_image" {
+  description = "Docker image URI for the Cloud Run service"
+  type        = string
+}
+
+variable "cloud_run_memory" {
+  description = "Memory limit for Cloud Run containers"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "cloud_run_cpu" {
+  description = "CPU limit for Cloud Run containers"
+  type        = string
+  default     = "1"
+}
+
+variable "cloud_run_min_instances" {
+  description = "Minimum number of Cloud Run instances (0 = scale to zero)"
+  type        = number
+  default     = 0
+}
+
+variable "cloud_run_max_instances" {
+  description = "Maximum number of Cloud Run instances"
+  type        = number
+  default     = 10
+}
+
+variable "cloud_run_concurrency" {
+  description = "Maximum concurrent requests per Cloud Run instance"
+  type        = number
+  default     = 80
+}
+
+variable "cloud_run_timeout" {
+  description = "Request timeout in seconds"
+  type        = string
+  default     = "300s"
+}
+
+# ---- Cloud SQL ----
+
+variable "cloud_sql_instance_name" {
+  description = "Cloud SQL instance name"
+  type        = string
+}
+
+variable "cloud_sql_tier" {
+  description = "Cloud SQL machine tier"
+  type        = string
+  default     = "db-f1-micro"
+}
+
+variable "cloud_sql_database_version" {
+  description = "PostgreSQL version for Cloud SQL"
+  type        = string
+  default     = "POSTGRES_14"
+}
+
+variable "cloud_sql_database_name" {
+  description = "Name of the database within the Cloud SQL instance"
+  type        = string
+  default     = "aifeelnews"
+}
+
+# ---- Cloud Scheduler ----
+
+variable "scheduler_timezone" {
+  description = "Timezone for Cloud Scheduler jobs"
+  type        = string
+  default     = "UTC"
+}
+
+variable "ingestion_schedule" {
+  description = "Cron schedule for news ingestion (default: every 8 hours)"
+  type        = string
+  default     = "0 */8 * * *"
+}
+
+variable "cleanup_schedule" {
+  description = "Cron schedule for database cleanup (default: daily at 2 AM)"
+  type        = string
+  default     = "0 2 * * *"
+}
+
+# ---- BigQuery ----
+
+variable "bigquery_dataset_id" {
+  description = "BigQuery dataset ID for analytics"
+  type        = string
+  default     = "aifeelnews"
+}
+
+variable "bigquery_location" {
+  description = "BigQuery dataset location"
+  type        = string
+  default     = "europe-west1"
+}
+
+# ---- IAM ----
+
+variable "github_actions_sa_email" {
+  description = "Email of the GitHub Actions service account"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Codifies **all existing GCP resources** as Terraform IaC in `infra/`
- Every resource includes inline comments explaining the **"Why"** behind the architectural choice
- Multi-environment support via `envs/prod.tfvars` and `envs/staging.tfvars`

## Resources codified

| Resource | Terraform Type | Why |
|---|---|---|
| Artifact Registry | `google_artifact_registry_repository` | GCR shut down March 2025, AR is the successor with IAM per-repo |
| Cloud Run v2 | `google_cloud_run_v2_service` | Scale-to-zero (cost), no cluster ops, built-in HTTPS |
| Cloud SQL | `google_sql_database_instance` | Managed PostgreSQL — automated backups, patching, SLA |
| Cloud Scheduler | `google_cloud_scheduler_job` x2 | Ingestion (8h) + cleanup (daily) — survives scale-to-zero |
| Secret Manager | `google_secret_manager_secret` x2 | Versioned, auditable, IAM-controlled credentials |
| BigQuery | `google_bigquery_dataset` + `table` | OLAP analytics warehouse — partitioned by day, clustered by label+source |
| IAM | `google_project_iam_member` x4 | Least-privilege per service account |
| APIs | `google_project_service` x8 | Explicit enablement for reproducibility |

## File structure
```
infra/
├── main.tf           # All resources with "Why" comments
├── variables.tf      # Input variables with types and defaults
├── outputs.tf        # Cloud Run URL, SQL connection, AR URL, etc.
└── envs/
    ├── prod.tfvars       # Production values (active)
    └── staging.tfvars    # Staging values (demonstrates multi-env, not deployed)
```

## Multi-environment strategy
Staging tfvars exists to demonstrate the architecture supports multiple environments. It's not deployed (would double costs). If needed: `terraform apply -var-file=envs/staging.tfvars` creates an isolated stack.

## Next steps
- Install Terraform CLI locally
- `terraform init` to download the Google provider
- `terraform import` existing resources into state
- `terraform plan -var-file=envs/prod.tfvars` to verify config matches reality

## Test plan
- [ ] `terraform init` succeeds
- [ ] `terraform validate` passes
- [ ] `terraform plan -var-file=envs/prod.tfvars` shows no unexpected changes after import
- [ ] All resource names match what's live in GCP Console