### PR TITLE
feat(bigquery): activate BQ analytics with entity/category dashboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,8 @@ jobs:
         service: ${{ env.SERVICE }}
         region: ${{ env.REGION }}
         image: ${{ env.AR_REGISTRY }}/${{ env.SERVICE }}:${{ github.sha }}
+        env_vars: |
+          BIGQUERY_ENABLE_BIGQUERY=true
         flags: |
           --allow-unauthenticated
           --service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com

--- a/app/config/bigquery.py
+++ b/app/config/bigquery.py
@@ -51,6 +51,16 @@ class BigQueryConfig(BaseSettings):
         description="Table name for pipeline run metrics",
     )
 
+    entity_table: str = Field(
+        default="entity_events",
+        description="Table name for per-article entity events",
+    )
+
+    category_table: str = Field(
+        default="category_events",
+        description="Table name for per-article GCP NL category events",
+    )
+
     class Config:
         env_prefix = "BIGQUERY_"
         case_sensitive = False

--- a/app/jobs/backfill_bigquery.py
+++ b/app/jobs/backfill_bigquery.py
@@ -1,0 +1,429 @@
+"""
+Backfill BigQuery from existing PostgreSQL data.
+
+Streams sentiment_events, entity_events, and category_events from
+PostgreSQL into BigQuery. Idempotent via event_id pre-check.
+
+Usage:
+    python -m app.jobs.backfill_bigquery                    # backfill all
+    python -m app.jobs.backfill_bigquery --dry-run           # preview only
+    python -m app.jobs.backfill_bigquery --since=2025-06-01  # partial
+    python -m app.jobs.backfill_bigquery --sentiment-only    # skip entities/categories
+"""
+
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set
+
+from app.config import config
+from app.database import SessionLocal
+from app.models.article import Article
+from app.models.article_category import ArticleCategory
+from app.models.article_content import ArticleContent
+from app.models.article_entity import ArticleEntity
+from app.models.entity import Entity
+from app.models.sentiment_analysis import SentimentAnalysis
+from app.models.source import Source
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_existing_event_ids(table_id: str) -> Set[str]:
+    """Query BigQuery for event_ids already present in a table."""
+    try:
+        from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+        from app.services.bigquery import _get_client, _table_fqn
+
+        fqn = _table_fqn(table_id)
+        query = f"SELECT DISTINCT event_id FROM {fqn}"
+        results = _get_client().query(query, job_config=bigquery.QueryJobConfig())
+        return {row["event_id"] for row in results}
+    except Exception as e:
+        logger.warning("Could not fetch existing IDs from %s: %s", table_id, e)
+        return set()
+
+
+def _batch_insert(bq_rows: List[Dict[str, Any]], table_id: str) -> int:
+    """Insert rows into BigQuery in batches of 500. Returns rows inserted."""
+    if not bq_rows:
+        return 0
+
+    from app.services.bigquery import _ensure_tables, _get_client
+
+    _ensure_tables()
+    client = _get_client()
+    cfg = config.bigquery
+    table = client.get_table(client.dataset(cfg.dataset_id).table(table_id))
+
+    inserted = 0
+    for i in range(0, len(bq_rows), 500):
+        batch = bq_rows[i : i + 500]
+        errors = client.insert_rows_json(table, batch)
+        if errors:
+            logger.error("Insert errors (batch %d): %s", i, errors)
+        else:
+            inserted += len(batch)
+            logger.info(
+                "  Batch %d-%d (%d/%d)", i + 1, i + len(batch), inserted, len(bq_rows)
+            )
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Sentiment backfill
+# ---------------------------------------------------------------------------
+
+
+def backfill_sentiment_events(
+    dry_run: bool = False, since: Optional[datetime] = None
+) -> int:
+    logger.info("\n=== Backfilling sentiment_events ===")
+    if not config.bigquery.enable_bigquery and not dry_run:
+        logger.error(
+            "BigQuery disabled. Set BIGQUERY_ENABLE_BIGQUERY=true or use --dry-run"
+        )
+        return 0
+
+    db = SessionLocal()
+    try:
+        query = (
+            db.query(
+                SentimentAnalysis.article_id,
+                Article.url.label("article_url"),
+                Article.title.label("article_title"),
+                Source.name.label("source_name"),
+                Article.published_at,
+                SentimentAnalysis.analyzed_at.label("ingested_at"),
+                SentimentAnalysis.provider.label("sentiment_provider"),
+                SentimentAnalysis.model_name.label("sentiment_model"),
+                SentimentAnalysis.score.label("sentiment_score"),
+                SentimentAnalysis.magnitude.label("sentiment_magnitude"),
+                SentimentAnalysis.label.label("sentiment_label"),
+                SentimentAnalysis.language,
+                Article.country,
+                Article.category,
+                ArticleContent.content_length,
+            )
+            .join(Article, SentimentAnalysis.article_id == Article.id)
+            .join(Source, Article.source_id == Source.id)
+            .outerjoin(ArticleContent, Article.id == ArticleContent.article_id)
+        )
+        if since:
+            query = query.filter(SentimentAnalysis.analyzed_at >= since)
+
+        rows = query.order_by(SentimentAnalysis.analyzed_at.asc()).all()
+        logger.info("Found %d sentiment analyses in PostgreSQL", len(rows))
+        if not rows:
+            return 0
+
+        existing_ids = (
+            set()
+            if dry_run
+            else _get_existing_event_ids(config.bigquery.sentiment_table)
+        )
+        if existing_ids:
+            logger.info("Found %d existing event IDs in BigQuery", len(existing_ids))
+
+        bq_rows: List[Dict[str, Any]] = []
+        provider_counts: Dict[str, int] = {}
+        skipped = 0
+
+        for row in rows:
+            provider = row.sentiment_provider or "VADER"
+            provider_counts[provider] = provider_counts.get(provider, 0) + 1
+            event_id = f"{row.article_id}_{provider}_{int(row.ingested_at.timestamp())}"
+
+            if event_id in existing_ids:
+                skipped += 1
+                continue
+
+            bq_rows.append(
+                {
+                    "event_id": event_id,
+                    "article_id": row.article_id,
+                    "article_url": row.article_url,
+                    "article_title": row.article_title,
+                    "source_name": row.source_name,
+                    "published_at": row.published_at.isoformat()
+                    if row.published_at
+                    else None,
+                    "ingested_at": row.ingested_at.isoformat()
+                    if row.ingested_at
+                    else None,
+                    "sentiment_provider": provider,
+                    "sentiment_model": row.sentiment_model or "",
+                    "sentiment_score": row.sentiment_score,
+                    "sentiment_magnitude": row.sentiment_magnitude,
+                    "sentiment_label": row.sentiment_label,
+                    "confidence": None,
+                    "language": row.language,
+                    "country": row.country,
+                    "category": row.category,
+                    "content_length": row.content_length,
+                    "processing_time_ms": None,
+                    "extraction_method": "backfill_gcpnl"
+                    if provider == "GCP_NL"
+                    else "backfill_vader",
+                }
+            )
+
+        logger.info(
+            "Providers: %s | Skipped: %d | To insert: %d",
+            provider_counts,
+            skipped,
+            len(bq_rows),
+        )
+
+        if dry_run:
+            for r in bq_rows[:5]:
+                logger.info(
+                    "  [%s] article=%s source=%s label=%s",
+                    r["extraction_method"],
+                    r["article_id"],
+                    r["source_name"],
+                    r["sentiment_label"],
+                )
+            if len(bq_rows) > 5:
+                logger.info("  ... and %d more", len(bq_rows) - 5)
+            return len(bq_rows)
+
+        inserted = _batch_insert(bq_rows, config.bigquery.sentiment_table)
+        logger.info("Sentiment backfill: %d inserted", inserted)
+        return inserted
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Entity backfill
+# ---------------------------------------------------------------------------
+
+
+def backfill_entity_events(
+    dry_run: bool = False, since: Optional[datetime] = None
+) -> int:
+    logger.info("\n=== Backfilling entity_events ===")
+    if not config.bigquery.enable_bigquery and not dry_run:
+        logger.error("BigQuery disabled.")
+        return 0
+
+    db = SessionLocal()
+    try:
+        query = (
+            db.query(
+                ArticleEntity.article_id,
+                Article.url.label("article_url"),
+                Article.title.label("article_title"),
+                Source.name.label("source_name"),
+                Article.published_at,
+                ArticleEntity.analyzed_at.label("ingested_at"),
+                Entity.name.label("entity_name"),
+                Entity.type.label("entity_type"),
+                ArticleEntity.salience,
+                ArticleEntity.mention_count,
+                Entity.wikipedia_url,
+                Article.sentiment_label,
+                Article.sentiment_score,
+            )
+            .join(Entity, ArticleEntity.entity_id == Entity.id)
+            .join(Article, ArticleEntity.article_id == Article.id)
+            .join(Source, Article.source_id == Source.id)
+        )
+        if since:
+            query = query.filter(ArticleEntity.analyzed_at >= since)
+
+        rows = query.order_by(ArticleEntity.analyzed_at.asc()).all()
+        logger.info("Found %d entity-article links in PostgreSQL", len(rows))
+        if not rows:
+            return 0
+
+        existing_ids = (
+            set() if dry_run else _get_existing_event_ids(config.bigquery.entity_table)
+        )
+        if existing_ids:
+            logger.info("Found %d existing event IDs in BigQuery", len(existing_ids))
+
+        bq_rows: List[Dict[str, Any]] = []
+        skipped = 0
+
+        for row in rows:
+            event_id = f"{row.article_id}_ent_{row.entity_name[:20]}_{int(row.ingested_at.timestamp())}"
+            if event_id in existing_ids:
+                skipped += 1
+                continue
+
+            bq_rows.append(
+                {
+                    "event_id": event_id,
+                    "article_id": row.article_id,
+                    "article_url": row.article_url,
+                    "article_title": row.article_title,
+                    "source_name": row.source_name,
+                    "published_at": row.published_at.isoformat()
+                    if row.published_at
+                    else None,
+                    "ingested_at": row.ingested_at.isoformat()
+                    if row.ingested_at
+                    else None,
+                    "entity_name": row.entity_name,
+                    "entity_type": row.entity_type,
+                    "salience": row.salience,
+                    "mention_count": row.mention_count,
+                    "wikipedia_url": row.wikipedia_url,
+                    "sentiment_label": row.sentiment_label,
+                    "sentiment_score": row.sentiment_score,
+                }
+            )
+
+        logger.info("Skipped: %d | To insert: %d", skipped, len(bq_rows))
+
+        if dry_run:
+            for r in bq_rows[:5]:
+                logger.info(
+                    "  %s (%s) article=%s salience=%.2f",
+                    r["entity_name"],
+                    r["entity_type"],
+                    r["article_id"],
+                    r["salience"] or 0,
+                )
+            if len(bq_rows) > 5:
+                logger.info("  ... and %d more", len(bq_rows) - 5)
+            return len(bq_rows)
+
+        inserted = _batch_insert(bq_rows, config.bigquery.entity_table)
+        logger.info("Entity backfill: %d inserted", inserted)
+        return inserted
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Category backfill
+# ---------------------------------------------------------------------------
+
+
+def backfill_category_events(
+    dry_run: bool = False, since: Optional[datetime] = None
+) -> int:
+    logger.info("\n=== Backfilling category_events ===")
+    if not config.bigquery.enable_bigquery and not dry_run:
+        logger.error("BigQuery disabled.")
+        return 0
+
+    db = SessionLocal()
+    try:
+        query = (
+            db.query(
+                ArticleCategory.article_id,
+                Source.name.label("source_name"),
+                Article.published_at,
+                ArticleCategory.analyzed_at.label("ingested_at"),
+                ArticleCategory.name.label("category_name"),
+                ArticleCategory.confidence.label("category_confidence"),
+                Article.sentiment_label,
+                Article.sentiment_score,
+            )
+            .join(Article, ArticleCategory.article_id == Article.id)
+            .join(Source, Article.source_id == Source.id)
+        )
+        if since:
+            query = query.filter(ArticleCategory.analyzed_at >= since)
+
+        rows = query.order_by(ArticleCategory.analyzed_at.asc()).all()
+        logger.info("Found %d article-category links in PostgreSQL", len(rows))
+        if not rows:
+            return 0
+
+        existing_ids = (
+            set()
+            if dry_run
+            else _get_existing_event_ids(config.bigquery.category_table)
+        )
+        if existing_ids:
+            logger.info("Found %d existing event IDs in BigQuery", len(existing_ids))
+
+        bq_rows: List[Dict[str, Any]] = []
+        skipped = 0
+
+        for row in rows:
+            event_id = f"{row.article_id}_cat_{row.category_name[:30]}_{int(row.ingested_at.timestamp())}"
+            if event_id in existing_ids:
+                skipped += 1
+                continue
+
+            bq_rows.append(
+                {
+                    "event_id": event_id,
+                    "article_id": row.article_id,
+                    "source_name": row.source_name,
+                    "published_at": row.published_at.isoformat()
+                    if row.published_at
+                    else None,
+                    "ingested_at": row.ingested_at.isoformat()
+                    if row.ingested_at
+                    else None,
+                    "category_name": row.category_name,
+                    "category_confidence": row.category_confidence,
+                    "sentiment_label": row.sentiment_label,
+                    "sentiment_score": row.sentiment_score,
+                }
+            )
+
+        logger.info("Skipped: %d | To insert: %d", skipped, len(bq_rows))
+
+        if dry_run:
+            for r in bq_rows[:5]:
+                logger.info(
+                    "  %s confidence=%.2f article=%s",
+                    r["category_name"],
+                    r["category_confidence"] or 0,
+                    r["article_id"],
+                )
+            if len(bq_rows) > 5:
+                logger.info("  ... and %d more", len(bq_rows) - 5)
+            return len(bq_rows)
+
+        inserted = _batch_insert(bq_rows, config.bigquery.category_table)
+        logger.info("Category backfill: %d inserted", inserted)
+        return inserted
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    dry_run = "--dry-run" in sys.argv
+    sentiment_only = "--sentiment-only" in sys.argv
+
+    since = None
+    for arg in sys.argv:
+        if arg.startswith("--since="):
+            since = datetime.fromisoformat(arg.split("=", 1)[1]).replace(
+                tzinfo=timezone.utc
+            )
+
+    if dry_run:
+        logger.info("DRY RUN mode\n")
+
+    s = backfill_sentiment_events(dry_run=dry_run, since=since)
+
+    if not sentiment_only:
+        e = backfill_entity_events(dry_run=dry_run, since=since)
+        c = backfill_category_events(dry_run=dry_run, since=since)
+    else:
+        e, c = 0, 0
+        logger.info("\nSkipping entity/category (--sentiment-only)")
+
+    logger.info("\n=== Summary ===")
+    logger.info("Sentiment: %d | Entities: %d | Categories: %d", s, e, c)

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -364,9 +364,13 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
 
         db.commit()
 
