### PR TITLE
feat(nlp): expand GCP NL to annotateText with entities and categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,8 @@ available_sources.csv
 # Terraform state (sensitive, auto-generated)
 infra/.terraform/
 infra/*.tfstate
-infra/*.tfstate.backup
+infra/*.tfstate.*
 infra/.terraform.lock.hcl
+
+# Assessment module descriptions (private, not part of the project)
+.github/mods/

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,8 +5,7 @@ from sqlalchemy import engine_from_config, pool
 from alembic import context
 from app.config import settings
 from app.database import Base
-from app.models.article import Article  # noqa: F401
-from app.models.source import Source  # noqa: F401
+from app.models import *  # noqa: F401, F403 — ensure all models register with Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/alembic/versions/c7d8e9f0a1b2_add_entities_article_entities_and_article_categories.py
+++ b/alembic/versions/c7d8e9f0a1b2_add_entities_article_entities_and_article_categories.py
@@ -1,0 +1,103 @@
+"""add entities, article_entities, and article_categories tables
+
+Revision ID: c7d8e9f0a1b2
+Revises: b1c2d3e4f5g6
+Create Date: 2026-02-19 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d8e9f0a1b2"
+down_revision: Union[str, None] = "b1c2d3e4f5g6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Canonical entities lookup table (no FKs to other new tables)
+    op.create_table(
+        "entities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("wikipedia_url", sa.String(length=1000), nullable=True),
+        sa.Column("mid", sa.String(length=100), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_entities_id"), "entities", ["id"])
+    op.create_index("ix_entities_name_type", "entities", ["name", "type"], unique=True)
+    op.create_index("ix_entities_name", "entities", ["name"])
+    op.create_index("ix_entities_type", "entities", ["type"])
+
+    # 2. Article-Entity M2M association table
+    op.create_table(
+        "article_entities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("article_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("salience", sa.Float(), nullable=False),
+        sa.Column(
+            "analyzed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["article_id"], ["articles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["entity_id"], ["entities.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_article_entities_id"), "article_entities", ["id"])
+    op.create_index(
+        "ix_article_entities_article_id", "article_entities", ["article_id"]
+    )
+    op.create_index("ix_article_entities_entity_id", "article_entities", ["entity_id"])
+    op.create_index(
+        "ix_article_entities_article_entity",
+        "article_entities",
+        ["article_id", "entity_id"],
+        unique=True,
+    )
+    op.create_index("ix_article_entities_salience", "article_entities", ["salience"])
+
+    # 3. Article categories (1:many)
+    op.create_table(
+        "article_categories",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("article_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=500), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column(
+            "analyzed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["article_id"], ["articles.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_article_categories_id"), "article_categories", ["id"])
+    op.create_index(
+        "ix_article_categories_article_id", "article_categories", ["article_id"]
+    )
+    op.create_index("ix_article_categories_name", "article_categories", ["name"])
+    op.create_index(
+        "ix_article_categories_confidence", "article_categories", ["confidence"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("article_categories")
+    op.drop_table("article_entities")
+    op.drop_table("entities")

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -131,7 +131,6 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
     domain = get_domain_from_url(url)
 
     try:
-
         logger.info(f"🔍 Crawling: {url}")
 
         # Update status to in progress
@@ -242,49 +241,86 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
             )
             db.add(content)
 
-        # Step 6: Perform sentiment analysis
-        logger.debug(f"Analyzing sentiment for {url}")
+        # Step 6: NLP analysis (sentiment + entities + categories)
+        logger.debug(f"Analyzing article content for {url}")
 
-        # Get configured provider info
         from app.config import config
-        from app.utils.sentiment import analyze_sentiment_gcp_nl
+        from app.models.article_category import ArticleCategory
+        from app.models.article_entity import ArticleEntity
+        from app.models.entity import Entity
+        from app.utils.sentiment import annotate_text_gcp_nl
 
         provider = config.sentiment.sentiment_provider
-
-        # Analyze sentiment with the configured provider (English only)
-        # We filter to English articles at ingestion
-        sentiment_label, sentiment_score = analyze_sentiment(article_text)
-
-        # For GCP NL, we can get additional metadata like magnitude
         magnitude = None
-        model_name = "vader_lexicon"  # default
+        model_name = "vader_lexicon"
+        entities_stored = 0
+        categories_stored = 0
 
         if provider == "GCP_NL":
-            # Get the full GCP NL response for additional metadata
-            try:
-                gcp_label, gcp_score, gcp_magnitude = analyze_sentiment_gcp_nl(
-                    article_text
-                )
-                magnitude = gcp_magnitude
-                model_name = "gcp_nl_v1"
-                # Use GCP results (they should match what analyze_sentiment returned)
-                sentiment_label, sentiment_score = gcp_label, gcp_score
-            except Exception as e:
-                logger.warning(f"Could not get GCP NL magnitude: {e}")
+            # Single annotateText call: sentiment + entities + categories
+            result = annotate_text_gcp_nl(article_text)
 
-        # Store sentiment analysis with proper provider metadata
+            if result is not None:
+                sentiment_label = result.sentiment_label
+                sentiment_score = result.sentiment_score
+                magnitude = result.sentiment_magnitude
+                model_name = "gcp_nl_v1"
+
+                # Store entities (get-or-create canonical Entity, then link)
+                for ent in result.entities:
+                    canonical = (
+                        db.query(Entity)
+                        .filter(Entity.name == ent.name, Entity.type == ent.type)
+                        .first()
+                    )
+                    if not canonical:
+                        canonical = Entity(
+                            name=ent.name,
+                            type=ent.type,
+                            wikipedia_url=ent.wikipedia_url,
+                            mid=ent.mid,
+                        )
+                        db.add(canonical)
+                        db.flush()  # Get the id without full commit
+
+                    article_entity = ArticleEntity(
+                        article_id=article.id,
+                        entity_id=canonical.id,
+                        salience=ent.salience,
+                    )
+                    db.add(article_entity)
+                    entities_stored += 1
+
+                # Store categories
+                for cat in result.categories:
+                    article_category = ArticleCategory(
+                        article_id=article.id,
+                        name=cat.name,
+                        confidence=cat.confidence,
+                    )
+                    db.add(article_category)
+                    categories_stored += 1
+            else:
+                # GCP NL failed — fall back to VADER for sentiment only
+                logger.warning("GCP NL annotateText failed, falling back to VADER")
+                sentiment_label, sentiment_score = analyze_sentiment(article_text)
+        else:
+            # VADER provider — sentiment only, no entities/categories
+            sentiment_label, sentiment_score = analyze_sentiment(article_text)
+
+        # Store sentiment analysis record
         sentiment_analysis = SentimentAnalysis(
             article_id=article.id,
-            provider=provider,
+            provider=provider if model_name == "gcp_nl_v1" else "VADER",
             model_name=model_name,
             score=sentiment_score,
             magnitude=magnitude,
             label=sentiment_label,
-            language="en",  # Hardcoded since we only ingest English articles
+            language="en",
         )
         db.add(sentiment_analysis)
 
-        # Update article with sentiment (for quick access)
+        # Update denormalized article fields
         article.sentiment_label = sentiment_label  # type: ignore[assignment]
         article.sentiment_score = sentiment_score  # type: ignore[assignment]
 
@@ -323,6 +359,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
             f"({sentiment_score:.3f}{magnitude_info})"
         )
         logger.info(sentiment_info)
+        logger.info(f"   Entities: {entities_stored}, Categories: {categories_stored}")
         content_info = (
             f"   Content: {len(article_text)} chars → "
             f"{len(truncated_text)} chars stored"
@@ -389,9 +426,7 @@ def create_crawl_jobs_for_articles(db: Session, limit: int = 20) -> int:
     # Find articles without crawl jobs
     articles_without_jobs = (
         db.query(Article)
-        .filter(
-            ~Article.id.in_(db.query(CrawlJob.article_id).distinct())
-        )  # type: ignore
+        .filter(~Article.id.in_(db.query(CrawlJob.article_id).distinct()))  # type: ignore
         .limit(limit)
         .all()
     )

--- a/app/jobs/ttl_demo.py
+++ b/app/jobs/ttl_demo.py
@@ -132,7 +132,7 @@ def run_ttl_demo():
     ttl_info = get_ttl_info()
     print("⚙️ TTL Configuration:")
     print(
-        f"   Duration: {ttl_info['ttl_hours']} hours ({ttl_info['ttl_hours']//24} days)"
+        f"   Duration: {ttl_info['ttl_hours']} hours ({ttl_info['ttl_hours'] // 24} days)"
     )
     print(
         f"   Current Time: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}"

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,17 @@ except Exception as e:
     logger.warning(f"Could not import sentiment router: {e}")
     sentiment_available = False
 
+# Import entities router with error handling
+entities_available = False
+entities_mod: Any = None
+try:
+    from app.routers import entities as entities_mod
+
+    entities_available = True
+except Exception as e:
+    logger.warning(f"Could not import entities router: {e}")
+    entities_available = False
+
 APP_VERSION = os.getenv("APP_VERSION", "1.0.1")
 app = FastAPI(title="aiFeelNews API", version=APP_VERSION)
 
@@ -54,6 +65,10 @@ app.include_router(sources.router, prefix="/sources", tags=["Sources"])
 # Register sentiment router if available
 if sentiment_available and sentiment:
     app.include_router(sentiment.router, prefix="/api/v1/sentiment")
+
+# Register entities router if available
+if entities_available and entities_mod:
+    app.include_router(entities_mod.router, prefix="/api/v1/entities")
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,7 +1,10 @@
 from app.models.article import Article  # noqa: F401
+from app.models.article_category import ArticleCategory  # noqa: F401
 from app.models.article_content import ArticleContent  # noqa: F401
+from app.models.article_entity import ArticleEntity  # noqa: F401
 from app.models.bookmark import Bookmark  # noqa: F401
 from app.models.crawl_job import CrawlJob  # noqa: F401
+from app.models.entity import Entity  # noqa: F401
 from app.models.sentiment_analysis import SentimentAnalysis  # noqa: F401
 from app.models.source import Source  # noqa: F401
 from app.models.user import User  # noqa: F401

--- a/app/models/article.py
+++ b/app/models/article.py
@@ -49,3 +49,15 @@ class Article(Base):
         cascade="all, delete-orphan",
         lazy="select",
     )
+    article_entities = relationship(
+        "ArticleEntity",
+        back_populates="article",
+        cascade="all, delete-orphan",
+        lazy="select",
+    )
+    article_categories = relationship(
+        "ArticleCategory",
+        back_populates="article",
+        cascade="all, delete-orphan",
+        lazy="select",
+    )

--- a/app/models/article_category.py
+++ b/app/models/article_category.py
@@ -1,0 +1,33 @@
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String, func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class ArticleCategory(Base):
+    """
+    GCP NL content classification categories for articles.
+
+    Stores taxonomy paths like "/News/Business" with confidence scores.
+    Simple 1:many from articles (categories are per-article, not deduplicated).
+    """
+
+    __tablename__ = "article_categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    article_id = Column(
+        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(500), nullable=False)  # Taxonomy path: "/News/Business"
+    confidence = Column(Float, nullable=False)  # 0.0 to 1.0
+
+    analyzed_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+
+    # Relationships
+    article = relationship("Article", back_populates="article_categories")
+
+    __table_args__ = (
+        Index("ix_article_categories_article_id", "article_id"),
+        Index("ix_article_categories_name", "name"),
+        Index("ix_article_categories_confidence", "confidence"),
+    )

--- a/app/models/article_entity.py
+++ b/app/models/article_entity.py
@@ -1,0 +1,41 @@
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class ArticleEntity(Base):
+    """
+    Association table for the Article <-> Entity M2M relationship.
+
+    Each row represents one entity mention within one article,
+    storing the article-specific salience score from GCP NL.
+    """
+
+    __tablename__ = "article_entities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    article_id = Column(
+        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    )
+    entity_id = Column(
+        Integer, ForeignKey("entities.id", ondelete="CASCADE"), nullable=False
+    )
+    salience = Column(Float, nullable=False)  # 0.0 to 1.0 relevance score
+    analyzed_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+
+    # Relationships
+    article = relationship("Article", back_populates="article_entities")
+    entity = relationship("Entity", back_populates="article_entities")
+
+    __table_args__ = (
+        Index("ix_article_entities_article_id", "article_id"),
+        Index("ix_article_entities_entity_id", "entity_id"),
+        Index(
+            "ix_article_entities_article_entity",
+            "article_id",
+            "entity_id",
+            unique=True,
+        ),
+        Index("ix_article_entities_salience", "salience"),
+    )

--- a/app/models/entity.py
+++ b/app/models/entity.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Column, DateTime, Index, Integer, String, func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class Entity(Base):
+    """
+    Canonical entity lookup table.
+
+    Stores unique (name, type) pairs extracted by GCP NL annotateText.
+    Entities are deduplicated: "Google" + "ORGANIZATION" appears once,
+    regardless of how many articles reference it.
+    """
+
+    __tablename__ = "entities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    type = Column(String(50), nullable=False)
+    wikipedia_url = Column(String(1000), nullable=True)
+    mid = Column(String(100), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+
+    # M2M relationship via association table
+    article_entities = relationship(
+        "ArticleEntity",
+        back_populates="entity",
+        cascade="all, delete-orphan",
+        lazy="select",
+    )
+
+    __table_args__ = (
+        Index("ix_entities_name_type", "name", "type", unique=True),
+        Index("ix_entities_name", "name"),
+        Index("ix_entities_type", "type"),
+    )

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -1,10 +1,11 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, subqueryload
 
 from app.database import get_db
 from app.models.article import Article as ArticleModel
+from app.models.article_entity import ArticleEntity
 from app.schemas.article import ArticleRead
 
 router = APIRouter(tags=["Articles"])
@@ -28,7 +29,12 @@ def get_latest_articles(
     articles = (
         db.query(ArticleModel)
         .options(
-            joinedload(ArticleModel.source), joinedload(ArticleModel.sentiment_analyses)
+            joinedload(ArticleModel.source),
+            joinedload(ArticleModel.sentiment_analyses),
+            subqueryload(ArticleModel.article_entities).joinedload(
+                ArticleEntity.entity
+            ),
+            subqueryload(ArticleModel.article_categories),
         )
         .order_by(ArticleModel.published_at.desc())
         .limit(limit)
@@ -39,7 +45,18 @@ def get_latest_articles(
 
 @router.get("/{article_id}", response_model=ArticleRead)
 def get_article(article_id: int, db: Session = Depends(get_db)) -> ArticleRead:
-    article = db.query(ArticleModel).filter_by(id=article_id).first()
+    article = (
+        db.query(ArticleModel)
+        .options(
+            joinedload(ArticleModel.source),
+            subqueryload(ArticleModel.article_entities).joinedload(
+                ArticleEntity.entity
+            ),
+            subqueryload(ArticleModel.article_categories),
+        )
+        .filter_by(id=article_id)
+        .first()
+    )
     if not article:
         raise HTTPException(status_code=404, detail="Article not found")
     return article  # type: ignore[return-value,no-any-return]

--- a/app/routers/entities.py
+++ b/app/routers/entities.py
@@ -1,0 +1,71 @@
+"""Entity analysis API endpoints."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.article_entity import ArticleEntity
+from app.models.entity import Entity
+from app.schemas.entity import EntityRead, EntityWithArticleCount
+
+router = APIRouter(tags=["Entities"])
+
+
+@router.get("/", response_model=List[EntityWithArticleCount])
+def list_entities(
+    db: Session = Depends(get_db),
+    entity_type: Optional[str] = Query(None, description="Filter by entity type"),
+    limit: int = Query(50, ge=1, le=200),
+    min_articles: int = Query(1, ge=1, description="Minimum article count"),
+) -> list:
+    """
+    List entities ordered by frequency (number of articles mentioning them).
+
+    Useful for discovering trending people, organizations, locations across news.
+    """
+    query = (
+        db.query(
+            Entity,
+            func.count(ArticleEntity.id).label("article_count"),
+        )
+        .join(ArticleEntity, Entity.id == ArticleEntity.entity_id)
+        .group_by(Entity.id)
+        .having(func.count(ArticleEntity.id) >= min_articles)
+        .order_by(func.count(ArticleEntity.id).desc())
+    )
+
+    if entity_type:
+        query = query.filter(Entity.type == entity_type.upper())
+
+    results = query.limit(limit).all()
+
+    return [
+        EntityWithArticleCount(
+            id=entity.id,
+            name=entity.name,
+            type=entity.type,
+            wikipedia_url=entity.wikipedia_url,
+            mid=entity.mid,
+            article_count=count,
+        )
+        for entity, count in results
+    ]
+
+
+@router.get("/types", response_model=List[str])
+def list_entity_types(db: Session = Depends(get_db)) -> list:
+    """List all distinct entity types in the database."""
+    types = db.query(Entity.type).distinct().order_by(Entity.type).all()
+    return [t[0] for t in types]
+
+
+@router.get("/{entity_id}", response_model=EntityRead)
+def get_entity(entity_id: int, db: Session = Depends(get_db)) -> EntityRead:
+    """Get a single entity by ID."""
+    entity = db.query(Entity).filter_by(id=entity_id).first()
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    return entity  # type: ignore[return-value,no-any-return]

--- a/app/schemas/article.py
+++ b/app/schemas/article.py
@@ -1,7 +1,9 @@
 from datetime import datetime
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field, HttpUrl, field_validator
+
+from app.schemas.entity import ArticleCategoryRead, ArticleEntityRead
 
 
 class ArticleBase(BaseModel):
@@ -72,6 +74,16 @@ class ArticleRead(ArticleBase):
     )
     sentiment_score: Optional[float] = Field(
         None, ge=-1.0, le=1.0, description="Latest sentiment score (-1 to 1)"
+    )
+
+    # Entity and category data (populated when GCP NL provider is used)
+    article_entities: Optional[List[ArticleEntityRead]] = Field(
+        default=None,
+        description="Named entities extracted from article content",
+    )
+    article_categories: Optional[List[ArticleCategoryRead]] = Field(
+        default=None,
+        description="Content categories from GCP NL classification",
     )
 
     model_config = {

--- a/app/schemas/entity.py
+++ b/app/schemas/entity.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class EntityRead(BaseModel):
+    """Schema for reading a canonical entity."""
+
+    id: int
+    name: str = Field(..., description="Entity name (e.g., 'Google')")
+    type: str = Field(..., description="Entity type (e.g., 'ORGANIZATION')")
+    wikipedia_url: Optional[str] = Field(None, description="Wikipedia URL if available")
+    mid: Optional[str] = Field(None, description="Google Knowledge Graph MID")
+
+    model_config = {"from_attributes": True}
+
+
+class ArticleEntityRead(BaseModel):
+    """Schema for an entity associated with an article."""
+
+    id: int
+    entity: EntityRead = Field(..., description="The canonical entity")
+    salience: float = Field(..., ge=0.0, le=1.0, description="Relevance to article")
+    analyzed_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ArticleCategoryRead(BaseModel):
+    """Schema for a GCP NL category associated with an article."""
+
+    id: int
+    name: str = Field(..., description="Taxonomy path (e.g., '/News/Business')")
+    confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Classification confidence"
+    )
+    analyzed_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class EntityWithArticleCount(BaseModel):
+    """Entity with count of associated articles, for the entities listing endpoint."""
+
+    id: int
+    name: str
+    type: str
+    wikipedia_url: Optional[str] = None
+    mid: Optional[str] = None
+    article_count: int = Field(
+        ..., description="Number of articles mentioning this entity"
+    )
+
+    model_config = {"from_attributes": True}

--- a/app/utils/gcp_nlp.py
+++ b/app/utils/gcp_nlp.py
@@ -1,13 +1,19 @@
 """
 Google Cloud Natural Language integration.
 
-This module provides a production-grade sentiment analysis client using
+This module provides a production-grade NLP client using
 Google Cloud Natural Language API with proper error handling, rate limiting,
 and abstraction that matches the existing sentiment provider interface.
+
+Uses annotateText for single-call extraction of:
+  - Document sentiment (score + magnitude)
+  - Named entities (people, organizations, locations, etc.)
+  - Content classification (taxonomy categories)
 """
 
 import logging
-from typing import Optional, Tuple
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
 
 from google.api_core import exceptions as gcp_exceptions  # type: ignore[import-untyped]
 from google.cloud import language_v1  # type: ignore[import-untyped]
@@ -15,6 +21,39 @@ from google.cloud import language_v1  # type: ignore[import-untyped]
 from app.config import config
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EntityResult:
+    """Single entity from GCP NL annotateText."""
+
+    name: str
+    type: str  # e.g., "PERSON", "ORGANIZATION", "LOCATION"
+    salience: float  # 0.0 to 1.0
+    wikipedia_url: Optional[str] = None
+    mid: Optional[str] = None
+
+
+@dataclass
+class CategoryResult:
+    """Single category from GCP NL annotateText."""
+
+    name: str  # Taxonomy path, e.g., "/News/Business"
+    confidence: float  # 0.0 to 1.0
+
+
+@dataclass
+class AnnotateTextResult:
+    """Full result from GCP NL annotateText (sentiment + entities + categories)."""
+
+    # Sentiment
+    sentiment_label: str
+    sentiment_score: float
+    sentiment_magnitude: Optional[float]
+    # Entities
+    entities: List[EntityResult] = field(default_factory=list)
+    # Categories
+    categories: List[CategoryResult] = field(default_factory=list)
 
 
 class GcpNlpClient:
@@ -158,6 +197,142 @@ class GcpNlpClient:
             result = self.analyze_sentiment(text)
             results.append(result)
         return results
+
+    def annotate_text(self, text: str) -> AnnotateTextResult:
+        """
+        Analyze text using GCP NL annotateText for sentiment + entities + categories.
+
+        Single API call replaces separate analyzeSentiment / analyzeEntities /
+        classifyText calls, saving quota and cost.
+
+        Args:
+            text: English text to analyze
+
+        Returns:
+            AnnotateTextResult with sentiment, entities, and categories
+        """
+        if not text or not text.strip():
+            logger.warning("Empty text provided for annotateText")
+            return AnnotateTextResult(
+                sentiment_label="neutral",
+                sentiment_score=0.0,
+                sentiment_magnitude=None,
+            )
+
+        # Truncate text if too long
+        max_length = config.sentiment.gcp_nl_max_text_length
+        if len(text.encode("utf-8")) > max_length:
+            logger.warning(f"Text too long ({len(text)} chars), truncating")
+            text = text[: max_length // 4]
+
+        try:
+            document = language_v1.Document(
+                content=text,
+                type_=language_v1.Document.Type.PLAIN_TEXT,
+                language="en",
+            )
+
+            # Request all three features in one call
+            features = language_v1.AnnotateTextRequest.Features(
+                extract_entities=True,
+                extract_document_sentiment=True,
+                classify_text=True,
+            )
+
+            response = self.client.annotate_text(
+                request={
+                    "document": document,
+                    "features": features,
+                    "encoding_type": language_v1.EncodingType.UTF8,
+                }
+            )
+
+            # Extract sentiment (same logic as analyze_sentiment)
+            sentiment = response.document_sentiment
+            score = float(sentiment.score)
+            magnitude = float(sentiment.magnitude)
+
+            if score >= self.positive_threshold:
+                label = "positive"
+            elif score <= self.negative_threshold:
+                label = "negative"
+            else:
+                label = "neutral"
+
+            # Extract entities
+            entities: List[EntityResult] = []
+            for entity in response.entities:
+                wikipedia_url = None
+                mid = None
+                if entity.metadata:
+                    wikipedia_url = entity.metadata.get("wikipedia_url")
+                    mid = entity.metadata.get("mid")
+
+                entities.append(
+                    EntityResult(
+                        name=entity.name,
+                        type=language_v1.Entity.Type(entity.type_).name,
+                        salience=float(entity.salience),
+                        wikipedia_url=wikipedia_url,
+                        mid=mid,
+                    )
+                )
+
+            # Extract categories (classifyText needs ~20 tokens;
+            # short texts may return empty — this is expected)
+            categories: List[CategoryResult] = []
+            for category in response.categories:
+                categories.append(
+                    CategoryResult(
+                        name=category.name,
+                        confidence=float(category.confidence),
+                    )
+                )
+
+            logger.debug(
+                f"GCP NL annotateText: sentiment={label} ({score:.3f}), "
+                f"entities={len(entities)}, categories={len(categories)}"
+            )
+
+            return AnnotateTextResult(
+                sentiment_label=label,
+                sentiment_score=score,
+                sentiment_magnitude=magnitude,
+                entities=entities,
+                categories=categories,
+            )
+
+        except gcp_exceptions.InvalidArgument as e:
+            logger.error(f"Invalid argument for GCP NL annotateText: {e}")
+            return AnnotateTextResult(
+                sentiment_label="neutral",
+                sentiment_score=0.0,
+                sentiment_magnitude=None,
+            )
+
+        except gcp_exceptions.ResourceExhausted as e:
+            logger.error(f"GCP NL API quota exceeded: {e}")
+            return AnnotateTextResult(
+                sentiment_label="neutral",
+                sentiment_score=0.0,
+                sentiment_magnitude=None,
+            )
+
+        except gcp_exceptions.DeadlineExceeded as e:
+            logger.error(f"GCP NL API timeout: {e}")
+            return AnnotateTextResult(
+                sentiment_label="neutral",
+                sentiment_score=0.0,
+                sentiment_magnitude=None,
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error in GCP NL annotateText: {e}")
+            return AnnotateTextResult(
+                sentiment_label="neutral",
+                sentiment_score=0.0,
+                sentiment_magnitude=None,
+            )
 
 
 # Singleton instance for dependency injection

--- a/app/utils/sentiment.py
+++ b/app/utils/sentiment.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import logging
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from app.utils.gcp_nlp import AnnotateTextResult
 
 from vaderSentiment.vaderSentiment import (  # type: ignore[import-untyped]
     SentimentIntensityAnalyzer,
@@ -53,6 +58,27 @@ def analyze_sentiment_gcp_nl(text: str) -> Tuple[str, float, Optional[float]]:
             return "neutral", 0.0, None
 
 
+def annotate_text_gcp_nl(text: str) -> Optional[AnnotateTextResult]:
+    """
+    Full annotateText using GCP NL (sentiment + entities + categories in one call).
+
+    Returns None if GCP NL is unavailable or fails, so the caller
+    can fall back to VADER for sentiment-only analysis.
+    """
+    try:
+        from app.utils.gcp_nlp import gcp_nlp_client
+
+        return gcp_nlp_client.annotate_text(text)
+    except ImportError as e:
+        logger.warning(f"GCP NL client not available: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Error in GCP NL annotateText: {e}")
+        if config.sentiment.enable_fallback:
+            logger.info("annotateText failed, caller should fallback to VADER")
+        return None
+
+
 def analyze_sentiment(text: str) -> Tuple[str, float]:
     """
     Analyze sentiment using the configured provider (English only).
@@ -86,9 +112,9 @@ def analyze_sentiment(text: str) -> Tuple[str, float]:
         return analyze_sentiment_vader(text)
 
 
-def get_sentiment_provider_info() -> (
-    Dict[str, Union[str, float, bool, List[str], None]]
-):
+def get_sentiment_provider_info() -> Dict[
+    str, Union[str, float, bool, List[str], None]
+]:
     """Get information about the current sentiment analysis provider."""
     provider = config.sentiment.sentiment_provider
 


### PR DESCRIPTION
## Summary
- Replace `analyzeSentiment` with `annotateText` — single API call extracts sentiment + named entities + content categories (saves quota: 1 call instead of 3)
- Add M2M entity model (`entities` + `article_entities` join table) with deduplication by (name, type) and per-article salience scores
- Add `article_categories` table for GCP NL taxonomy classifications with confidence scores
- Add `/api/v1/entities/` router: list entities by frequency, filter by type, get by ID
- Update `ArticleRead` schema and article endpoints with eager-loaded entity/category data
- VADER fallback unchanged — sentiment-only when GCP NL is unavailable

## New tables
| Table | Purpose | Key columns |
|-------|---------|-------------|
| `entities` | Canonical entity lookup (deduplicated) | name, type, wikipedia_url, mid |
| `article_entities` | Article ↔ Entity M2M join | article_id, entity_id, salience |
| `article_categories` | GCP NL content classification | article_id, name (taxonomy path), confidence |

## Test plan
- [ ] `alembic upgrade head` — migration creates 3 new tables
- [ ] Trigger ingestion with `SENTIMENT_PROVIDER=GCP_NL` — logs show entity/category counts
- [ ] `GET /api/v1/entities/` returns entities ranked by article count
- [ ] `GET /articles/latest` includes `article_entities` and `article_categories` in response
- [ ] Verify VADER fallback: `SENTIMENT_PROVIDER=VADER` still works, entity fields return null
- [ ] CI passes (ruff + mypy + pytest)