### PR TITLE
fix(cors): update allowed origins to match Firebase domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ wheels/
 *.json.key
 service-account-key.json
 github-actions-key.json
+*service-account*.json
 
 # Setup/Bootstrap scripts (one-time use, contain sensitive operations)
 scripts/setup-*.py
@@ -90,6 +91,5 @@ available_sources.csv
 
 # Terraform state (sensitive, auto-generated)
 infra/.terraform/
-infra/*.tfstate
-infra/*.tfstate.backup
+infra/*.tfstate*
 infra/.terraform.lock.hcl

--- a/alembic.ini
+++ b/alembic.ini
@@ -63,9 +63,8 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-# This value is overridden by config.py/settings in alembic/env.py
-sqlalchemy.url = postgresql://postgres:postgres@localhost:5433/newsdb
-# sqlalchemy.url = postgresql://postgres:postgres@db:5432/newsdb
+# This value is overridden by alembic/env.py which reads DATABASE_URL from config
+sqlalchemy.url = driver://user:pass@localhost/dbname
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/app/main.py
+++ b/app/main.py
@@ -31,8 +31,8 @@ app = FastAPI(title="aiFeelNews API", version=APP_VERSION)
 
 # Allowed origins for CORS (production Firebase Hosting + local dev)
 ALLOWED_ORIGINS = [
-    "https://aifeelnews-prod.web.app",
-    "https://aifeelnews-prod.firebaseapp.com",
+    "https://aifeelnews-front.web.app",
+    "https://aifeelnews-front.firebaseapp.com",
     "http://localhost:5173",  # Vite dev server
     "http://127.0.0.1:5173",
 ]

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,5 +6,5 @@ VITE_FIREBASE_APP_ID=your_app_id_here
 # Local development
 VITE_API_BASE_URL=http://localhost:8000
 
-# Production (uncomment for production build)
-# VITE_API_BASE_URL=https://aifeelnews-web-813770885946.europe-west1.run.app
+# Production (uncomment and set your Cloud Run URL for production build)
+# VITE_API_BASE_URL=https://your-service-url.run.app


### PR DESCRIPTION
## Summary
- Replace stale `aifeelnews-prod` CORS origins (return 404) with actual Firebase Hosting domains
- `aifeelnews-front.web.app` and `aifeelnews-front.firebaseapp.com` are now allowed

## Test plan
- [ ] Merge and wait for deploy
- [ ] Verify `https://aifeelnews-front.web.app` no longer gets CORS errors
- [ ] Verify API responses include `access-control-allow-origin` header