### PR TITLE
fix(entities): source-layer dedup + mention_count extraction

### DIFF
--- a/alembic/versions/d8e9f0a1b2c3_add_mention_count_to_article_entities.py
+++ b/alembic/versions/d8e9f0a1b2c3_add_mention_count_to_article_entities.py
@@ -1,0 +1,35 @@
+"""add mention_count to article_entities
+
+Revision ID: d8e9f0a1b2c3
+Revises: c7d8e9f0a1b2
+Create Date: 2026-02-19 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d8e9f0a1b2c3"
+down_revision: Union[str, None] = "c7d8e9f0a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "article_entities",
+        sa.Column(
+            "mention_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("article_entities", "mention_count")

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 from bs4 import BeautifulSoup
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -266,7 +267,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                 magnitude = result.sentiment_magnitude
                 model_name = "gcp_nl_v1"
 
-                # Store entities (get-or-create canonical Entity, then link)
+                # Store entities — data arrives deduplicated from gcp_nlp.py
                 for ent in result.entities:
                     canonical = (
                         db.query(Entity)
@@ -274,21 +275,53 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                         .first()
                     )
                     if not canonical:
-                        canonical = Entity(
-                            name=ent.name,
-                            type=ent.type,
-                            wikipedia_url=ent.wikipedia_url,
-                            mid=ent.mid,
-                        )
-                        db.add(canonical)
-                        db.flush()  # Get the id without full commit
+                        try:
+                            canonical = Entity(
+                                name=ent.name,
+                                type=ent.type,
+                                wikipedia_url=ent.wikipedia_url,
+                                mid=ent.mid,
+                            )
+                            db.add(canonical)
+                            db.flush()
+                        except IntegrityError:
+                            # Concurrent worker created it — read back
+                            db.rollback()
+                            canonical = (
+                                db.query(Entity)
+                                .filter(
+                                    Entity.name == ent.name,
+                                    Entity.type == ent.type,
+                                )
+                                .first()
+                            )
+                            if not canonical:
+                                logger.error(
+                                    f"Entity {ent.name}/{ent.type} "
+                                    "missing after IntegrityError"
+                                )
+                                continue
 
-                    article_entity = ArticleEntity(
-                        article_id=article.id,
-                        entity_id=canonical.id,
-                        salience=ent.salience,
+                    # Re-analysis guard: update if link already exists
+                    existing_link = (
+                        db.query(ArticleEntity)
+                        .filter(
+                            ArticleEntity.article_id == article.id,
+                            ArticleEntity.entity_id == canonical.id,
+                        )
+                        .first()
                     )
-                    db.add(article_entity)
+                    if existing_link:
+                        existing_link.salience = ent.salience  # type: ignore[assignment]
+                        existing_link.mention_count = ent.mention_count  # type: ignore[assignment]
+                    else:
+                        article_entity = ArticleEntity(
+                            article_id=article.id,
+                            entity_id=canonical.id,
+                            salience=ent.salience,
+                            mention_count=ent.mention_count,
+                        )
+                        db.add(article_entity)
                     entities_stored += 1
 
                 # Store categories

--- a/app/models/article_entity.py
+++ b/app/models/article_entity.py
@@ -22,6 +22,7 @@ class ArticleEntity(Base):
         Integer, ForeignKey("entities.id", ondelete="CASCADE"), nullable=False
     )
     salience = Column(Float, nullable=False)  # 0.0 to 1.0 relevance score
+    mention_count = Column(Integer, nullable=False, default=1)  # Times entity appears
     analyzed_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
 
     # Relationships

--- a/app/schemas/entity.py
+++ b/app/schemas/entity.py
@@ -22,6 +22,7 @@ class ArticleEntityRead(BaseModel):
     id: int
     entity: EntityRead = Field(..., description="The canonical entity")
     salience: float = Field(..., ge=0.0, le=1.0, description="Relevance to article")
+    mention_count: int = Field(1, ge=1, description="Times entity mentioned in article")
     analyzed_at: datetime
 
     model_config = {"from_attributes": True}

--- a/app/utils/gcp_nlp.py
+++ b/app/utils/gcp_nlp.py
@@ -32,6 +32,7 @@ class EntityResult:
     salience: float  # 0.0 to 1.0
     wikipedia_url: Optional[str] = None
     mid: Optional[str] = None
+    mention_count: int = 1  # Number of mentions in source text
 
 
 @dataclass
@@ -259,8 +260,11 @@ class GcpNlpClient:
             else:
                 label = "neutral"
 
-            # Extract entities
-            entities: List[EntityResult] = []
+            # Extract entities with dedup by (name, type).
+            # The API should return one Entity per unique entity, but
+            # in practice near-duplicates with different salience occur.
+            # Dedup here at the source so downstream code receives clean data.
+            entity_map: dict[tuple[str, str], EntityResult] = {}
             for entity in response.entities:
                 wikipedia_url = None
                 mid = None
@@ -268,15 +272,35 @@ class GcpNlpClient:
                     wikipedia_url = entity.metadata.get("wikipedia_url")
                     mid = entity.metadata.get("mid")
 
-                entities.append(
-                    EntityResult(
+                entity_type_name = language_v1.Entity.Type(entity.type_).name
+                mention_count = len(entity.mentions) if entity.mentions else 1
+                key = (entity.name, entity_type_name)
+
+                if key in entity_map:
+                    existing = entity_map[key]
+                    # Keep highest salience, sum mention counts
+                    if float(entity.salience) > existing.salience:
+                        entity_map[key] = EntityResult(
+                            name=entity.name,
+                            type=entity_type_name,
+                            salience=float(entity.salience),
+                            wikipedia_url=wikipedia_url or existing.wikipedia_url,
+                            mid=mid or existing.mid,
+                            mention_count=existing.mention_count + mention_count,
+                        )
+                    else:
+                        existing.mention_count += mention_count
+                else:
+                    entity_map[key] = EntityResult(
                         name=entity.name,
-                        type=language_v1.Entity.Type(entity.type_).name,
+                        type=entity_type_name,
                         salience=float(entity.salience),
                         wikipedia_url=wikipedia_url,
                         mid=mid,
+                        mention_count=mention_count,
                     )
-                )
+
+            entities: List[EntityResult] = list(entity_map.values())
 
             # Extract categories (classifyText needs ~20 tokens;
             # short texts may return empty — this is expected)


### PR DESCRIPTION
## Summary
- **Bug fix**: GCP NL `annotateText` occasionally returns near-duplicate entities (same name+type, different salience), causing `UniqueViolation` on `article_entities`
- **Root cause**: Dedup was missing at the data extraction layer (`gcp_nlp.py`); was only attempted at the persistence layer
- **Enhancement**: Extracts `mention_count` from the API `mentions[]` array (how many times an entity appears in the article)

## Changes
| File | What |
|------|------|
| `app/utils/gcp_nlp.py` | Dedup entities by `(name, type)` at source; extract `len(entity.mentions)` |
| `app/models/article_entity.py` | Add `mention_count` column |
| `app/jobs/crawl_worker.py` | `IntegrityError` handler for concurrent workers + re-analysis guard |
| `app/schemas/entity.py` | Expose `mention_count` in API responses |
| `alembic/versions/d8e9...` | Migration: add `mention_count` with `server_default=1` |

## Architecture
| Concern | Layer | Mechanism |
|---------|-------|-----------|
| API near-duplicate entities | Data extraction (`gcp_nlp.py`) | Dict dedup by `(name, type)` |
| Mention count | Data extraction (`gcp_nlp.py`) | `len(entity.mentions)` |
| Concurrent canonical Entity creation | DB persistence (`crawl_worker.py`) | `IntegrityError` catch + re-read |
| Article re-crawl | DB persistence (`crawl_worker.py`) | Check-or-update guard |

## Test plan
- [ ] CI passes (ruff, mypy, pre-commit hooks)
- [ ] `alembic upgrade head` applies cleanly
- [ ] Trigger ingestion — no `UniqueViolation` errors
- [ ] `GET /api/v1/entities/` returns entities with `mention_count`
- [ ] `GET /articles/latest` includes `mention_count` in `article_entities`