-        # Step 8: Queue sentiment event for BigQuery analytics (if enabled)
+        # Step 8: Queue events for BigQuery analytics (if enabled)
         try:
-            from app.services.bigquery import queue_sentiment_event
+            from app.services.bigquery import (
+                queue_category_event,
+                queue_entity_event,
+                queue_sentiment_event,
+            )
 
             queue_sentiment_event(
                 article_id=article.id,
@@ -382,6 +386,36 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                 language=article.language,
                 content_length=len(article_text),
             )
+
+            # Stream entity events (GCP_NL only)
+            if provider == "GCP_NL" and result is not None:
+                for ent in result.entities:
+                    queue_entity_event(
+                        article_id=article.id,
+                        article_url=article.url,
+                        article_title=article.title or "",
+                        source_name=article.source.name,
+                        published_at=article.published_at,
+                        entity_name=ent.name,
+                        entity_type=ent.type,
+                        salience=ent.salience,
+                        mention_count=ent.mention_count,
+                        sentiment_label=sentiment_label,
+                        sentiment_score=sentiment_score,
+                        wikipedia_url=ent.wikipedia_url,
+                    )
+
+                # Stream category events (GCP_NL only)
+                for cat in result.categories:
+                    queue_category_event(
+                        article_id=article.id,
+                        source_name=article.source.name,
+                        published_at=article.published_at,
+                        category_name=cat.name,
+                        category_confidence=cat.confidence,
+                        sentiment_label=sentiment_label,
+                        sentiment_score=sentiment_score,
+                    )
         except Exception as e:
             logger.debug(f"BigQuery streaming failed (this is optional): {e}")
 

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -7,15 +7,21 @@ from fastapi import APIRouter, Query
 from app.config import config
 from app.schemas.analytics import (
     CategoryBreakdown,
+    EntitySentiment,
+    NlpCategoryBreakdown,
     PipelineRun,
     SentimentTrendPoint,
     SourceComparison,
+    TopEntity,
 )
 from app.services.bigquery import (
     get_category_breakdown,
+    get_entity_sentiment,
+    get_nlp_categories,
     get_pipeline_stats,
     get_sentiment_trends,
     get_source_comparison,
+    get_top_entities,
 )
 
 router = APIRouter(tags=["Analytics"])
