### PR TITLE
refactor(iam): dedicated Cloud Run SA with least-privilege roles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,7 @@ jobs:
         image: ${{ env.AR_REGISTRY }}/${{ env.SERVICE }}:${{ github.sha }}
         flags: |
           --allow-unauthenticated
+          --service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com
           --memory=512Mi
           --cpu=1
           --min-instances=0

--- a/infra/envs/prod.tfvars
+++ b/infra/envs/prod.tfvars
@@ -26,4 +26,4 @@ bigquery_location   = "europe-west1"
 
 # IAM
 github_actions_sa_email = "github-actions-sa@aifeelnews-prod.iam.gserviceaccount.com"
-cloud_run_sa_email      = "813770885946-compute@developer.gserviceaccount.com"
+# cloud_run_sa_email removed — SA is now created by Terraform (cloudrun-sa)

--- a/infra/envs/staging.tfvars
+++ b/infra/envs/staging.tfvars
@@ -34,4 +34,4 @@ bigquery_location   = "europe-west1"
 
 # IAM — same SA (single project, different services)
 github_actions_sa_email = "github-actions-sa@aifeelnews-prod.iam.gserviceaccount.com"
-cloud_run_sa_email      = "813770885946-compute@developer.gserviceaccount.com"
+# cloud_run_sa_email removed — SA is now created by Terraform (cloudrun-sa)

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -297,9 +297,44 @@ resource "google_bigquery_table" "sentiment_events" {
 #   - Principle of least privilege: each SA gets only what it needs
 #   - Auditable: every permission is documented in code
 #   - Reviewable: IAM changes go through PR review
+#   - Mitigates STRIDE "Elevation of Privilege": a compromised container
+#     can only do what the dedicated SA allows, not project-wide editor
 # ==========================================================================
 
-# GitHub Actions SA — deploys containers and manages Cloud Run
+# ---------- Dedicated Cloud Run Service Account ----------
+# Why a dedicated SA instead of the Compute Engine default?
+#   - Default SA has roles/editor (read/write almost everything)
+#   - Dedicated SA gets exactly 3 roles — nothing more
+#   - If the container is compromised, blast radius is minimal
+resource "google_service_account" "cloudrun" {
+  account_id   = "cloudrun-sa"
+  display_name = "Cloud Run Service Account"
+  description  = "Least-privilege SA for aiFeelNews Cloud Run services (web, worker, scheduler)"
+}
+
+# Role 1: Read secrets (DB password, API keys, Firebase SA)
+resource "google_project_iam_member" "cloudrun_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+# Role 2: Connect to Cloud SQL via Cloud SQL Auth Proxy
+resource "google_project_iam_member" "cloudrun_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+# Role 3: Call Cloud Natural Language API (sentiment + entities + categories)
+resource "google_project_iam_member" "cloudrun_nl_user" {
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
+  member  = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+# ---------- GitHub Actions SA ----------
+# Deploys containers and manages Cloud Run revisions
 resource "google_project_iam_member" "github_actions_run_admin" {
   project = var.project_id
   role    = "roles/run.admin"
@@ -312,16 +347,9 @@ resource "google_project_iam_member" "github_actions_ar_writer" {
   member  = "serviceAccount:${var.github_actions_sa_email}"
 }
 
-resource "google_project_iam_member" "github_actions_sa_user" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${var.github_actions_sa_email}"
-}
-
-# Cloud Run default SA — reads secrets at runtime
-# Uses Compute Engine default SA (Cloud Run's default when no custom SA is specified)
-resource "google_project_iam_member" "cloud_run_secret_accessor" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${var.cloud_run_sa_email}"
+# Allow GitHub Actions to deploy Cloud Run revisions AS the dedicated SA
+resource "google_service_account_iam_member" "github_actions_act_as_cloudrun" {
+  service_account_id = google_service_account.cloudrun.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${var.github_actions_sa_email}"
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -27,3 +27,8 @@ output "scheduler_cleanup_job" {
   description = "Cloud Scheduler cleanup job name"
   value       = google_cloud_scheduler_job.cleanup.name
 }
+
+output "cloudrun_sa_email" {
+  description = "Dedicated Cloud Run service account email (use in deploy.yml --service-account flag)"
+  value       = google_service_account.cloudrun.email
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -98,7 +98,5 @@ variable "github_actions_sa_email" {
   type        = string
 }
 
-variable "cloud_run_sa_email" {
-  description = "Email of the service account used by Cloud Run (Compute Engine default SA)"
-  type        = string
-}
+## cloud_run_sa_email removed — SA is now created by Terraform
+## (google_service_account.cloudrun) with least-privilege roles


### PR DESCRIPTION
## Summary
- Create dedicated `cloudrun-sa` service account (replaces Compute Engine default SA with `roles/editor`)
- Grant exactly 3 roles: `secretmanager.secretAccessor`, `cloudsql.client`, `serviceusage.serviceUsageConsumer`
- Scope GitHub Actions `iam.serviceAccountUser` to the Cloud Run SA only (was project-wide)
- Remove stale `appspot` SA reference (was causing Terraform apply errors)
- Update `deploy.yml` with `--service-account` flag

## Why
The Compute Engine default SA has `roles/editor` — if the container is compromised, an attacker could read/write almost everything in the project. The dedicated SA limits blast radius to secrets, DB, and NL API.

Addresses **STRIDE Elevation of Privilege** for the Cybersecurity assessment.

## Deployment order
1. **Run `terraform apply -var-file=envs/prod.tfvars`** to create the SA and grant roles
2. **Then merge this PR** — CI will deploy Cloud Run with `--service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com`

## Test plan
- [ ] `terraform plan` shows SA creation + 3 IAM bindings + 1 SA-level binding
- [ ] `terraform apply` succeeds
- [ ] Merge PR, CI deploys successfully
- [ ] `/health` endpoint returns 200
- [ ] Trigger ingestion works (secrets, DB, NL API all accessible)