### PR TITLE
fix(secrets): resolve GCP project ID from metadata server

### DIFF
--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -111,12 +111,12 @@ class LegacySettings:
 
     @property
     def SENTIMENT_GCP_NL_PROJECT_ID(self) -> str:
-        import os
+        from app.utils.secrets import get_gcp_project_id
 
         project_id = self._config.sentiment.gcp_nl_project_id
         if project_id:
             return project_id
-        return os.getenv("GOOGLE_CLOUD_PROJECT", "")
+        return get_gcp_project_id() or ""
 
 
 settings = LegacySettings(config)

--- a/app/utils/gcp_nlp.py
+++ b/app/utils/gcp_nlp.py
@@ -19,6 +19,7 @@ from google.api_core import exceptions as gcp_exceptions  # type: ignore[import-
 from google.cloud import language_v1  # type: ignore[import-untyped]
 
 from app.config import config
+from app.utils.secrets import get_gcp_project_id
 
 logger = logging.getLogger(__name__)
 
@@ -72,12 +73,8 @@ class GcpNlpClient:
         Args:
             project_id: GCP project ID. If None, uses default from environment.
         """
-        import os
-
         self.project_id = (
-            project_id
-            or config.sentiment.gcp_nl_project_id
-            or os.getenv("GOOGLE_CLOUD_PROJECT")
+            project_id or config.sentiment.gcp_nl_project_id or get_gcp_project_id()
         )
         self._client: Optional[language_v1.LanguageServiceClient] = None
 

--- a/app/utils/secrets.py
+++ b/app/utils/secrets.py
@@ -4,11 +4,45 @@ Google Cloud Secret Manager utilities for secure credential management.
 
 import logging
 import os
+from functools import lru_cache
 from typing import Optional
 
+import requests
 from google.cloud import secretmanager
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def get_gcp_project_id() -> Optional[str]:
+    """
+    Discover the GCP project ID from environment or the metadata server.
+
+    Resolution order:
+      1. GOOGLE_CLOUD_PROJECT env var (set explicitly or by some GCP runtimes)
+      2. GCP metadata server (available on Cloud Run, GCE, GKE, Cloud Functions)
+
+    The result is cached for the lifetime of the process.
+    """
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    if project_id:
+        return project_id
+
+    try:
+        resp = requests.get(
+            "http://metadata.google.internal/computeMetadata/v1/project/project-id",
+            headers={"Metadata-Flavor": "Google"},
+            timeout=2,
+        )
+        if resp.status_code == 200:
+            project_id = resp.text.strip()
+            logger.info("Resolved GCP project ID from metadata server: %s", project_id)
+            return project_id
+    except requests.RequestException:
+        pass
+
+    logger.warning("Could not resolve GCP project ID from env or metadata server")
+    return None
 
 
 class SecretManagerClient:
@@ -21,7 +55,7 @@ class SecretManagerClient:
         Args:
             project_id: GCP project ID. If None, will use environment or default.
         """
-        self.project_id = project_id or os.getenv("GOOGLE_CLOUD_PROJECT")
+        self.project_id = project_id or get_gcp_project_id()
         self._client: Optional[secretmanager.SecretManagerServiceClient] = None
 
     @property


### PR DESCRIPTION
## Summary
- Cloud Run does not set `GOOGLE_CLOUD_PROJECT` as an env var, causing Secret Manager and NLP client to silently skip project ID resolution
- Added `get_gcp_project_id()` in `app/utils/secrets.py` that falls back to the GCP metadata server (`http://metadata.google.internal/...`) when the env var is missing
- Result is `@lru_cache`-d so the metadata HTTP call only happens once per process lifetime
- Updated all 3 callsites (`secrets.py`, `gcp_nlp.py`, `config/__init__.py`) to use the shared helper

## Test plan
- [x] All 23 existing tests pass
- [x] Ruff + mypy clean
- [ ] Deploy to Cloud Run and verify `No project ID available for Secret Manager` warning is gone from logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)