### PR TITLE
fix(ingestion): mount Mediastack API key on Cloud Run and stop silent mock fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,9 @@ jobs:
         image: ${{ env.AR_REGISTRY }}/${{ env.SERVICE }}:${{ github.sha }}
         env_vars: |
           BIGQUERY_ENABLE_BIGQUERY=true
+          ENV=production
+        secrets: |
+          MEDIASTACK_API_KEY=mediastack-api-key:latest
         flags: |
           --allow-unauthenticated
           --service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com

--- a/app/jobs/fetch_from_mediastack.py
+++ b/app/jobs/fetch_from_mediastack.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import date
 
 import requests
@@ -7,10 +8,38 @@ from app.config import settings
 from app.jobs.mock_mediastack import fetch_mock_articles_from_source
 from app.jobs.sources_list import SOURCES
 
+logger = logging.getLogger(__name__)
+
+
+def _is_production() -> bool:
+    return os.getenv("ENV", "local") in ("production", "prod")
+
+
+class MediastackAPIError(Exception):
+    """Raised when Mediastack returns an inline error in an HTTP 200 response."""
+
+    def __init__(self, code: int, error_type: str, message: str):
+        self.code = code
+        self.error_type = error_type
+        super().__init__(f"Mediastack error {code} ({error_type}): {message}")
+
 
 def fetch_articles_from_source(source: str) -> list[dict]:
+    api_key = settings.MEDIASTACK_API_KEY
+
+    if not api_key:
+        if _is_production():
+            logger.error(
+                "MEDIASTACK_API_KEY is empty — skipping %s. "
+                "Check Secret Manager and Cloud Run env vars.",
+                source,
+            )
+            return []
+        logger.info("MEDIASTACK_API_KEY not set — using mock data for %s", source)
+        return fetch_mock_articles_from_source(source)
+
     base_params = {
-        "access_key": settings.MEDIASTACK_API_KEY,
+        "access_key": api_key,
         "sources": source,
         "languages": settings.MEDIASTACK_LANGUAGES,
         "sort": settings.MEDIASTACK_SORT,
@@ -26,25 +55,85 @@ def fetch_articles_from_source(source: str) -> list[dict]:
             timeout=settings.MEDIASTACK_TIMEOUT,
         )
         resp.raise_for_status()
-        data = resp.json().get("data", [])
-        logging.info("→ %d from %s", len(data), source)
-        # annotate for later
+
+        body = resp.json()
+
+        # Mediastack returns HTTP 200 with inline error JSON for bad keys, etc.
+        if "error" in body:
+            err = body["error"]
+            raise MediastackAPIError(
+                code=err.get("code", 0),
+                error_type=err.get("type", "unknown"),
+                message=err.get("info", "No details"),
+            )
+
+        data = body.get("data", [])
+        logger.info("-> %d from %s", len(data), source)
+        if data:
+            sample = data[0]
+            logger.debug(
+                "   sample: published=%s url=%s",
+                sample.get("published_at", "?"),
+                (sample.get("url") or "?")[:120],
+            )
+
         for art in data:
             art["source_name"] = source
         return data  # type: ignore[no-any-return]
+
+    except MediastackAPIError as e:
+        logger.error("Mediastack API error for %s: %s", source, e)
+        return []
+
     except (requests.RequestException, requests.HTTPError) as e:
-        logging.warning("✖ Mediastack API error for %s: %s", source, e)
-        logging.info("→ Falling back to mock data for %s", source)
+        if _is_production():
+            logger.error("Mediastack request failed for %s: %s", source, e)
+            return []
+        logger.warning(
+            "Mediastack request failed for %s: %s — using mock data", source, e
+        )
         return fetch_mock_articles_from_source(source)
 
 
 def fetch_all_sources() -> list[dict]:
-    all_articles = []
+    api_key = settings.MEDIASTACK_API_KEY
+    logger.info(
+        "Starting fetch for %d sources [env=%s, api_key=%s]",
+        len(SOURCES),
+        "production" if _is_production() else "development",
+        "SET" if api_key else "EMPTY",
+    )
+
+    all_articles: list[dict] = []
+    real_count = 0
+    mock_count = 0
+
     for src in SOURCES:
-        logging.info("🔎 Fetching from %s…", src)
         try:
-            all_articles.extend(fetch_articles_from_source(src))
+            articles = fetch_articles_from_source(src)
+            all_articles.extend(articles)
+
+            if articles and "example.com" in articles[0].get("url", ""):
+                mock_count += 1
+            elif articles:
+                real_count += 1
         except Exception as e:
-            logging.error("✖ %s: %s", src, e)
-    logging.info("✅ Fetched %d raw articles", len(all_articles))
+            logger.error("Unexpected error fetching %s: %s", src, e)
+
+    empty_count = len(SOURCES) - real_count - mock_count
+    logger.info(
+        "Fetched %d raw articles from %d sources (%d real, %d mock, %d empty)",
+        len(all_articles),
+        len(SOURCES),
+        real_count,
+        mock_count,
+        empty_count,
+    )
+
+    if mock_count > 0 and _is_production():
+        logger.warning(
+            "%d sources returned mock data in production — this should not happen",
+            mock_count,
+        )
+
     return all_articles

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,15 @@ from app.utils.logging import setup_logging
 setup_logging()
 logger = logging.getLogger(__name__)
 
+# Log config status at startup for early detection of misconfiguration
+from app.config import config as _app_config  # noqa: E402
+
+logger.info(
+    "aiFeelNews starting [env=%s, mediastack_key=%s]",
+    os.getenv("ENV", "local"),
+    "SET" if _app_config.ingestion.mediastack_api_key else "EMPTY",
+)
+
 # Import sentiment router with error handling
 sentiment_available = False
 sentiment: Any = None

--- a/app/utils/secrets.py
+++ b/app/utils/secrets.py
@@ -130,8 +130,8 @@ def get_secret_or_env(
         secret_value = client.get_secret(secret_name)
         if secret_value:
             return secret_value
-    except Exception:
-        pass  # Fall back to environment variable
+    except Exception as e:
+        logger.debug("Secret Manager lookup for '%s' failed: %s", secret_name, e)
 
     # Fallback to environment variable (development)
     env_value = os.getenv(env_var)

--- a/docs/CICD_PIPELINE.md
+++ b/docs/CICD_PIPELINE.md
@@ -67,6 +67,8 @@ flowchart TB
 | **Registry** | Artifact Registry (`europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/`) |
 | **Deploy target** | Cloud Run `aifeelnews-web` in `europe-west1` |
 | **Deploy config** | 512Mi, 1 vCPU, min-instances=0, max=10, concurrency=80, timeout=300s |
+| **Env vars** | `BIGQUERY_ENABLE_BIGQUERY=true`, `ENV=production` |
+| **Secrets** | `MEDIASTACK_API_KEY` mounted from Secret Manager (`mediastack-api-key:latest`) |
 | **Service account** | `cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com` (least-privilege) |
 | **Health check** | `curl /health` after deployment |
 | **Deploy gate** | Only on push to main (PRs run tests only) |
@@ -113,6 +115,7 @@ test (lint + type-check + unit tests)
 | Secret | Used By | Purpose |
 |--------|---------|---------|
 | `GCP_SA_KEY` | `deploy.yml` | Google Cloud authentication for Artifact Registry + Cloud Run |
+| `mediastack-api-key` (GCP Secret Manager) | `deploy.yml` | Mounted as `MEDIASTACK_API_KEY` env var on Cloud Run at deploy time |
 | `VITE_FIREBASE_API_KEY` | Frontend workflows | Firebase client config (injected at build time) |
 | `VITE_FIREBASE_AUTH_DOMAIN` | Frontend workflows | Firebase auth domain |
 | `VITE_FIREBASE_PROJECT_ID` | Frontend workflows | Firebase project identifier |


### PR DESCRIPTION
## Summary

- Pipeline was silently falling back to **mock data** for all 22 sources because `MEDIASTACK_API_KEY` was never passed to Cloud Run
- This produced exactly **88 static articles** (22 sources x 4 mock articles), all ingested on Feb 20th and seen as duplicates on every run since
- `ENV` was also never set, so Cloud Run ran with plain text logging instead of JSON — making errors invisible in Cloud Logging

## Changes

- **deploy.yml**: Mount `mediastack-api-key` Secret Manager secret as Cloud Run env var + set `ENV=production`
- **fetch_from_mediastack.py**: Gate mock fallback to dev only, detect Mediastack inline API errors (HTTP 200 with error body), log real/mock/empty source counts
- **secrets.py**: Replace silent `except: pass` with debug logging
- **main.py**: Log config status at startup (`mediastack_key=SET/EMPTY`)
- **docs/CICD_PIPELINE.md**: Document new env vars and secrets in deploy config

## Test plan

- [ ] Verify `mediastack-api-key` secret version exists in GCP Secret Manager
- [ ] Merge and let deploy workflow run
- [ ] Check Cloud Run logs for `aiFeelNews starting [env=production, mediastack_key=SET]`
- [ ] Trigger ingestion and verify `Fetched X raw articles from Y sources (Y real, 0 mock, Z empty)`
- [ ] Confirm new articles appear on frontend