### PR TITLE
fix(infra): remove Cloud Run from Terraform, fix IAM and secrets

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -104,7 +104,7 @@ def readiness_check() -> dict[str, str]:
 @app.get("/metrics", tags=["Meta"])
 def metrics() -> dict[str, Any]:
     """Lightweight application metrics for observability dashboards."""
-    from sqlalchemy import func
+    from sqlalchemy import func, select
 
     from app.database import SessionLocal
     from app.models.article import Article
@@ -114,41 +114,42 @@ def metrics() -> dict[str, Any]:
 
     db = SessionLocal()
     try:
+        # SQLAlchemy 2.0 select() style — proper type support
+        article_count = db.execute(select(func.count(Article.id))).scalar() or 0
+        source_count = db.execute(select(func.count(Source.id))).scalar() or 0
+        crawl_total = db.execute(select(func.count(CrawlJob.id))).scalar() or 0
+        sentiment_total = (
+            db.execute(select(func.count(SentimentAnalysis.id))).scalar() or 0
+        )
+
+        # Access column via __table__.c to avoid mypy conflict with
+        # legacy Column() type annotations on the model class
+        status_col = CrawlJob.__table__.c.status
+        crawl_by_status = {
+            str(row.status): row.count
+            for row in db.execute(
+                select(status_col, func.count(CrawlJob.id).label("count")).group_by(
+                    status_col
+                )
+            )
+        }
+
+        sentiment_by_label = {
+            str(row.sentiment_label): row.count
+            for row in db.execute(
+                select(
+                    SentimentAnalysis.sentiment_label,
+                    func.count(SentimentAnalysis.id).label("count"),
+                ).group_by(SentimentAnalysis.sentiment_label)
+            )
+        }
+
         return {
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "articles": {
-                "total": db.query(func.count(Article.id)).scalar() or 0,
-                "sources": db.query(func.count(Source.id)).scalar() or 0,
-            },
-            "crawl_jobs": {
-                "total": db.query(func.count(CrawlJob.id)).scalar() or 0,
-                "by_status": {
-                    str(status): count
-                    for status, count in db.query(
-                        CrawlJob.status, func.count(CrawlJob.id)
-                    )
-                    .group_by(CrawlJob.status)
-                    .all()
-                },
-            },
-            "sentiment": {
-                "analyzed": db.query(func.count(SentimentAnalysis.id)).scalar() or 0,
-                "by_label": {
-                    str(label): count
-                    for label, count in db.query(
-                        SentimentAnalysis.sentiment_label,
-                        func.count(SentimentAnalysis.id),
-                    )
-                    .group_by(SentimentAnalysis.sentiment_label)
-                    .all()
-                },
-            },
-            "database": {
-                "status": "connected",
-                "pool_size": getattr(
-                    getattr(db.bind, "pool", None), "size", lambda: None
-                )(),
-            },
+            "articles": {"total": article_count, "sources": source_count},
+            "crawl_jobs": {"total": crawl_total, "by_status": crawl_by_status},
+            "sentiment": {"analyzed": sentiment_total, "by_label": sentiment_by_label},
+            "database": {"status": "connected"},
         }
     except Exception as e:
         logger.error(f"Metrics collection failed: {e}")

--- a/app/main.py
+++ b/app/main.py
@@ -122,26 +122,32 @@ def metrics() -> dict[str, Any]:
             },
             "crawl_jobs": {
                 "total": db.query(func.count(CrawlJob.id)).scalar() or 0,
-                "by_status": dict(
-                    db.query(CrawlJob.status, func.count(CrawlJob.id))
+                "by_status": {
+                    str(status): count
+                    for status, count in db.query(
+                        CrawlJob.status, func.count(CrawlJob.id)
+                    )
                     .group_by(CrawlJob.status)
                     .all()
-                ),
+                },
             },
             "sentiment": {
                 "analyzed": db.query(func.count(SentimentAnalysis.id)).scalar() or 0,
-                "by_label": dict(
-                    db.query(
+                "by_label": {
+                    str(label): count
+                    for label, count in db.query(
                         SentimentAnalysis.sentiment_label,
                         func.count(SentimentAnalysis.id),
                     )
                     .group_by(SentimentAnalysis.sentiment_label)
                     .all()
-                ),
+                },
             },
             "database": {
                 "status": "connected",
-                "pool_size": db.bind.pool.size() if hasattr(db.bind, "pool") else None,
+                "pool_size": getattr(
+                    getattr(db.bind, "pool", None), "size", lambda: None
+                )(),
             },
         }
     except Exception as e:

--- a/infra/envs/prod.tfvars
+++ b/infra/envs/prod.tfvars
@@ -7,14 +7,8 @@ project_id  = "aifeelnews-prod"
 region      = "europe-west1"
 environment = "prod"
 