@@ -76,3 +82,49 @@ def pipeline_health(
     if not config.bigquery.enable_bigquery:
         return _disabled_response()
     return [PipelineRun(**row) for row in get_pipeline_stats(days)]
+
+
+@router.get(
+    "/entities/top",
+    response_model=Union[List[TopEntity], Dict[str, str]],
+)
+def top_entities(
+    days: int = Query(30, ge=1, le=365),
+    entity_type: Optional[str] = Query(None, description="Filter by entity type"),
+    limit: int = Query(20, ge=1, le=100),
+) -> Union[List[TopEntity], Dict[str, str]]:
+    """Top entities by article mention count, with average sentiment."""
+    if not config.bigquery.enable_bigquery:
+        return _disabled_response()
+    return [TopEntity(**row) for row in get_top_entities(days, entity_type, limit)]
+
+
+@router.get(
+    "/entities/sentiment",
+    response_model=Union[List[EntitySentiment], Dict[str, str]],
+)
+def entity_sentiment(
+    days: int = Query(30, ge=1, le=365),
+    entity_type: Optional[str] = Query(None, description="Filter by entity type"),
+    limit: int = Query(20, ge=1, le=100),
+) -> Union[List[EntitySentiment], Dict[str, str]]:
+    """Per-entity sentiment statistics (entities appearing in 2+ articles)."""
+    if not config.bigquery.enable_bigquery:
+        return _disabled_response()
+    return [
+        EntitySentiment(**row) for row in get_entity_sentiment(days, entity_type, limit)
+    ]
+
+
+@router.get(
+    "/categories/nlp",
+    response_model=Union[List[NlpCategoryBreakdown], Dict[str, str]],
+)
+def nlp_categories(
+    days: int = Query(30, ge=1, le=365),
+    limit: int = Query(20, ge=1, le=100),
+) -> Union[List[NlpCategoryBreakdown], Dict[str, str]]:
+    """GCP NL content categories with sentiment aggregation."""
+    if not config.bigquery.enable_bigquery:
+        return _disabled_response()
+    return [NlpCategoryBreakdown(**row) for row in get_nlp_categories(days, limit)]

--- a/app/schemas/analytics.py
+++ b/app/schemas/analytics.py
@@ -47,3 +47,32 @@ class PipelineRun(BaseModel):
     crawl_successful: Optional[int] = None
     crawl_failed: Optional[int] = None
     include_crawling: bool
+
+
+class TopEntity(BaseModel):
+    """Top entity by article mention count."""
+
+    entity_name: str
+    entity_type: str
+    article_count: int
+    avg_salience: Optional[float] = None
+    avg_sentiment_score: Optional[float] = None
+
+
+class EntitySentiment(BaseModel):
+    """Per-entity sentiment statistics."""
+
+    entity_name: str
+    entity_type: str
+    article_count: int
+    avg_sentiment_score: Optional[float] = None
+    avg_salience: Optional[float] = None
+
+
+class NlpCategoryBreakdown(BaseModel):
+    """GCP NL content category with sentiment aggregation."""
+
+    category_name: str
+    article_count: int
+    avg_confidence: Optional[float] = None
+    avg_sentiment_score: Optional[float] = None

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -84,6 +84,26 @@ def _ensure_tables() -> None:
         partition_field="started_at",
     )
 
+    # --- entity_events ---
+    _ensure_table(
+        client,
+        cfg.dataset_id,
+        cfg.entity_table,
+        _entity_schema(),
+        partition_field="ingested_at",
+        clustering_fields=["entity_type", "entity_name"],
+    )
+
+    # --- category_events ---
+    _ensure_table(
+        client,
+        cfg.dataset_id,
+        cfg.category_table,
+        _category_schema(),
+        partition_field="ingested_at",
+        clustering_fields=["category_name"],
+    )
+
     _tables_provisioned = True
     logger.info("BigQuery tables provisioned")
 
