### PR TITLE
feat(api): add structured logging and metrics endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,9 +9,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from app import models  # noqa: F401
 from app.database import Base, engine  # noqa: F401
 from app.routers import articles, bookmarks, sources, users
+from app.utils.logging import setup_logging
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
+# Structured logging (JSON in production, plain text locally)
+setup_logging()
 logger = logging.getLogger(__name__)
 
 # Import sentiment router with error handling
@@ -98,6 +99,59 @@ def get_version() -> dict[str, str]:
 def readiness_check() -> dict[str, str]:
     """Readiness check for Kubernetes deployments."""
     return {"status": "ready", "service": "aifeelnews-api"}
+
+
+@app.get("/metrics", tags=["Meta"])
+def metrics() -> dict[str, Any]:
+    """Lightweight application metrics for observability dashboards."""
+    from sqlalchemy import func
+
+    from app.database import SessionLocal
+    from app.models.article import Article
+    from app.models.crawl_job import CrawlJob
+    from app.models.sentiment_analysis import SentimentAnalysis
+    from app.models.source import Source
+
+    db = SessionLocal()
+    try:
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "articles": {
+                "total": db.query(func.count(Article.id)).scalar() or 0,
+                "sources": db.query(func.count(Source.id)).scalar() or 0,
+            },
+            "crawl_jobs": {
+                "total": db.query(func.count(CrawlJob.id)).scalar() or 0,
+                "by_status": dict(
+                    db.query(CrawlJob.status, func.count(CrawlJob.id))
+                    .group_by(CrawlJob.status)
+                    .all()
+                ),
+            },
+            "sentiment": {
+                "analyzed": db.query(func.count(SentimentAnalysis.id)).scalar() or 0,
+                "by_label": dict(
+                    db.query(
+                        SentimentAnalysis.sentiment_label,
+                        func.count(SentimentAnalysis.id),
+                    )
+                    .group_by(SentimentAnalysis.sentiment_label)
+                    .all()
+                ),
+            },
+            "database": {
+                "status": "connected",
+                "pool_size": db.bind.pool.size() if hasattr(db.bind, "pool") else None,
+            },
+        }
+    except Exception as e:
+        logger.error(f"Metrics collection failed: {e}")
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "error": str(e),
+        }
+    finally:
+        db.close()
 
 
 @app.post("/api/v1/trigger-ingestion")

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -1,0 +1,65 @@
+"""Structured JSON logging compatible with Google Cloud Logging.
+
+Uses JSON in production (auto-parsed by Cloud Logging) and plain text locally.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+
+class CloudJsonFormatter(logging.Formatter):
+    """Format log records as JSON that Cloud Logging auto-parses."""
+
+    SEVERITY_MAP = {
+        logging.DEBUG: "DEBUG",
+        logging.INFO: "INFO",
+        logging.WARNING: "WARNING",
+        logging.ERROR: "ERROR",
+        logging.CRITICAL: "CRITICAL",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "severity": self.SEVERITY_MAP.get(record.levelno, "DEFAULT"),
+            "message": record.getMessage(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "logger": record.name,
+            "module": record.module,
+        }
+
+        if record.exc_info and record.exc_info[0] is not None:
+            log_entry["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_entry)
+
+
+def setup_logging() -> None:
+    """Configure application-wide logging.
+
+    JSON in production (Cloud Logging), plain text locally (readability).
+    """
+    env = os.getenv("ENV", "development")
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(getattr(logging, log_level, logging.INFO))
+
+    root_logger.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stdout)
+
+    if env in ("production", "prod"):
+        handler.setFormatter(CloudJsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
+        )
+
+    root_logger.addHandler(handler)
+
+    # Quiet noisy libraries
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- **Structured JSON logging** (`app/utils/logging.py`) — auto-parsed by Cloud Logging in production, plain text locally for readability
- **`GET /metrics` endpoint** — lightweight application metrics for observability dashboards

## Metrics response example
```json
{
  "timestamp": "2026-02-18T...",
  "articles": { "total": 4500, "sources": 12 },
  "crawl_jobs": { "total": 1200, "by_status": { "COMPLETED": 1100, "FAILED": 50, "PENDING": 50 } },
  "sentiment": { "analyzed": 3800, "by_label": { "positive": 1500, "neutral": 1800, "negative": 500 } },
  "database": { "status": "connected", "pool_size": 5 }
}
```

## Logging behavior
| Environment | Format | Example |
|---|---|---|
| `ENV=production` | JSON (Cloud Logging) | `{"severity":"INFO","message":"...","timestamp":"..."}` |
| `ENV=development` | Plain text | `2026-02-18 INFO app.main: ...` |

## Observability approach
Lightweight by design — no Prometheus/Grafana stack, no external dependencies. Cloud Logging handles log aggregation natively, and the `/metrics` endpoint provides application-level insights via a single DB query. Appropriate for project scale and budget.

## Test plan
- [ ] `GET /metrics` returns valid JSON with all fields
- [ ] Logs output JSON when `ENV=production`
- [ ] Logs output plain text when `ENV=development`
- [ ] Noisy libraries (uvicorn.access, sqlalchemy.engine) are quieted