### PR TITLE
feat(frontend): redesign article cards with rich analysis display and images

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { userStore, loginWithGoogle, logout } from './lib/firebase';
-  import { fetchLatestArticles, type ArticleDto } from './lib/api';
+  import {
+    fetchLatestArticles,
+    type ArticleDto,
+    type ArticleEntityDto,
+    type ArticleCategoryDto,
+  } from './lib/api';
   import Dashboard from './lib/Dashboard.svelte';
 
   let currentPage: 'articles' | 'analytics' = 'articles';
@@ -35,15 +40,102 @@
     loadArticles();
   }
 
+  // ── Sentiment helpers ──────────────────────────────────────────────
+
   function getSentimentColor(label?: string): string {
     if (!label) return 'text-gray-500';
     switch (label.toLowerCase()) {
       case 'positive': return 'text-green-600';
       case 'negative': return 'text-red-600';
-      case 'neutral': return 'text-blue-600';
-      default: return 'text-gray-500';
+      case 'neutral':  return 'text-blue-600';
+      default:         return 'text-gray-500';
     }
   }
+
+  function getSentimentBgColor(label?: string): string {
+    if (!label) return 'bg-gray-100';
+    switch (label.toLowerCase()) {
+      case 'positive': return 'bg-green-100';
+      case 'negative': return 'bg-red-100';
+      case 'neutral':  return 'bg-blue-100';
+      default:         return 'bg-gray-100';
+    }
+  }
+
+  function getSentimentBarColor(label?: string): string {
+    if (!label) return '#9ca3af';
+    switch (label.toLowerCase()) {
+      case 'positive': return '#16a34a';
+      case 'negative': return '#dc2626';
+      case 'neutral':  return '#2563eb';
+      default:         return '#9ca3af';
+    }
+  }
+
+  function sentimentScoreToPercent(score: number): number {
+    return Math.round(((score + 1) / 2) * 100);
+  }
+
+  function getSentimentExplanation(label?: string | null, score?: number | null): string {
+    if (!label || score === null || score === undefined) return '';
+    const abs = Math.abs(score);
+    const intensity = abs > 0.6 ? 'strongly' : abs > 0.25 ? 'moderately' : 'slightly';
+    switch (label.toLowerCase()) {
+      case 'positive': return `Overall tone is ${intensity} positive`;
+      case 'negative': return `Overall tone is ${intensity} negative`;
+      case 'neutral':  return 'Balanced, neutral tone';
+      default:         return '';
+    }
+  }
+
+  // ── Entity / category helpers ────────────────────────────────────
+
+  function getTopEntities(entities?: ArticleEntityDto[] | null, max = 3): ArticleEntityDto[] {
+    if (!entities || entities.length === 0) return [];
+    return [...entities].sort((a, b) => b.salience - a.salience).slice(0, max);
+  }
+
+  function getTopCategories(categories?: ArticleCategoryDto[] | null, max = 2): ArticleCategoryDto[] {
+    if (!categories || categories.length === 0) return [];
+    return [...categories].sort((a, b) => b.confidence - a.confidence).slice(0, max);
+  }
+
+  function formatCategoryName(taxonomyPath: string): string {
+    const parts = taxonomyPath.split('/').filter(Boolean);
+    return parts[parts.length - 1] || taxonomyPath;
+  }
+
+  function formatEntityType(type: string): string {
+    const map: Record<string, string> = {
+      ORGANIZATION: 'Org', PERSON: 'Person', LOCATION: 'Place',
+      EVENT: 'Event', WORK_OF_ART: 'Work', CONSUMER_GOOD: 'Product',
+      OTHER: '', UNKNOWN: '',
+    };
+    return map[type] ?? type.charAt(0) + type.slice(1).toLowerCase();
+  }
+
+  // ── Image / favicon helpers ─────────────────────────────────────
+
+  function getDomain(url: string): string {
+    try {
+      return new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      return '';
+    }
+  }
+
+  function getFaviconUrl(articleUrl: string, size = 20): string {
+    const domain = getDomain(articleUrl);
+    if (!domain) return '';
+    return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
+  }
+
+  function handleImageError(event: Event) {
+    const img = event.target as HTMLImageElement;
+    img.style.display = 'none';
+  }
+
+  // ── General helpers ──────────────────────────────────────────────
 
   function formatDate(dateStr: string): string {
     return new Date(dateStr).toLocaleDateString();
@@ -137,60 +229,156 @@
 
         <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {#each articles as article}
-            <div class="bg-white rounded-lg shadow-sm border p-6 hover:shadow-md transition-shadow">
-              <!-- Source -->
-              <div class="flex items-center justify-between mb-3">
-                <span class="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
-                  {article.source?.name || `Source #${article.source?.id || 'Unknown'}`}
-                </span>
-                <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
+            <div class="bg-white rounded-lg shadow-sm border overflow-hidden hover:shadow-md transition-shadow">
+              <!-- Article image / placeholder -->
+              <div class="card-image-wrapper">
+                <div class="card-image-placeholder">
+                  <svg class="card-image-placeholder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15l-5-5L5 21" />
+                    <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
+                  </svg>
+                </div>
+                {#if article.image_url}
+                  <img
+                    src={article.image_url}
+                    alt=""
+                    class="card-image"
+                    loading="lazy"
+                    decoding="async"
+                    referrerpolicy="no-referrer"
+                    on:error={handleImageError}
+                  />
+                {/if}
               </div>
 
-              <!-- Title -->
-              <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
-                {article.title}
-              </h3>
-
-              <!-- Description -->
-              {#if article.description}
-                <p class="text-gray-600 text-sm mb-3 line-clamp-3">
-                  {article.description}
-                </p>
-              {/if}
-
-              <!-- Sentiment -->
-              {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
-                <div class="flex items-center justify-between mb-4">
-                  <span class="text-xs text-gray-500">Sentiment:</span>
-                  <span class="text-sm font-medium {getSentimentColor(article.sentiment_label)}">
-                    {article.sentiment_label} ({article.sentiment_score.toFixed(2)})
+              <div class="card-body">
+                <!-- Source (with favicon) -->
+                <div class="flex items-center justify-between mb-3">
+                  <span class="source-badge text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
+                    {#if getDomain(article.url)}
+                      <img
+                        src={getFaviconUrl(article.url)}
+                        alt=""
+                        class="source-favicon"
+                        loading="lazy"
+                        on:error={handleImageError}
+                      />
+                    {/if}
+                    {article.source?.name || `Source #${article.source?.id || 'Unknown'}`}
                   </span>
+                  <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
                 </div>
-              {/if}
 
-              <!-- Actions -->
-              <div class="flex items-center justify-between">
-                <a
-                  href={article.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-blue-600 hover:text-blue-800 text-sm font-medium"
-                >
-                  Read Article →
-                </a>
+                <!-- Title -->
+                <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+                  {article.title}
+                </h3>
 
-                {#if $userStore}
-                  <button
-                    on:click={() => handleBookmark(article)}
-                    class="text-gray-400 hover:text-gray-600"
-                    aria-label="Bookmark this article"
-                    title="Bookmark this article"
-                  >
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
-                    </svg>
-                  </button>
+                <!-- Description -->
+                {#if article.description}
+                  <p class="text-gray-600 text-sm mb-3 line-clamp-3">
+                    {article.description}
+                  </p>
                 {/if}
+
+                <!-- Sentiment analysis -->
+                {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
+                  <div class="sentiment-section mb-3">
+                    <div class="flex items-center justify-between mb-2">
+                      <span class="text-xs font-semibold px-2 rounded {getSentimentBgColor(article.sentiment_label)} {getSentimentColor(article.sentiment_label)}">
+                        {article.sentiment_label.toUpperCase()}
+                      </span>
+                      <span
+                        class="text-xs text-gray-500"
+                        title="Sentiment score from -1.0 (very negative) to 1.0 (very positive)"
+                      >
+                        Score: {article.sentiment_score.toFixed(2)}
+                      </span>
+                    </div>
+
+                    <div class="sentiment-bar-track">
+                      <div
+                        class="sentiment-bar-fill"
+                        style="width: {sentimentScoreToPercent(article.sentiment_score)}%; background-color: {getSentimentBarColor(article.sentiment_label)};"
+                      ></div>
+                      <div class="sentiment-bar-midpoint"></div>
+                    </div>
+
+                    <p class="text-xs text-gray-400 mt-1 sentiment-explanation">
+                      {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
+                    </p>
+                  </div>
+                {/if}
+
+                <!-- Content categories -->
+                {#if getTopCategories(article.article_categories).length > 0}
+                  <div class="flex items-center flex-wrap gap-1 mb-2">
+                    <span class="text-xs text-gray-400 mr-1">Topics:</span>
+                    {#each getTopCategories(article.article_categories) as cat}
+                      <span
+                        class="category-chip"
+                        title="Category: {cat.name} (confidence: {(cat.confidence * 100).toFixed(0)}%)"
+                      >
+                        {formatCategoryName(cat.name)}
+                      </span>
+                    {/each}
+                  </div>
+                {/if}
+
+                <!-- Key entities -->
+                {#if getTopEntities(article.article_entities).length > 0}
+                  <div class="flex items-center flex-wrap gap-1 mb-3">
+                    <span class="text-xs text-gray-400 mr-1">Entities:</span>
+                    {#each getTopEntities(article.article_entities) as ae}
+                      {#if ae.entity.wikipedia_url}
+                        <a
+                          href={ae.entity.wikipedia_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="entity-chip entity-chip-link"
+                          title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
+                        >
+                          {ae.entity.name}
+                          {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
+                        </a>
+                      {:else}
+                        <span
+                          class="entity-chip"
+                          title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
+                        >
+                          {ae.entity.name}
+                          {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
+                        </span>
+                      {/if}
+                    {/each}
+                  </div>
+                {/if}
+
+                <!-- Actions -->
+                <div class="flex items-center justify-between">
+                  <a
+                    href={article.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                  >
+                    Read Article →
+                  </a>
+
+                  {#if $userStore}
+                    <button
+                      on:click={() => handleBookmark(article)}
+                      class="text-gray-400 hover:text-gray-600"
+                      aria-label="Bookmark this article"
+                      title="Bookmark this article"
+                    >
+                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+                      </svg>
+                    </button>
+                  {/if}
+                </div>
               </div>
             </div>
           {/each}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -100,7 +100,151 @@ body {
 
 .text-center { text-align: center; }
 
+.gap-1 { gap: 0.25rem; }
+.gap-2 { gap: 0.5rem; }
 .gap-6 { gap: 1.5rem; }
+.flex-wrap { flex-wrap: wrap; }
+.mr-1 { margin-right: 0.25rem; }
+.mt-1 { margin-top: 0.25rem; }
+.bg-green-100 { background-color: #dcfce7; }
+.bg-gray-100 { background-color: #f3f4f6; }
+
+/* --- Sentiment bar --- */
+.sentiment-section {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 0.75rem;
+}
+
+.sentiment-bar-track {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background-color: #e5e7eb;
+  border-radius: 3px;
+  overflow: visible;
+}
+
+.sentiment-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+  min-width: 2px;
+}
+
+.sentiment-bar-midpoint {
+  position: absolute;
+  top: -2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 10px;
+  background-color: #9ca3af;
+  border-radius: 1px;
+}
+
+.sentiment-explanation {
+  font-style: italic;
+}
+
+/* --- Category chips --- */
+.category-chip {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.5;
+  border: 1px solid #e5e7eb;
+  padding: 0 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  background-color: #f3f4f6;
+  color: #4b5563;
+}
+
+/* --- Entity chips --- */
+.entity-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  line-height: 1.5;
+  padding: 0 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  background-color: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+}
+
+.entity-chip-link {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.entity-chip-link:hover {
+  background-color: #dbeafe;
+  border-color: #93c5fd;
+}
+
+.entity-type {
+  font-weight: 400;
+  opacity: 0.6;
+  font-size: 0.65rem;
+}
+
+/* --- Article card image --- */
+.card-image-wrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0.5rem 0.5rem 0 0;
+  background: linear-gradient(135deg, #e5e7eb 0%, #d1d5db 50%, #e5e7eb 100%);
+  flex-shrink: 0;
+}
+
+.card-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-image-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 50%, #d1d5db 100%);
+}
+
+.card-image-placeholder-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: #9ca3af;
+  opacity: 0.5;
+}
+
+.card-body {
+  padding: 1.5rem;
+}
+
+/* --- Source favicon --- */
+.source-favicon {
+  width: 20px;
+  height: 20px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.source-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.overflow-hidden { overflow: hidden; }
 
 .animate-spin {
   animation: spin 1s linear infinite;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,33 @@ const API_BASE = (() => {
   return DEFAULT_PROD_API_BASE;
 })();
 
+// ---------------------------------------------------------------------------
+// Article types (mirrors backend ArticleRead / entity schemas)
+// ---------------------------------------------------------------------------
+
+export type EntityDto = {
+  id: number;
+  name: string;
+  type: string;
+  wikipedia_url: string | null;
+  mid: string | null;
+};
+
+export type ArticleEntityDto = {
+  id: number;
+  entity: EntityDto;
+  salience: number;
+  mention_count: number;
+  analyzed_at: string;
+};
+
+export type ArticleCategoryDto = {
+  id: number;
+  name: string;
+  confidence: number;
+  analyzed_at: string;
+};
+
 export type ArticleDto = {
   id: number;
   title: string;
@@ -33,6 +60,8 @@ export type ArticleDto = {
   language?: string | null;
   country?: string | null;
   category?: string | null;
+  article_entities?: ArticleEntityDto[] | null;
+  article_categories?: ArticleCategoryDto[] | null;
 };
 
 export async function fetchLatestArticles(limit = 40): Promise<ArticleDto[]> {


### PR DESCRIPTION
## Summary

- **Sentiment section**: Colored badge (POSITIVE/NEGATIVE/NEUTRAL), visual progress bar mapping -1.0 to +1.0, and human-readable explanation (e.g., *"Overall tone is moderately positive"*)
- **Entity chips**: Top 3 by salience as blue chips with abbreviated type; Wikipedia-linked entities are clickable. Hover tooltip shows full type, relevance %, and mention count
- **Category chips**: Top 2 by confidence as gray chips showing leaf name from taxonomy path. Hover tooltip shows full path and confidence %
- **Article images**: Featured image at card top (16:9 aspect ratio) with gradient placeholder for missing/broken images. Uses `referrerpolicy="no-referrer"` to bypass hotlink restrictions
- **Source favicons**: 20x20 icon from Google Favicon API next to source name badge, derived from article domain at render time (zero backend changes)
- **TypeScript types**: Added `EntityDto`, `ArticleEntityDto`, `ArticleCategoryDto` to match backend `ArticleRead` schema

All sections conditionally render — cards degrade gracefully when data is missing.

## Test plan

- [ ] Verify cards with full data show image, favicon, sentiment bar, categories, and entities
- [ ] Verify cards without `image_url` show gradient placeholder (consistent card height)
- [ ] Verify broken image URLs fall back to placeholder gracefully
- [ ] Verify source favicons render next to source name; hidden on error
- [ ] Verify sentiment bar: negative = short/red, neutral = half/blue, positive = long/green
- [ ] Verify entity chips with Wikipedia URLs open in new tab
- [ ] Verify hover tooltips on score, category chips, and entity chips
- [ ] Verify 3-column grid layout and mobile responsiveness
- [ ] Run `npm run build` — no compilation errors