-# Cloud Run
-cloud_run_service_name  = "aifeelnews-web"
-cloud_run_image         = "europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/aifeelnews-web:latest"
-cloud_run_memory        = "512Mi"
-cloud_run_cpu           = "1"
-cloud_run_min_instances = 0
-cloud_run_max_instances = 10
-cloud_run_concurrency   = 80
+# Cloud Run (deployed by CI/CD, only URL needed for Scheduler targets)
+cloud_run_url = "https://aifeelnews-web-813770885946.europe-west1.run.app"
 
 # Cloud SQL
 cloud_sql_instance_name    = "aifeelnews-db"
@@ -32,3 +26,4 @@ bigquery_location   = "europe-west1"
 
 # IAM
 github_actions_sa_email = "github-actions-sa@aifeelnews-prod.iam.gserviceaccount.com"
+cloud_run_sa_email      = "813770885946-compute@developer.gserviceaccount.com"

--- a/infra/envs/staging.tfvars
+++ b/infra/envs/staging.tfvars
@@ -15,14 +15,8 @@ project_id  = "aifeelnews-prod"
 region      = "europe-west1"
 environment = "staging"
 
-# Cloud Run — smaller limits for staging
-cloud_run_service_name  = "aifeelnews-web-staging"
-cloud_run_image         = "europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/aifeelnews-web:staging"
-cloud_run_memory        = "256Mi"
-cloud_run_cpu           = "1"
-cloud_run_min_instances = 0
-cloud_run_max_instances = 2
-cloud_run_concurrency   = 40
+# Cloud Run (deployed by CI/CD, only URL needed for Scheduler targets)
+cloud_run_url = "https://aifeelnews-web-staging.europe-west1.run.app"
 
 # Cloud SQL — same tier (cheapest available)
 cloud_sql_instance_name    = "aifeelnews-db-staging"
@@ -40,3 +34,4 @@ bigquery_location   = "europe-west1"
 
 # IAM — same SA (single project, different services)
 github_actions_sa_email = "github-actions-sa@aifeelnews-prod.iam.gserviceaccount.com"
+cloud_run_sa_email      = "813770885946-compute@developer.gserviceaccount.com"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -156,75 +156,34 @@ resource "google_secret_manager_secret" "mediastack_api_key" {
   depends_on = [google_project_service.apis["secretmanager.googleapis.com"]]
 }
 