@@ -127,16 +147,16 @@ def _sentiment_schema() -> list:
     return [
         bigquery.SchemaField("event_id", "STRING", mode="REQUIRED"),
         bigquery.SchemaField("article_id", "INTEGER", mode="REQUIRED"),
-        bigquery.SchemaField("article_url", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("article_url", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("article_title", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("source_name", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("published_at", "TIMESTAMP", mode="REQUIRED"),
+        bigquery.SchemaField("published_at", "TIMESTAMP", mode="NULLABLE"),
         bigquery.SchemaField("ingested_at", "TIMESTAMP", mode="REQUIRED"),
-        bigquery.SchemaField("sentiment_provider", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("sentiment_provider", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("sentiment_model", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("sentiment_score", "FLOAT", mode="REQUIRED"),
+        bigquery.SchemaField("sentiment_score", "FLOAT", mode="NULLABLE"),
         bigquery.SchemaField("sentiment_magnitude", "FLOAT", mode="NULLABLE"),
-        bigquery.SchemaField("sentiment_label", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("sentiment_label", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("confidence", "FLOAT", mode="NULLABLE"),
         bigquery.SchemaField("language", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("country", "STRING", mode="NULLABLE"),
@@ -163,11 +183,50 @@ def _ingestion_schema() -> list:
     ]
 
 
+def _entity_schema() -> list:
+    from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+    return [
+        bigquery.SchemaField("event_id", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("article_id", "INTEGER", mode="REQUIRED"),
+        bigquery.SchemaField("article_url", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("article_title", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("source_name", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("published_at", "TIMESTAMP", mode="NULLABLE"),
+        bigquery.SchemaField("ingested_at", "TIMESTAMP", mode="REQUIRED"),
+        bigquery.SchemaField("entity_name", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("entity_type", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("salience", "FLOAT", mode="NULLABLE"),
+        bigquery.SchemaField("mention_count", "INTEGER", mode="NULLABLE"),
+        bigquery.SchemaField("wikipedia_url", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("sentiment_label", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("sentiment_score", "FLOAT", mode="NULLABLE"),
+    ]
+
+
+def _category_schema() -> list:
+    from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+    return [
+        bigquery.SchemaField("event_id", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("article_id", "INTEGER", mode="REQUIRED"),
+        bigquery.SchemaField("source_name", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("published_at", "TIMESTAMP", mode="NULLABLE"),
+        bigquery.SchemaField("ingested_at", "TIMESTAMP", mode="REQUIRED"),
+        bigquery.SchemaField("category_name", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("category_confidence", "FLOAT", mode="NULLABLE"),
+        bigquery.SchemaField("sentiment_label", "STRING", mode="NULLABLE"),
+        bigquery.SchemaField("sentiment_score", "FLOAT", mode="NULLABLE"),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Batch-buffered streaming
 # ---------------------------------------------------------------------------
 _sentiment_buffer: List[Dict[str, Any]] = []
 _ingestion_buffer: List[Dict[str, Any]] = []
+_entity_buffer: List[Dict[str, Any]] = []
+_category_buffer: List[Dict[str, Any]] = []
 
 
 def queue_sentiment_event(
@@ -246,6 +305,80 @@ def queue_ingestion_event(
         flush_ingestion()
 
 
+def queue_entity_event(
+    article_id: int,
+    article_url: str,
+    article_title: str,
+    source_name: str,
+    published_at: datetime,
+    entity_name: str,
+    entity_type: str,
+    salience: float,
+    mention_count: int,
+    sentiment_label: str,
+    sentiment_score: float,
+    wikipedia_url: Optional[str] = None,
+) -> None:
+    """Buffer an entity event; auto-flushes at batch_size."""
+    if not config.bigquery.enable_bigquery:
+        return
+
+    now_utc = datetime.now(timezone.utc)
+    _entity_buffer.append(
+        {
+            "event_id": f"{article_id}_ent_{entity_name[:20]}_{int(now_utc.timestamp())}",
+            "article_id": article_id,
+            "article_url": article_url,
+            "article_title": article_title,
+            "source_name": source_name,
+            "published_at": published_at.isoformat() if published_at else None,
+            "ingested_at": now_utc.isoformat(),
+            "entity_name": entity_name,
+            "entity_type": entity_type,
+            "salience": salience,
+            "mention_count": mention_count,
+            "wikipedia_url": wikipedia_url,
+            "sentiment_label": sentiment_label,
+            "sentiment_score": sentiment_score,
+        }
+    )
+
+    if len(_entity_buffer) >= config.bigquery.batch_size:
+        flush_entities()
+
+
+def queue_category_event(
+    article_id: int,
+    source_name: str,
+    published_at: datetime,
+    category_name: str,
+    category_confidence: float,
+    sentiment_label: str,
+    sentiment_score: float,
+) -> None:
+    """Buffer a category event; auto-flushes at batch_size."""
+    if not config.bigquery.enable_bigquery:
+        return
+
+    now_utc = datetime.now(timezone.utc)
+    _category_buffer.append(
+        {
+            "event_id": f"{article_id}_cat_{category_name[:30]}_{int(now_utc.timestamp())}",
+            "article_id": article_id,
+            "source_name": source_name,
+            "published_at": published_at.isoformat() if published_at else None,
+            "ingested_at": now_utc.isoformat(),
+            "category_name": category_name,
+            "category_confidence": category_confidence,
+            "sentiment_label": sentiment_label,
+            "sentiment_score": sentiment_score,
+        }
+    )
+
+    if len(_category_buffer) >= config.bigquery.batch_size:
+        flush_categories()
+
+
 def flush_sentiment() -> bool:
     """Flush sentiment buffer to BigQuery. Returns True on success."""
     return _flush_buffer(
@@ -262,11 +395,29 @@ def flush_ingestion() -> bool:
     )
 
 
+def flush_entities() -> bool:
+    """Flush entity buffer to BigQuery. Returns True on success."""
+    return _flush_buffer(
+        _entity_buffer,
+        config.bigquery.entity_table,
+    )
+
+
+def flush_categories() -> bool:
+    """Flush category buffer to BigQuery. Returns True on success."""
+    return _flush_buffer(
+        _category_buffer,
+        config.bigquery.category_table,
+    )
+
+
 def flush() -> bool:
     """Flush all buffers. Call at end of pipeline runs."""
     s = flush_sentiment()
     i = flush_ingestion()
-    return s and i
+    e = flush_entities()
+    c = flush_categories()
+    return s and i and e and c
 
 
 def _flush_buffer(buffer: List[Dict[str, Any]], table_id: str) -> bool:
@@ -467,4 +618,139 @@ def get_pipeline_stats(days: int = 7) -> List[Dict[str, Any]]:
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Pipeline stats query failed: %s", e)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Entity & category analytics queries
+# ---------------------------------------------------------------------------
+
+
+def get_top_entities(
+    days: int = 30,
+    entity_type: Optional[str] = None,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    """Top entities by article mention count."""
+    if not config.bigquery.enable_bigquery:
+        return []
+
+    from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+    fqn = _table_fqn(config.bigquery.entity_table)
+
+    query = f"""
+    SELECT
+        entity_name,
+        entity_type,
+        COUNT(DISTINCT article_id) AS article_count,
+        AVG(salience) AS avg_salience,
+        AVG(sentiment_score) AS avg_sentiment_score
+    FROM {fqn}
+    WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+      AND (@entity_type IS NULL OR entity_type = @entity_type)
+    GROUP BY entity_name, entity_type
+    ORDER BY article_count DESC
+    LIMIT @limit
+    """
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("days", "INT64", days),
+            bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
+            bigquery.ScalarQueryParameter("limit", "INT64", limit),
+        ]
+    )
+
+    try:
+        results = _get_client().query(query, job_config=job_config)
+        return [dict(row) for row in results]
+    except Exception as e:
+        logger.error("Top entities query failed: %s", e)
+        return []
+
+
+def get_entity_sentiment(
+    days: int = 30,
+    entity_type: Optional[str] = None,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    """Per-entity sentiment statistics."""
+    if not config.bigquery.enable_bigquery:
+        return []
+
+    from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+    fqn = _table_fqn(config.bigquery.entity_table)
+
+    query = f"""
+    SELECT
+        entity_name,
+        entity_type,
+        COUNT(DISTINCT article_id) AS article_count,
+        AVG(sentiment_score) AS avg_sentiment_score,
+        AVG(salience) AS avg_salience
+    FROM {fqn}
+    WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+      AND (@entity_type IS NULL OR entity_type = @entity_type)
+    GROUP BY entity_name, entity_type
+    HAVING COUNT(DISTINCT article_id) >= 2
+    ORDER BY avg_sentiment_score DESC
+    LIMIT @limit
+    """
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("days", "INT64", days),
+            bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
+            bigquery.ScalarQueryParameter("limit", "INT64", limit),
+        ]
+    )
+
+    try:
+        results = _get_client().query(query, job_config=job_config)
+        return [dict(row) for row in results]
+    except Exception as e:
+        logger.error("Entity sentiment query failed: %s", e)
+        return []
+
+
+def get_nlp_categories(
+    days: int = 30,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    """GCP NL content categories with sentiment aggregation."""
+    if not config.bigquery.enable_bigquery:
+        return []
+
+    from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+    fqn = _table_fqn(config.bigquery.category_table)
+
+    query = f"""
+    SELECT
+        category_name,
+        COUNT(DISTINCT article_id) AS article_count,
+        AVG(category_confidence) AS avg_confidence,
+        AVG(sentiment_score) AS avg_sentiment_score
+    FROM {fqn}
+    WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+      AND category_name IS NOT NULL
+    GROUP BY category_name
+    ORDER BY article_count DESC
+    LIMIT @limit
+    """
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("days", "INT64", days),
+            bigquery.ScalarQueryParameter("limit", "INT64", limit),
+        ]
+    )
+
+    try:
+        results = _get_client().query(query, job_config=job_config)
+        return [dict(row) for row in results]
+    except Exception as e:
+        logger.error("NLP categories query failed: %s", e)
         return []

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.1",
         "firebase": "^12.6.0"
       },
       "devDependencies": {
@@ -1151,6 +1152,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1650,6 +1657,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "vite": "^7.2.4"
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
     "firebase": "^12.6.0"
   }
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,9 @@
   import { onMount } from 'svelte';
   import { userStore, loginWithGoogle, logout } from './lib/firebase';
   import { fetchLatestArticles, type ArticleDto } from './lib/api';
+  import Dashboard from './lib/Dashboard.svelte';
 
+  let currentPage: 'articles' | 'analytics' = 'articles';
   let articles: ArticleDto[] = [];
   let loading = true;
   let error = '';
@@ -18,6 +20,11 @@
     } finally {
       loading = false;
     }
+  }
+
+  // Redirect to articles if user logs out while on analytics
+  $: if (!$userStore && currentPage === 'analytics') {
+    currentPage = 'articles';
   }
 
   onMount(() => {
@@ -55,7 +62,28 @@
   <header class="bg-white shadow-sm border-b">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between items-center h-16">
-        <h1 class="text-2xl font-bold text-gray-900">aiFeelNews</h1>
+        <div class="flex items-center space-x-6">
+          <h1 class="text-2xl font-bold text-gray-900">aiFeelNews</h1>
+
+          <nav class="flex space-x-1">
+            <button
+              on:click={() => currentPage = 'articles'}
+              class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors
+                {currentPage === 'articles' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}"
+            >
+              Articles
+            </button>
+            {#if $userStore}
+              <button
+                on:click={() => currentPage = 'analytics'}
+                class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors
+                  {currentPage === 'analytics' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}"
+              >
+                Analytics
+              </button>
+            {/if}
+          </nav>
+        </div>
 
         <div class="flex items-center space-x-4">
           {#if $userStore}
@@ -81,90 +109,98 @@
 
   <!-- Main Content -->
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    {#if error}
-      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
-        <div class="flex items-center justify-between">
-          <span>{error}</span>
-          <button
-            on:click={handleRetry}
-            class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
-          >
-            Retry
-          </button>
-        </div>
-      </div>
-    {/if}
-
-    {#if loading}
-      <div class="text-center py-12">
-        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-        <p class="mt-4 text-gray-600">Loading latest articles...</p>
-      </div>
-    {:else}
-      <div class="mb-6">
-        <h2 class="text-xl font-semibold text-gray-900">Latest Articles ({articles.length})</h2>
-        <p class="text-gray-600">Recent news with sentiment analysis</p>
-      </div>
-
-      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {#each articles as article}
-          <div class="bg-white rounded-lg shadow-sm border p-6 hover:shadow-md transition-shadow">
-            <!-- Source -->
-            <div class="flex items-center justify-between mb-3">
-              <span class="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
-                {article.source?.name || `Source #${article.source?.id || 'Unknown'}`}
-              </span>
-              <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
-            </div>
-
-            <!-- Title -->
-            <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
-              {article.title}
-            </h3>
-
-            <!-- Description -->
-            {#if article.description}
-              <p class="text-gray-600 text-sm mb-3 line-clamp-3">
-                {article.description}
-              </p>
-            {/if}
-
-            <!-- Sentiment -->
-            {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
-              <div class="flex items-center justify-between mb-4">
-                <span class="text-xs text-gray-500">Sentiment:</span>
-                <span class="text-sm font-medium {getSentimentColor(article.sentiment_label)}">
-                  {article.sentiment_label} ({article.sentiment_score.toFixed(2)})
-                </span>
-              </div>
-            {/if}
-
-            <!-- Actions -->
-            <div class="flex items-center justify-between">
-              <a
-                href={article.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-blue-600 hover:text-blue-800 text-sm font-medium"
-              >
-                Read Article →
-              </a>
-
-              {#if $userStore}
-                <button
-                  on:click={() => handleBookmark(article)}
-                  class="text-gray-400 hover:text-gray-600"
-                  aria-label="Bookmark this article"
-                  title="Bookmark this article"
-                >
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
-                  </svg>
-                </button>
-              {/if}
-            </div>
+    {#if currentPage === 'articles'}
+      {#if error}
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+          <div class="flex items-center justify-between">
+            <span>{error}</span>
+            <button
+              on:click={handleRetry}
+              class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
+            >
+              Retry
+            </button>
           </div>
-        {/each}
+        </div>
+      {/if}
+
+      {#if loading}
+        <div class="text-center py-12">
+          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p class="mt-4 text-gray-600">Loading latest articles...</p>
+        </div>
+      {:else}
+        <div class="mb-6">
+          <h2 class="text-xl font-semibold text-gray-900">Latest Articles ({articles.length})</h2>
+          <p class="text-gray-600">Recent news with sentiment analysis</p>
+        </div>
+
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {#each articles as article}
+            <div class="bg-white rounded-lg shadow-sm border p-6 hover:shadow-md transition-shadow">
+              <!-- Source -->
+              <div class="flex items-center justify-between mb-3">
+                <span class="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
+                  {article.source?.name || `Source #${article.source?.id || 'Unknown'}`}
+                </span>
+                <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
+              </div>
+
+              <!-- Title -->
+              <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+                {article.title}
+              </h3>
+
+              <!-- Description -->
+              {#if article.description}
+                <p class="text-gray-600 text-sm mb-3 line-clamp-3">
+                  {article.description}
+                </p>
+              {/if}
+
+              <!-- Sentiment -->
+              {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
+                <div class="flex items-center justify-between mb-4">
+                  <span class="text-xs text-gray-500">Sentiment:</span>
+                  <span class="text-sm font-medium {getSentimentColor(article.sentiment_label)}">
+                    {article.sentiment_label} ({article.sentiment_score.toFixed(2)})
+                  </span>
+                </div>
+              {/if}
+
+              <!-- Actions -->
+              <div class="flex items-center justify-between">
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                >
+                  Read Article →
+                </a>
+
+                {#if $userStore}
+                  <button
+                    on:click={() => handleBookmark(article)}
+                    class="text-gray-400 hover:text-gray-600"
+                    aria-label="Bookmark this article"
+                    title="Bookmark this article"
+                  >
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+                    </svg>
+                  </button>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {:else if currentPage === 'analytics' && $userStore}
+      <Dashboard />
+    {:else}
+      <div class="text-center py-12">
+        <p class="text-gray-600">Please log in to access analytics.</p>
       </div>
     {/if}
   </main>

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -1,0 +1,405 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { Chart, registerables } from 'chart.js';
+  import {
+    fetchSentimentTrends,
+    fetchSourceComparison,
+    fetchTopEntities,
+    fetchNlpCategories,
+    fetchPipelineHealth,
+    type SentimentTrendPoint,
+    type SourceComparison,
+    type TopEntity,
+    type NlpCategoryBreakdown,
+    type PipelineRun,
+  } from './api';
+
+  Chart.register(...registerables);
+
+  let days = 30;
+  let loading = true;
+  let error = '';
+
+  // Data
+  let trends: SentimentTrendPoint[] = [];
+  let sources: SourceComparison[] = [];
+  let entities: TopEntity[] = [];
+  let nlpCategories: NlpCategoryBreakdown[] = [];
+  let pipeline: PipelineRun[] = [];
+
+  // Chart instances (for cleanup)
+  let trendChart: Chart | null = null;
+  let sourceChart: Chart | null = null;
+  let entityChart: Chart | null = null;
+  let categoryChart: Chart | null = null;
+
+  // Canvas refs
+  let trendCanvas: HTMLCanvasElement;
+  let sourceCanvas: HTMLCanvasElement;
+  let entityCanvas: HTMLCanvasElement;
+  let categoryCanvas: HTMLCanvasElement;
+
+  const COLORS = {
+    positive: '#16a34a',
+    negative: '#dc2626',
+    neutral: '#2563eb',
+  };
+
+  async function loadData() {
+    loading = true;
+    error = '';
+    try {
+      [trends, sources, entities, nlpCategories, pipeline] = await Promise.all([
+        fetchSentimentTrends(days),
+        fetchSourceComparison(days),
+        fetchTopEntities(days, undefined, 15),
+        fetchNlpCategories(days, 15),
+        fetchPipelineHealth(Math.min(days, 90)),
+      ]);
+      // Defer chart rendering to next tick so canvases are mounted
+      setTimeout(renderCharts, 0);
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load analytics';
+    } finally {
+      loading = false;
+    }
+  }
+
+  function destroyCharts() {
+    trendChart?.destroy(); trendChart = null;
+    sourceChart?.destroy(); sourceChart = null;
+    entityChart?.destroy(); entityChart = null;
+    categoryChart?.destroy(); categoryChart = null;
+  }
+
+  function renderCharts() {
+    destroyCharts();
+    renderTrendChart();
+    renderSourceChart();
+    renderEntityChart();
+    renderCategoryChart();
+  }
+
+  function renderTrendChart() {
+    if (!trendCanvas || !trends.length) return;
+
+    // Group by date, then by label
+    const dateMap = new Map<string, Record<string, number>>();
+    for (const t of trends) {
+      if (!dateMap.has(t.date)) dateMap.set(t.date, {});
+      dateMap.get(t.date)![t.sentiment_label] = t.article_count;
+    }
+    const dates = [...dateMap.keys()].sort();
+
+    trendChart = new Chart(trendCanvas, {
+      type: 'line',
+      data: {
+        labels: dates,
+        datasets: ['positive', 'negative', 'neutral'].map(label => ({
+          label: label.charAt(0).toUpperCase() + label.slice(1),
+          data: dates.map(d => dateMap.get(d)?.[label] ?? 0),
+          borderColor: COLORS[label as keyof typeof COLORS],
+          backgroundColor: COLORS[label as keyof typeof COLORS] + '20',
+          tension: 0.3,
+          fill: false,
+        })),
+      },
+      options: {
+        responsive: true,
+        plugins: { legend: { position: 'top' } },
+        scales: { y: { beginAtZero: true, title: { display: true, text: 'Articles' } } },
+      },
+    });
+  }
+
+  function renderSourceChart() {
+    if (!sourceCanvas || !sources.length) return;
+
+    // Get unique sources and build stacked data
+    const sourceNames = [...new Set(sources.map(s => s.source_name))];
+    const labels = ['positive', 'negative', 'neutral'];
+
+    sourceChart = new Chart(sourceCanvas, {
+      type: 'bar',
+      data: {
+        labels: sourceNames,
+        datasets: labels.map(label => ({
+          label: label.charAt(0).toUpperCase() + label.slice(1),
+          data: sourceNames.map(src => {
+            const match = sources.find(s => s.source_name === src && s.sentiment_label === label);
+            return match?.percentage ?? 0;
+          }),
+          backgroundColor: COLORS[label as keyof typeof COLORS] + 'CC',
+        })),
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        plugins: { legend: { position: 'top' } },
+        scales: { x: { stacked: true, max: 100, title: { display: true, text: '%' } }, y: { stacked: true } },
+      },
+    });
+  }
+
+  function renderEntityChart() {
+    if (!entityCanvas || !entities.length) return;
+
+    entityChart = new Chart(entityCanvas, {
+      type: 'bar',
+      data: {
+        labels: entities.map(e => `${e.entity_name} (${e.entity_type})`),
+        datasets: [{
+          label: 'Articles',
+          data: entities.map(e => e.article_count),
+          backgroundColor: entities.map(e => {
+            const score = e.avg_sentiment_score ?? 0;
+            if (score > 0.1) return COLORS.positive + 'CC';
+            if (score < -0.1) return COLORS.negative + 'CC';
+            return COLORS.neutral + 'CC';
+          }),
+        }],
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        plugins: { legend: { display: false } },
+        scales: { x: { beginAtZero: true, title: { display: true, text: 'Article mentions' } } },
+      },
+    });
+  }
+
+  function renderCategoryChart() {
+    if (!categoryCanvas || !nlpCategories.length) return;
+
+    categoryChart = new Chart(categoryCanvas, {
+      type: 'bar',
+      data: {
+        labels: nlpCategories.map(c => c.category_name),
+        datasets: [{
+          label: 'Articles',
+          data: nlpCategories.map(c => c.article_count),
+          backgroundColor: nlpCategories.map(c => {
+            const score = c.avg_sentiment_score ?? 0;
+            if (score > 0.1) return COLORS.positive + 'CC';
+            if (score < -0.1) return COLORS.negative + 'CC';
+            return COLORS.neutral + 'CC';
+          }),
+        }],
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        plugins: { legend: { display: false } },
+        scales: { x: { beginAtZero: true, title: { display: true, text: 'Articles' } } },
+      },
+    });
+  }
+
+  function handleDaysChange(event: Event) {
+    days = parseInt((event.target as HTMLSelectElement).value);
+    loadData();
+  }
+
+  function formatDate(dateStr: string): string {
+    return new Date(dateStr).toLocaleString();
+  }
+
+  onMount(() => { loadData(); });
+  onDestroy(() => { destroyCharts(); });
+</script>
+
+<div class="dashboard">
+  <!-- Controls -->
+  <div class="controls">
+    <h2 class="text-xl font-semibold text-gray-900">Analytics Dashboard</h2>
+    <select on:change={handleDaysChange} value={days} class="select">
+      <option value={7}>Last 7 days</option>
+      <option value={30}>Last 30 days</option>
+      <option value={90}>Last 90 days</option>
+      <option value={365}>Last year</option>
+    </select>
+  </div>
+
+  {#if error}
+    <div class="error-banner">{error}</div>
+  {/if}
+
+  {#if loading}
+    <div class="loading">
+      <div class="spinner"></div>
+      <p class="text-gray-600">Loading analytics...</p>
+    </div>
+  {:else}
+    <div class="grid-2">
+      <!-- Sentiment Trends -->
+      <div class="card">
+        <h3 class="text-lg font-semibold text-gray-900">Sentiment Trends</h3>
+        {#if trends.length}
+          <canvas bind:this={trendCanvas}></canvas>
+        {:else}
+          <p class="text-sm text-gray-500 empty">No trend data available</p>
+        {/if}
+      </div>
+
+      <!-- Source Comparison -->
+      <div class="card">
+        <h3 class="text-lg font-semibold text-gray-900">Source Comparison</h3>
+        {#if sources.length}
+          <canvas bind:this={sourceCanvas}></canvas>
+        {:else}
+          <p class="text-sm text-gray-500 empty">No source data available</p>
+        {/if}
+      </div>
+
+      <!-- Top Entities -->
+      <div class="card">
+        <h3 class="text-lg font-semibold text-gray-900">Top Entities</h3>
+        <p class="text-xs text-gray-500">Color: green = positive, red = negative, blue = neutral sentiment</p>
+        {#if entities.length}
+          <canvas bind:this={entityCanvas}></canvas>
+        {:else}
+          <p class="text-sm text-gray-500 empty">No entity data available</p>
+        {/if}
+      </div>
+
+      <!-- NLP Categories -->
+      <div class="card">
+        <h3 class="text-lg font-semibold text-gray-900">GCP NL Categories</h3>
+        <p class="text-xs text-gray-500">ML-classified content taxonomy from GCP Natural Language</p>
+        {#if nlpCategories.length}
+          <canvas bind:this={categoryCanvas}></canvas>
+        {:else}
+          <p class="text-sm text-gray-500 empty">No category data available</p>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Pipeline Health -->
+    <div class="card" style="margin-top: 1.5rem;">
+      <h3 class="text-lg font-semibold text-gray-900">Pipeline Health</h3>
+      {#if pipeline.length}
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Started</th>
+                <th>Duration</th>
+                <th>Fetched</th>
+                <th>Ingested</th>
+                <th>Crawl OK</th>
+                <th>Crawl Fail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each pipeline as run}
+                <tr>
+                  <td>{formatDate(run.started_at)}</td>
+                  <td>{run.duration_seconds.toFixed(1)}s</td>
+                  <td>{run.articles_fetched}</td>
+                  <td>{run.articles_ingested}</td>
+                  <td>{run.crawl_successful ?? '-'}</td>
+                  <td>{run.crawl_failed ?? '-'}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {:else}
+        <p class="text-sm text-gray-500 empty">No pipeline data available</p>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .dashboard { padding: 0; }
+
+  .controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+  }
+
+  .select {
+    padding: 0.5rem 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    background: white;
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+
+  .error-banner {
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #b91c1c;
+    padding: 0.75rem 1rem;
+    border-radius: 0.375rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .loading {
+    text-align: center;
+    padding: 3rem 0;
+  }
+
+  .spinner {
+    width: 3rem;
+    height: 3rem;
+    border: 2px solid transparent;
+    border-bottom-color: #2563eb;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin: 0 auto 1rem;
+  }
+
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .grid-2 {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 768px) {
+    .grid-2 { grid-template-columns: 1fr 1fr; }
+  }
+
+  .card {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  }
+
+  .card h3 { margin-bottom: 0.75rem; }
+
+  .empty {
+    text-align: center;
+    padding: 2rem 0;
+  }
+
+  .table-wrapper { overflow-x: auto; }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  th, td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  th {
+    font-weight: 600;
+    color: #374151;
+    background: #f9fafb;
+  }
+
+  td { color: #6b7280; }
+</style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -64,3 +64,107 @@ export async function fetchBookmarks(): Promise<any[]> {
   if (!res.ok) throw new Error("Failed to fetch bookmarks");
   return await res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Analytics API (BigQuery-powered)
+// ---------------------------------------------------------------------------
+
+export type SentimentTrendPoint = {
+  date: string;
+  sentiment_label: string;
+  article_count: number;
+  avg_sentiment_score: number;
+  avg_magnitude: number | null;
+};
+
+export type SourceComparison = {
+  source_name: string;
+  sentiment_label: string;
+  article_count: number;
+  avg_sentiment_score: number;
+  percentage: number;
+};
+
+export type CategoryBreakdown = {
+  category: string;
+  article_count: number;
+  avg_sentiment_score: number;
+  avg_magnitude: number | null;
+};
+
+export type PipelineRun = {
+  run_id: string;
+  started_at: string;
+  finished_at: string;
+  duration_seconds: number;
+  articles_fetched: number;
+  articles_ingested: number;
+  crawl_successful: number | null;
+  crawl_failed: number | null;
+  include_crawling: boolean;
+};
+
+export type TopEntity = {
+  entity_name: string;
+  entity_type: string;
+  article_count: number;
+  avg_salience: number | null;
+  avg_sentiment_score: number | null;
+};
+
+export type EntitySentiment = {
+  entity_name: string;
+  entity_type: string;
+  article_count: number;
+  avg_sentiment_score: number | null;
+  avg_salience: number | null;
+};
+
+export type NlpCategoryBreakdown = {
+  category_name: string;
+  article_count: number;
+  avg_confidence: number | null;
+  avg_sentiment_score: number | null;
+};
+
+async function fetchAnalytics<T>(path: string): Promise<T[]> {
+  const res = await fetch(`${API_BASE}/api/v1/analytics${path}`);
+  if (!res.ok) throw new Error(`Analytics request failed: ${res.status}`);
+  const data = await res.json();
+  // BQ disabled returns { message: "..." } instead of array
+  if (!Array.isArray(data)) return [];
+  return data;
+}
+
+export function fetchSentimentTrends(days = 30, source?: string): Promise<SentimentTrendPoint[]> {
+  const params = source ? `?days=${days}&source=${source}` : `?days=${days}`;
+  return fetchAnalytics(`/trends${params}`);
+}
+
+export function fetchSourceComparison(days = 30): Promise<SourceComparison[]> {
+  return fetchAnalytics(`/sources?days=${days}`);
+}
+
+export function fetchCategoryBreakdown(days = 30): Promise<CategoryBreakdown[]> {
+  return fetchAnalytics(`/categories?days=${days}`);
+}
+
+export function fetchPipelineHealth(days = 7): Promise<PipelineRun[]> {
+  return fetchAnalytics(`/pipeline?days=${days}`);
+}
+
+export function fetchTopEntities(days = 30, entityType?: string, limit = 20): Promise<TopEntity[]> {
+  let params = `?days=${days}&limit=${limit}`;
+  if (entityType) params += `&entity_type=${entityType}`;
+  return fetchAnalytics(`/entities/top${params}`);
+}
+
+export function fetchEntitySentiment(days = 30, entityType?: string, limit = 20): Promise<EntitySentiment[]> {
+  let params = `?days=${days}&limit=${limit}`;
+  if (entityType) params += `&entity_type=${entityType}`;
+  return fetchAnalytics(`/entities/sentiment${params}`);
+}
+
+export function fetchNlpCategories(days = 30, limit = 20): Promise<NlpCategoryBreakdown[]> {
+  return fetchAnalytics(`/categories/nlp?days=${days}&limit=${limit}`);
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,22 +1,10 @@
-# --------------------------------------------------------------------------
 # aiFeelNews — Infrastructure as Code (Terraform)
 #
-# Codifies the existing GCP resources that power the platform:
-#   - Artifact Registry (Docker images)
-#   - Cloud Run (API serving)
-#   - Cloud SQL (PostgreSQL)
-#   - Cloud Scheduler (ingestion + cleanup cron jobs)
-#   - Secret Manager (credentials)
-#   - BigQuery (analytics warehouse)
-#   - IAM bindings (service accounts + least-privilege roles)
-#   - API enablement
-#
-# Why Terraform?
-#   - Reproducible: anyone can recreate the full stack from these files
-#   - Auditable: infrastructure changes go through code review (PRs)
-#   - Multi-env ready: prod.tfvars vs staging.tfvars
-#   - Drift detection: `terraform plan` shows if manual changes happened
-# --------------------------------------------------------------------------
+# Codifies the GCP resources that power the platform:
+#   - Artifact Registry, Cloud Run (via CI/CD), Cloud SQL
+#   - Cloud Scheduler, Secret Manager, BigQuery
+#   - IAM (least-privilege service accounts)
+#   - Cloud Monitoring (uptime, alerting, dashboards)
 
 terraform {
   required_version = ">= 1.5"
@@ -34,11 +22,7 @@ provider "google" {
   region  = var.region
 }
 
-# ==========================================================================
-# API Enablement
-# Why: GCP requires explicitly enabling each API before resources can use it.
-# This ensures a fresh project can be bootstrapped from scratch.
-# ==========================================================================
+# --- API Enablement (required before any resource can use the service) ---
 
 locals {
   required_apis = [
@@ -64,12 +48,7 @@ resource "google_project_service" "apis" {
   disable_on_destroy = false
 }
 
-# ==========================================================================
-# Artifact Registry
-# Why: GCR (gcr.io) shut down March 2025. Artifact Registry is the
-# successor — same Docker workflow, better security (IAM per-repo),
-# regional storage, vulnerability scanning.
-# ==========================================================================
+# --- Artifact Registry (GCR successor — IAM per-repo, regional, vuln scanning) ---
 
 resource "google_artifact_registry_repository" "docker" {
   location      = var.region
@@ -80,18 +59,7 @@ resource "google_artifact_registry_repository" "docker" {
   depends_on = [google_project_service.apis["artifactregistry.googleapis.com"]]
 }
 
-# ==========================================================================
-# Cloud SQL — Managed PostgreSQL
-# Why Cloud SQL over self-hosted?
-#   - Automated backups, patching, failover
-#   - Private IP / Cloud SQL Auth Proxy for secure connections
-#   - SLA-backed availability (99.95%)
-#   - Frees us from DB ops so we focus on application logic
-# Why PostgreSQL over Firestore/Spanner?
-#   - Relational model fits our data (articles, sources, users, bookmarks)
-#   - SQL expertise transfers to industry
-#   - Assessment requires demonstrating relational DB skills
-# ==========================================================================
+# --- Cloud SQL — Managed PostgreSQL (automated backups, Auth Proxy, 99.95% SLA) ---
 
 resource "google_sql_database_instance" "main" {
   name             = var.cloud_sql_instance_name
@@ -131,13 +99,7 @@ resource "google_sql_database" "app" {
   instance = google_sql_database_instance.main.name
 }
 
-# ==========================================================================
-# Secret Manager
-# Why Secret Manager over env vars?
-#   - Secrets are versioned, auditable, and access-controlled via IAM
-#   - Rotation without redeployment
-#   - No secrets in code, env files, or CI/CD logs
-# ==========================================================================
+# --- Secret Manager (versioned, IAM-controlled, rotatable without redeploy) ---
 
 resource "google_secret_manager_secret" "db_password" {
   secret_id = "db-password"
@@ -179,23 +141,9 @@ resource "google_secret_manager_secret" "firebase_sa" {
   depends_on = [google_project_service.apis["secretmanager.googleapis.com"]]
 }
 
-# ==========================================================================
-# Cloud Run — NOT managed by Terraform
-# Cloud Run revisions are deployed by GitHub Actions (deploy.yml) on every
-# merge to main. Terraform managing the same service would conflict with
-# CI/CD and risk stripping env vars, volumes, and secrets from the live
-# service. Terraform manages the infrastructure Cloud Run depends on
-# (SQL, secrets, IAM, registry). CI/CD manages the application deployment.
-# ==========================================================================
+# --- Cloud Run — deployed by GitHub Actions, NOT Terraform (avoids CI/CD conflict) ---
 
-# ==========================================================================
-# Cloud Scheduler — Managed cron jobs
-# Why Cloud Scheduler over cron in a container?
-#   - Survives container restarts and scale-to-zero
-#   - Managed retry policies
-#   - Visible in GCP Console (observability)
-#   - Triggers Cloud Run via HTTP — clean separation of concerns
-# ==========================================================================
+# --- Cloud Scheduler — Managed cron (survives scale-to-zero, managed retries) ---
 
 resource "google_cloud_scheduler_job" "ingestion" {
   name      = "aifeelnews-ingestion"
@@ -237,15 +185,7 @@ resource "google_cloud_scheduler_job" "cleanup" {
   depends_on = [google_project_service.apis["cloudscheduler.googleapis.com"]]
 }
 
-# ==========================================================================
-# BigQuery — Analytics data warehouse
-# Why BigQuery over PostgreSQL for analytics?
-#   - Separation of concerns: OLTP (PostgreSQL) vs OLAP (BigQuery)
-#   - Columnar storage optimized for aggregation queries
-#   - 1 TB/month free queries, 10 GB/month free storage
-#   - Partitioning + clustering for efficient time-range + category queries
-#   - Powers the News Analyst persona dashboards
-# ==========================================================================
+# --- BigQuery — OLAP warehouse (columnar, partitioned, generous free tier) ---
 
 resource "google_bigquery_dataset" "analytics" {
   dataset_id = var.bigquery_dataset_id
@@ -318,64 +258,109 @@ resource "google_bigquery_table" "ingestion_events" {
   ])
 }
 
-# ==========================================================================
-# IAM — Least-privilege access
-# Why explicit IAM over primitive roles?
-#   - Principle of least privilege: each SA gets only what it needs
-#   - Auditable: every permission is documented in code
-#   - Reviewable: IAM changes go through PR review
-#   - Mitigates STRIDE "Elevation of Privilege": a compromised container
-#     can only do what the dedicated SA allows, not project-wide editor
-# ==========================================================================
+# BigQuery — Entity events (one row per article-entity pair from GCP NL)
+# Flat rows instead of REPEATED fields: simpler GROUP BY without UNNEST
+resource "google_bigquery_table" "entity_events" {
+  dataset_id = google_bigquery_dataset.analytics.dataset_id
+  table_id   = "entity_events"
 
-# ---------- Dedicated Cloud Run Service Account ----------
-# Why a dedicated SA instead of the Compute Engine default?
-#   - Default SA has roles/editor (read/write almost everything)
-#   - Dedicated SA gets exactly 5 roles — nothing more
-#   - If the container is compromised, blast radius is minimal
+  description = "Per-article entity mentions from GCP NL"
+
+  time_partitioning {
+    type  = "DAY"
+    field = "ingested_at"
+  }
+
+  clustering = ["entity_type", "entity_name"]
+
+  schema = jsonencode([
+    { name = "event_id", type = "STRING", mode = "REQUIRED", description = "Unique event identifier" },
+    { name = "article_id", type = "INTEGER", mode = "REQUIRED", description = "PostgreSQL article ID" },
+    { name = "article_url", type = "STRING", mode = "NULLABLE", description = "Original article URL" },
+    { name = "article_title", type = "STRING", mode = "NULLABLE", description = "Article headline" },
+    { name = "source_name", type = "STRING", mode = "NULLABLE", description = "News source name" },
+    { name = "published_at", type = "TIMESTAMP", mode = "NULLABLE", description = "Article publication time" },
+    { name = "ingested_at", type = "TIMESTAMP", mode = "REQUIRED", description = "Entity extraction time (partition key)" },
+    { name = "entity_name", type = "STRING", mode = "NULLABLE", description = "Entity name (e.g., Google, London)" },
+    { name = "entity_type", type = "STRING", mode = "NULLABLE", description = "Entity type (PERSON, ORGANIZATION, LOCATION, etc.)" },
+    { name = "salience", type = "FLOAT", mode = "NULLABLE", description = "Entity relevance score (0.0 to 1.0)" },
+    { name = "mention_count", type = "INTEGER", mode = "NULLABLE", description = "Times entity appears in article text" },
+    { name = "wikipedia_url", type = "STRING", mode = "NULLABLE", description = "Wikipedia link from Knowledge Graph" },
+    { name = "sentiment_label", type = "STRING", mode = "NULLABLE", description = "Article-level sentiment label" },
+    { name = "sentiment_score", type = "FLOAT", mode = "NULLABLE", description = "Article-level sentiment score (-1.0 to 1.0)" },
+  ])
+
+  depends_on = [google_project_service.apis["bigquery.googleapis.com"]]
+}
+
+# BigQuery — Category events (GCP NL content classification per article)
+# Distinct from Mediastack article.category — these are ML-classified taxonomy paths
+resource "google_bigquery_table" "category_events" {
+  dataset_id = google_bigquery_dataset.analytics.dataset_id
+  table_id   = "category_events"
+
+  description = "Per-article GCP NL content categories"
+
+  time_partitioning {
+    type  = "DAY"
+    field = "ingested_at"
+  }
+
+  clustering = ["category_name"]
+
+  schema = jsonencode([
+    { name = "event_id", type = "STRING", mode = "REQUIRED", description = "Unique event identifier" },
+    { name = "article_id", type = "INTEGER", mode = "REQUIRED", description = "PostgreSQL article ID" },
+    { name = "source_name", type = "STRING", mode = "NULLABLE", description = "News source name" },
+    { name = "published_at", type = "TIMESTAMP", mode = "NULLABLE", description = "Article publication time" },
+    { name = "ingested_at", type = "TIMESTAMP", mode = "REQUIRED", description = "Category classification time (partition key)" },
+    { name = "category_name", type = "STRING", mode = "NULLABLE", description = "GCP NL taxonomy path (e.g., /News/Business)" },
+    { name = "category_confidence", type = "FLOAT", mode = "NULLABLE", description = "Classification confidence (0.0 to 1.0)" },
+    { name = "sentiment_label", type = "STRING", mode = "NULLABLE", description = "Article-level sentiment label" },
+    { name = "sentiment_score", type = "FLOAT", mode = "NULLABLE", description = "Article-level sentiment score (-1.0 to 1.0)" },
+  ])
+
+  depends_on = [google_project_service.apis["bigquery.googleapis.com"]]
+}
+
+# --- IAM — Least-privilege (dedicated SA, not default Compute Engine editor) ---
 resource "google_service_account" "cloudrun" {
   account_id   = "cloudrun-sa"
   display_name = "Cloud Run Service Account"
   description  = "Least-privilege SA for aiFeelNews Cloud Run services (web, worker, scheduler)"
 }
 
-# Role 1: Read secrets (DB password, API keys, Firebase SA)
 resource "google_project_iam_member" "cloudrun_secret_accessor" {
   project = var.project_id
   role    = "roles/secretmanager.secretAccessor"
   member  = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
-# Role 2: Connect to Cloud SQL via Cloud SQL Auth Proxy
 resource "google_project_iam_member" "cloudrun_cloudsql_client" {
   project = var.project_id
   role    = "roles/cloudsql.client"
   member  = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
-# Role 3: Call Cloud Natural Language API (sentiment + entities + categories)
 resource "google_project_iam_member" "cloudrun_nl_user" {
   project = var.project_id
   role    = "roles/serviceusage.serviceUsageConsumer"
   member  = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
-# Role 4: Write data to BigQuery tables (sentiment + ingestion events)
 resource "google_project_iam_member" "cloudrun_bigquery_editor" {
   project = var.project_id
   role    = "roles/bigquery.dataEditor"
   member  = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
-# Role 5: Run BigQuery queries (analytics dashboard endpoints)
 resource "google_project_iam_member" "cloudrun_bigquery_jobuser" {
   project = var.project_id
   role    = "roles/bigquery.jobUser"
   member  = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
-# ---------- GitHub Actions SA ----------
-# Deploys containers and manages Cloud Run revisions
+# GitHub Actions SA — deploys containers and Cloud Run revisions
 resource "google_project_iam_member" "github_actions_run_admin" {
   project = var.project_id
   role    = "roles/run.admin"
@@ -388,25 +373,19 @@ resource "google_project_iam_member" "github_actions_ar_writer" {
   member  = "serviceAccount:${var.github_actions_sa_email}"
 }
 
-# Allow GitHub Actions to deploy Cloud Run revisions AS the dedicated SA
 resource "google_service_account_iam_member" "github_actions_act_as_cloudrun" {
   service_account_id = google_service_account.cloudrun.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${var.github_actions_sa_email}"
 }
 
-# ==========================================================================
-# Cloud Monitoring — Uptime checks, alerting, log-based metrics, dashboard
-# All free tier: system metrics, 50 GB/month logs, alerting, dashboards
-# ==========================================================================
+# --- Cloud Monitoring — Uptime checks, alerting, log-based metrics (free tier) ---
 
 locals {
   cloud_run_host = replace(var.cloud_run_url, "https://", "")
 }
 
-# ---------- Uptime Check ----------
-# /health tests DB connection (not /ready which is static JSON)
-# 10s timeout accommodates Cloud Run cold starts
+# Uptime check — /health (tests DB, 10s timeout for cold starts)
 resource "google_monitoring_uptime_check_config" "health" {
   display_name = "aifeelnews-health-check"
   timeout      = "10s"
@@ -430,7 +409,7 @@ resource "google_monitoring_uptime_check_config" "health" {
   depends_on = [google_project_service.apis["monitoring.googleapis.com"]]
 }
 
-# ---------- Notification Channel ----------
+# Notification channel
 resource "google_monitoring_notification_channel" "email" {
   display_name = "aiFeelNews Alert Email"
   type         = "email"
@@ -442,8 +421,7 @@ resource "google_monitoring_notification_channel" "email" {
   depends_on = [google_project_service.apis["monitoring.googleapis.com"]]
 }
 
-# ---------- Log-Based Metrics ----------
-# Derived from existing structured JSON logs (no SDK needed)
+# Log-based metrics (derived from structured JSON logs, no SDK needed)
 resource "google_logging_metric" "error_count" {
   name        = "aifeelnews/error_count"
   description = "Count of ERROR-severity log entries from Cloud Run"
@@ -460,7 +438,6 @@ resource "google_logging_metric" "error_count" {
   }
 }
 
-# Matches "Ingestion pipeline completed" from run_ingestion.py
 resource "google_logging_metric" "ingestion_runs" {
   name        = "aifeelnews/ingestion_pipeline_runs"
   description = "Count of completed ingestion pipeline runs"
@@ -478,7 +455,6 @@ resource "google_logging_metric" "ingestion_runs" {
   }
 }
 
-# Matches crawl errors from crawl_worker.py
 resource "google_logging_metric" "crawl_failures" {
   name        = "aifeelnews/crawl_failures"
   description = "Count of failed crawl jobs"
@@ -498,7 +474,7 @@ resource "google_logging_metric" "crawl_failures" {
   }
 }
 
-# ---------- Alerting Policies ----------
+# Alerting policies
 resource "google_monitoring_alert_policy" "uptime_failure" {
   display_name = "aiFeelNews Service Down"
   combiner     = "OR"
@@ -533,7 +509,6 @@ resource "google_monitoring_alert_policy" "uptime_failure" {
   depends_on = [google_project_service.apis["monitoring.googleapis.com"]]
 }
 
-# >10 errors in 5 minutes
 resource "google_monitoring_alert_policy" "high_error_rate" {
   display_name = "aiFeelNews High Error Rate"
   combiner     = "OR"
@@ -566,8 +541,7 @@ resource "google_monitoring_alert_policy" "high_error_rate" {
   depends_on = [google_project_service.apis["monitoring.googleapis.com"]]
 }
 
-# ---------- Monitoring Dashboard ----------
-# 5 Cloud Run system metrics + 3 custom log-based metrics
+# Monitoring dashboard (5 Cloud Run system metrics + 3 custom log-based)
 resource "google_monitoring_dashboard" "main" {
   dashboard_json = jsonencode({
     displayName = "aiFeelNews — Operations"


### PR DESCRIPTION
## Summary
- Activate BigQuery on Cloud Run via `BIGQUERY_ENABLE_BIGQUERY=true` env var
- Fix schema drift: 5 fields aligned REQUIRED→NULLABLE between Python and Terraform
- Add `entity_events` and `category_events` BQ tables (Terraform IaC + Python schemas)
- Stream entity/category data to BQ from crawl worker after GCP NL analysis
- 3 new analytics API endpoints: `/entities/top`, `/entities/sentiment`, `/categories/nlp`
- Idempotent backfill script (`--dry-run`, `--since`, per-provider extraction_method)
- Frontend: Chart.js analytics dashboard (auth-gated) with tab navigation
- Tighten Terraform comment verbosity across all sections

## Test plan
- [ ] `ruff check app/` passes
- [ ] `pytest tests/ -v` — 23/23 tests pass
- [ ] `cd frontend && npm run build` compiles successfully
- [ ] `terraform plan` shows 2 new BQ tables, no destructive changes
- [ ] Deploy to Cloud Run, verify `/api/v1/analytics/entities/top` returns data
- [ ] Run `python -m app.jobs.backfill_bigquery --dry-run` to preview backfill counts
- [ ] Frontend: Analytics tab only visible when logged in
- [ ] Frontend: Logout while on Analytics redirects to Articles