-# ==========================================================================
-# Cloud Run — Serverless container platform
-# Why Cloud Run over GKE?
-#   - Scale-to-zero: no cost when idle (critical for student budget)
-#   - No cluster management overhead (no nodes, no kubectl)
-#   - Built-in HTTPS, load balancing, auto-scaling
-#   - Sufficient for our traffic (~3 requests/day from scheduler + user traffic)
-# Why not App Engine?
-#   - Cloud Run gives full Docker control (multi-stage builds, any runtime)
-#   - Cloud Run supports multiple services (web, worker, scheduler)
-#   - More aligned with industry container practices
-# ==========================================================================
+resource "google_secret_manager_secret" "gcp_nlp_key" {
+  secret_id = "aifeelnews-gcp-nlp-key"
 
-resource "google_cloud_run_v2_service" "web" {
-  name     = var.cloud_run_service_name
-  location = var.region
-
-  template {
-    scaling {
-      min_instance_count = var.cloud_run_min_instances
-      max_instance_count = var.cloud_run_max_instances
-    }
-
-    containers {
-      image = var.cloud_run_image
-
-      ports {
-        container_port = 8080
-      }
-
-      resources {
-        limits = {
-          cpu    = var.cloud_run_cpu
-          memory = var.cloud_run_memory
-        }
-      }
-
-      startup_probe {
-        http_get {
-          path = "/ready"
-        }
-        initial_delay_seconds = 5
-        period_seconds        = 10
-        failure_threshold     = 3
-      }
-
-      liveness_probe {
-        http_get {
-          path = "/health"
-        }
-        period_seconds = 30
-      }
-    }
-
-    max_instance_request_concurrency = var.cloud_run_concurrency
-    timeout                          = var.cloud_run_timeout
+  replication {
+    auto {}
   }
 
-  depends_on = [google_project_service.apis["run.googleapis.com"]]
+  depends_on = [google_project_service.apis["secretmanager.googleapis.com"]]
 }
 
-# Allow unauthenticated access (public API)
-resource "google_cloud_run_v2_service_iam_member" "public" {
-  project  = var.project_id
-  location = var.region
-  name     = google_cloud_run_v2_service.web.name
-  role     = "roles/run.invoker"
-  member   = "allUsers"
+resource "google_secret_manager_secret" "firebase_sa" {
+  secret_id = "firebase-service-account-json"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis["secretmanager.googleapis.com"]]
 }
+
+# ==========================================================================
+# Cloud Run — NOT managed by Terraform
+# Cloud Run revisions are deployed by GitHub Actions (deploy.yml) on every
+# merge to main. Terraform managing the same service would conflict with
+# CI/CD and risk stripping env vars, volumes, and secrets from the live
+# service. Terraform manages the infrastructure Cloud Run depends on
+# (SQL, secrets, IAM, registry). CI/CD manages the application deployment.
+# ==========================================================================
 
 # ==========================================================================
 # Cloud Scheduler — Managed cron jobs
@@ -242,7 +201,7 @@ resource "google_cloud_scheduler_job" "ingestion" {
   time_zone = var.scheduler_timezone
 
   http_target {
-    uri         = "${google_cloud_run_v2_service.web.uri}/api/v1/trigger-ingestion"
+    uri         = "${var.cloud_run_url}/api/v1/trigger-ingestion"
     http_method = "POST"
   }
 
@@ -262,7 +221,7 @@ resource "google_cloud_scheduler_job" "cleanup" {
   time_zone = var.scheduler_timezone
 
   http_target {
-    uri         = "${google_cloud_run_v2_service.web.uri}/api/v1/cleanup"
+    uri         = "${var.cloud_run_url}/api/v1/cleanup"
     http_method = "POST"
   }
 
@@ -360,8 +319,9 @@ resource "google_project_iam_member" "github_actions_sa_user" {
 }
 
 # Cloud Run default SA — reads secrets at runtime
+# Uses Compute Engine default SA (Cloud Run's default when no custom SA is specified)
 resource "google_project_iam_member" "cloud_run_secret_accessor" {
   project = var.project_id
   role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${var.project_id}@appspot.gserviceaccount.com"
+  member  = "serviceAccount:${var.cloud_run_sa_email}"
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -3,11 +3,6 @@
 # Useful for CI/CD, debugging, and documentation
 # --------------------------------------------------------------------------
 
-output "cloud_run_url" {
-  description = "Public URL of the Cloud Run service"
-  value       = google_cloud_run_v2_service.web.uri
-}
-
 output "cloud_sql_connection_name" {
   description = "Cloud SQL connection name (used by Cloud SQL Auth Proxy)"
   value       = google_sql_database_instance.main.connection_name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -24,52 +24,12 @@ variable "environment" {
 }
 
 # ---- Cloud Run ----
+# Cloud Run service is deployed by CI/CD (deploy.yml), not Terraform.
+# Only the URL is needed here for Scheduler job targets.
 
-variable "cloud_run_service_name" {
-  description = "Cloud Run service name"
+variable "cloud_run_url" {
+  description = "Cloud Run service URL (used by Scheduler job targets)"
   type        = string
-  default     = "aifeelnews-web"
-}
-
-variable "cloud_run_image" {
-  description = "Docker image URI for the Cloud Run service"
-  type        = string
-}
-
-variable "cloud_run_memory" {
-  description = "Memory limit for Cloud Run containers"
-  type        = string
-  default     = "512Mi"
-}
-
-variable "cloud_run_cpu" {
-  description = "CPU limit for Cloud Run containers"
-  type        = string
-  default     = "1"
-}
-
-variable "cloud_run_min_instances" {
-  description = "Minimum number of Cloud Run instances (0 = scale to zero)"
-  type        = number
-  default     = 0
-}
-
-variable "cloud_run_max_instances" {
-  description = "Maximum number of Cloud Run instances"
-  type        = number
-  default     = 10
-}
-
-variable "cloud_run_concurrency" {
-  description = "Maximum concurrent requests per Cloud Run instance"
-  type        = number
-  default     = 80
-}
-
-variable "cloud_run_timeout" {
-  description = "Request timeout in seconds"
-  type        = string
-  default     = "300s"
 }
 
 # ---- Cloud SQL ----
@@ -135,5 +95,10 @@ variable "bigquery_location" {
 
 variable "github_actions_sa_email" {
   description = "Email of the GitHub Actions service account"
+  type        = string
+}
+
+variable "cloud_run_sa_email" {
+  description = "Email of the service account used by Cloud Run (Compute Engine default SA)"
   type        = string
 }


### PR DESCRIPTION
## Summary
- **Remove Cloud Run from Terraform** — CI/CD (deploy.yml) owns Cloud Run deployments. Having Terraform manage it would conflict and risk stripping env vars, volumes, and secrets from the live service.
- **Add missing secrets** — `aifeelnews-gcp-nlp-key` and `firebase-service-account-json` were discovered during `gcloud secrets list` but weren't in the original Terraform config.
- **Fix Cloud Run SA** — IAM binding was referencing non-existent App Engine default SA (`@appspot.gserviceaccount.com`). Fixed to use actual Compute Engine default SA (`813770885946-compute@developer.gserviceaccount.com`).
- **Scheduler URLs** — Now reference `var.cloud_run_url` instead of the removed Cloud Run resource.

All changes have been successfully applied to production via `terraform apply`.

## Test plan
- [x] `terraform apply` completed with 0 errors
- [x] All 15 new resources created (Artifact Registry, BigQuery, IAM, APIs)
- [x] 3 existing resources updated (Scheduler retry configs, Cloud SQL max_connections)
- [x] 0 resources destroyed
- [ ] Verify Cloud Run still serves traffic (CI/CD unaffected)
- [ ] Verify next scheduled ingestion/cleanup jobs fire correctly