### PR TITLE
feat(db): SQLAlchemy 2.0 migration, N+1 fix, views/functions/triggers, advanced SQL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
         cache: 'pip'
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Google Auth
       id: auth

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npm ci
         working-directory: frontend
       - run: npm run build

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npm ci
         working-directory: frontend
       - run: npm run build

--- a/alembic/versions/e1f2a3b4c5d6_add_db_objects_views_functions_triggers.py
+++ b/alembic/versions/e1f2a3b4c5d6_add_db_objects_views_functions_triggers.py
@@ -1,0 +1,237 @@
+"""add bookmark indexes, views, stored functions, and triggers
+
+Revision ID: e1f2a3b4c5d6
+Revises: d8e9f0a1b2c3
+Create Date: 2026-03-16 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d8e9f0a1b2c3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── B.1: Bookmark FK indexes (fixes full-table scans) ──────────────
+    op.create_index("ix_bookmarks_user_id", "bookmarks", ["user_id"])
+    op.create_index("ix_bookmarks_article_id", "bookmarks", ["article_id"])
+
+    # ── B.3: PostgreSQL Views ──────────────────────────────────────────
+    # View 1: Article summary with source name and sentiment
+    op.execute("""
+        CREATE OR REPLACE VIEW v_article_summary AS
+        SELECT
+            a.id            AS article_id,
+            a.title,
+            s.name          AS source_name,
+            a.published_at,
+            a.sentiment_label,
+            a.sentiment_score,
+            a.category,
+            a.country,
+            a.language
+        FROM articles a
+        JOIN sources s ON s.id = a.source_id
+        ORDER BY a.published_at DESC;
+    """)
+
+    # View 2: Source statistics (article count, avg sentiment, date range)
+    op.execute("""
+        CREATE OR REPLACE VIEW v_source_stats AS
+        SELECT
+            s.id                           AS source_id,
+            s.name                         AS source_name,
+            COUNT(a.id)                    AS article_count,
+            ROUND(AVG(a.sentiment_score)::numeric, 4) AS avg_sentiment,
+            MIN(a.published_at)            AS earliest_article,
+            MAX(a.published_at)            AS latest_article
+        FROM sources s
+        LEFT JOIN articles a ON a.source_id = s.id
+        GROUP BY s.id, s.name;
+    """)
+
+    # View 3: Daily sentiment aggregation
+    op.execute("""
+        CREATE OR REPLACE VIEW v_daily_sentiment AS
+        SELECT
+            DATE(a.published_at)          AS day,
+            COUNT(*)                      AS article_count,
+            ROUND(AVG(a.sentiment_score)::numeric, 4) AS avg_sentiment,
+            COUNT(*) FILTER (WHERE a.sentiment_label = 'positive')  AS positive_count,
+            COUNT(*) FILTER (WHERE a.sentiment_label = 'negative')  AS negative_count,
+            COUNT(*) FILTER (WHERE a.sentiment_label = 'neutral')   AS neutral_count
+        FROM articles a
+        WHERE a.sentiment_score IS NOT NULL
+        GROUP BY DATE(a.published_at)
+        ORDER BY day DESC;
+    """)
+
+    # View 4: Trending entities (top entities by recent article mentions)
+    op.execute("""
+        CREATE OR REPLACE VIEW v_trending_entities AS
+        SELECT
+            e.id                            AS entity_id,
+            e.name                          AS entity_name,
+            e.type                          AS entity_type,
+            COUNT(ae.article_id)            AS article_count,
+            SUM(ae.mention_count)           AS total_mentions,
+            ROUND(AVG(ae.salience)::numeric, 4) AS avg_salience
+        FROM entities e
+        JOIN article_entities ae ON ae.entity_id = e.id
+        JOIN articles a ON a.id = ae.article_id
+        WHERE a.published_at >= NOW() - INTERVAL '7 days'
+        GROUP BY e.id, e.name, e.type
+        ORDER BY article_count DESC, avg_salience DESC;
+    """)
+
+    # ── B.4: Stored Functions (PL/pgSQL) ───────────────────────────────
+    # Function 1: Sentiment distribution for a given date range
+    op.execute("""
+        CREATE OR REPLACE FUNCTION fn_sentiment_distribution(
+            p_days INTEGER DEFAULT 30
+        )
+        RETURNS TABLE (
+            sentiment_label VARCHAR,
+            article_count   BIGINT,
+            percentage      NUMERIC
+        )
+        LANGUAGE plpgsql
+        AS $$
+        DECLARE
+            v_total BIGINT;
+        BEGIN
+            SELECT COUNT(*) INTO v_total
+            FROM articles
+            WHERE sentiment_label IS NOT NULL
+              AND published_at >= NOW() - (p_days || ' days')::INTERVAL;
+
+            RETURN QUERY
+            SELECT
+                a.sentiment_label,
+                COUNT(*)            AS article_count,
+                ROUND(
+                    COUNT(*)::NUMERIC / GREATEST(v_total, 1) * 100, 2
+                )                   AS percentage
+            FROM articles a
+            WHERE a.sentiment_label IS NOT NULL
+              AND a.published_at >= NOW() - (p_days || ' days')::INTERVAL
+            GROUP BY a.sentiment_label
+            ORDER BY article_count DESC;
+        END;
+        $$;
+    """)
+
+    # Function 2: Source performance (articles, sentiment, entity richness)
+    op.execute("""
+        CREATE OR REPLACE FUNCTION fn_source_performance(
+            p_days INTEGER DEFAULT 30
+        )
+        RETURNS TABLE (
+            source_name      VARCHAR,
+            article_count    BIGINT,
+            avg_sentiment    NUMERIC,
+            entity_richness  NUMERIC,
+            crawl_success_rate NUMERIC
+        )
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            RETURN QUERY
+            SELECT
+                s.name                          AS source_name,
+                COUNT(DISTINCT a.id)            AS article_count,
+                ROUND(AVG(a.sentiment_score)::NUMERIC, 4) AS avg_sentiment,
+                ROUND(
+                    AVG(sub_ent.entity_count)::NUMERIC, 2
+                )                               AS entity_richness,
+                ROUND(
+                    COUNT(DISTINCT cj.id) FILTER (WHERE cj.status = 'SUCCESS')::NUMERIC
+                    / GREATEST(COUNT(DISTINCT cj.id), 1) * 100, 2
+                )                               AS crawl_success_rate
+            FROM sources s
+            JOIN articles a ON a.source_id = s.id
+            LEFT JOIN crawl_jobs cj ON cj.article_id = a.id
+            LEFT JOIN LATERAL (
+                SELECT COUNT(*) AS entity_count
+                FROM article_entities ae
+                WHERE ae.article_id = a.id
+            ) sub_ent ON TRUE
+            WHERE a.published_at >= NOW() - (p_days || ' days')::INTERVAL
+            GROUP BY s.name
+            ORDER BY article_count DESC;
+        END;
+        $$;
+    """)
+
+    # ── B.5: Triggers ──────────────────────────────────────────────────
+    # Trigger 1: Auto-update source.updated_at when a new article is inserted
+    op.execute("""
+        CREATE OR REPLACE FUNCTION trg_fn_update_source_timestamp()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            UPDATE sources SET updated_at = NOW() WHERE id = NEW.source_id;
+            RETURN NEW;
+        END;
+        $$;
+    """)
+    op.execute("""
+        CREATE TRIGGER trg_update_source_timestamp
+        AFTER INSERT ON articles
+        FOR EACH ROW
+        EXECUTE FUNCTION trg_fn_update_source_timestamp();
+    """)
+
+    # Trigger 2: Prevent duplicate bookmarks (same user + article)
+    op.execute("""
+        CREATE OR REPLACE FUNCTION trg_fn_prevent_duplicate_bookmark()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM bookmarks
+                WHERE user_id = NEW.user_id AND article_id = NEW.article_id
+            ) THEN
+                RAISE EXCEPTION 'Duplicate bookmark: user_id=% already bookmarked article_id=%',
+                    NEW.user_id, NEW.article_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+    """)
+    op.execute("""
+        CREATE TRIGGER trg_prevent_duplicate_bookmark
+        BEFORE INSERT ON bookmarks
+        FOR EACH ROW
+        EXECUTE FUNCTION trg_fn_prevent_duplicate_bookmark();
+    """)
+
+
+def downgrade() -> None:
+    # Triggers
+    op.execute("DROP TRIGGER IF EXISTS trg_prevent_duplicate_bookmark ON bookmarks;")
+    op.execute("DROP FUNCTION IF EXISTS trg_fn_prevent_duplicate_bookmark();")
+    op.execute("DROP TRIGGER IF EXISTS trg_update_source_timestamp ON articles;")
+    op.execute("DROP FUNCTION IF EXISTS trg_fn_update_source_timestamp();")
+
+    # Stored functions
+    op.execute("DROP FUNCTION IF EXISTS fn_source_performance(INTEGER);")
+    op.execute("DROP FUNCTION IF EXISTS fn_sentiment_distribution(INTEGER);")
+
+    # Views
+    op.execute("DROP VIEW IF EXISTS v_trending_entities;")
+    op.execute("DROP VIEW IF EXISTS v_daily_sentiment;")
+    op.execute("DROP VIEW IF EXISTS v_source_stats;")
+    op.execute("DROP VIEW IF EXISTS v_article_summary;")
+
+    # Bookmark indexes
+    op.drop_index("ix_bookmarks_article_id", "bookmarks")
+    op.drop_index("ix_bookmarks_user_id", "bookmarks")

--- a/app/crud/analytics.py
+++ b/app/crud/analytics.py
@@ -1,0 +1,218 @@
+"""PostgreSQL-based analytics queries using advanced SQL patterns.
+
+Demonstrates window functions, CTEs, and GROUPING SETS for the
+Relational Databases module. These complement the BigQuery analytics
+by providing real-time queries against the operational database.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def sentiment_rolling_average(
+    db: Session, *, days: int = 30, window: int = 7
+) -> list[dict[str, Any]]:
+    """7-day rolling average sentiment using a window function.
+
+    Uses AVG() OVER (ORDER BY ... ROWS BETWEEN) to smooth daily
+    sentiment fluctuations, revealing underlying trends.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    result = db.execute(
+        text("""
+            WITH daily AS (
+                SELECT
+                    DATE(published_at) AS day,
+                    COUNT(*)           AS article_count,
+                    AVG(sentiment_score) AS avg_sentiment
+                FROM articles
+                WHERE sentiment_score IS NOT NULL
+                  AND published_at >= :cutoff
+                GROUP BY DATE(published_at)
+            )
+            SELECT
+                day,
+                article_count,
+                ROUND(avg_sentiment::numeric, 4) AS avg_sentiment,
+                ROUND(
+                    AVG(avg_sentiment) OVER (
+                        ORDER BY day
+                        ROWS BETWEEN :window_size PRECEDING AND CURRENT ROW
+                    )::numeric, 4
+                ) AS rolling_avg
+            FROM daily
+            ORDER BY day
+        """),
+        {"cutoff": cutoff, "window_size": window - 1},
+    )
+    return [dict(row._mapping) for row in result]
+
+
+def source_sentiment_ranked(db: Session, *, days: int = 30) -> list[dict[str, Any]]:
+    """Rank sources by average sentiment using RANK() window function.
+
+    Uses a CTE to compute per-source stats, then RANK() OVER to
+    assign a rank by avg sentiment (highest = most positive source).
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    result = db.execute(
+        text("""
+            WITH source_stats AS (
+                SELECT
+                    s.name          AS source_name,
+                    COUNT(a.id)     AS article_count,
+                    AVG(a.sentiment_score) AS avg_sentiment,
+                    STDDEV(a.sentiment_score) AS sentiment_stddev
+                FROM sources s
+                JOIN articles a ON a.source_id = s.id
+                WHERE a.sentiment_score IS NOT NULL
+                  AND a.published_at >= :cutoff
+                GROUP BY s.name
+                HAVING COUNT(a.id) >= 3
+            )
+            SELECT
+                source_name,
+                article_count,
+                ROUND(avg_sentiment::numeric, 4) AS avg_sentiment,
+                ROUND(sentiment_stddev::numeric, 4) AS sentiment_stddev,
+                RANK() OVER (ORDER BY avg_sentiment DESC) AS positivity_rank
+            FROM source_stats
+            ORDER BY positivity_rank
+        """),
+        {"cutoff": cutoff},
+    )
+    return [dict(row._mapping) for row in result]
+
+
+def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, Any]]:
+    """Multi-dimensional sentiment breakdown using GROUPING SETS.
+
+    Returns article counts and avg sentiment grouped by:
+    - (category, sentiment_label) — per-category per-label
+    - (category) — subtotal per category
+    - (sentiment_label) — subtotal per label
+    - () — grand total
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    result = db.execute(
+        text("""
+            SELECT
+                COALESCE(category, '(all)')         AS category,
+                COALESCE(sentiment_label, '(all)')  AS sentiment_label,
+                COUNT(*)                             AS article_count,
+                ROUND(AVG(sentiment_score)::numeric, 4) AS avg_sentiment,
+                GROUPING(category)                   AS is_category_total,
+                GROUPING(sentiment_label)            AS is_label_total
+            FROM articles
+            WHERE sentiment_score IS NOT NULL
+              AND published_at >= :cutoff
+            GROUP BY GROUPING SETS (
+                (category, sentiment_label),
+                (category),
+                (sentiment_label),
+                ()
+            )
+            ORDER BY is_category_total, is_label_total, category, sentiment_label
+        """),
+        {"cutoff": cutoff},
+    )
+    return [dict(row._mapping) for row in result]
+
+
+def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
+    """Entity momentum: compare mention frequency this week vs last week.
+
+    Uses two CTEs partitioned by week, then computes growth rate.
+    Surfaces entities that are trending up or down.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    midpoint = datetime.now(timezone.utc) - timedelta(days=days // 2)
+    result = db.execute(
+        text("""
+            WITH recent AS (
+                SELECT
+                    e.name          AS entity_name,
+                    e.type          AS entity_type,
+                    COUNT(ae.id)    AS mention_count
+                FROM entities e
+                JOIN article_entities ae ON ae.entity_id = e.id
+                JOIN articles a ON a.id = ae.article_id
+                WHERE a.published_at >= :midpoint
+                GROUP BY e.name, e.type
+            ),
+            previous AS (
+                SELECT
+                    e.name          AS entity_name,
+                    e.type          AS entity_type,
+                    COUNT(ae.id)    AS mention_count
+                FROM entities e
+                JOIN article_entities ae ON ae.entity_id = e.id
+                JOIN articles a ON a.id = ae.article_id
+                WHERE a.published_at >= :cutoff
+                  AND a.published_at < :midpoint
+                GROUP BY e.name, e.type
+            )
+            SELECT
+                COALESCE(r.entity_name, p.entity_name) AS entity_name,
+                COALESCE(r.entity_type, p.entity_type) AS entity_type,
+                COALESCE(r.mention_count, 0)            AS recent_mentions,
+                COALESCE(p.mention_count, 0)            AS previous_mentions,
+                ROUND(
+                    CASE
+                        WHEN COALESCE(p.mention_count, 0) = 0 THEN 100.0
+                        ELSE (
+                            (COALESCE(r.mention_count, 0) - p.mention_count)::numeric
+                            / p.mention_count * 100
+                        )
+                    END, 2
+                ) AS growth_pct
+            FROM recent r
+            FULL OUTER JOIN previous p
+                ON r.entity_name = p.entity_name AND r.entity_type = p.entity_type
+            WHERE COALESCE(r.mention_count, 0) + COALESCE(p.mention_count, 0) >= 3
+            ORDER BY growth_pct DESC
+        """),
+        {"cutoff": cutoff, "midpoint": midpoint},
+    )
+    return [dict(row._mapping) for row in result]
+
+
+def daily_category_sentiment_pivot(
+    db: Session, *, days: int = 14
+) -> list[dict[str, Any]]:
+    """Daily sentiment per category using window functions for running totals.
+
+    Uses a CTE for daily aggregation, then adds cumulative article count
+    per category via SUM() OVER (PARTITION BY ... ORDER BY).
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    result = db.execute(
+        text("""
+            WITH daily_cat AS (
+                SELECT
+                    DATE(published_at)       AS day,
+                    COALESCE(category, 'uncategorized') AS category,
+                    COUNT(*)                 AS article_count,
+                    AVG(sentiment_score)     AS avg_sentiment
+                FROM articles
+                WHERE sentiment_score IS NOT NULL
+                  AND published_at >= :cutoff
+                GROUP BY DATE(published_at), category
+            )
+            SELECT
+                day,
+                category,
+                article_count,
+                ROUND(avg_sentiment::numeric, 4) AS avg_sentiment,
+                SUM(article_count) OVER (
+                    PARTITION BY category ORDER BY day
+                ) AS cumulative_articles
+            FROM daily_cat
+            ORDER BY day, category
+        """),
+        {"cutoff": cutoff},
+    )
+    return [dict(row._mapping) for row in result]

--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,7 @@
 from typing import Generator
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, declarative_base, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from app.config import settings
 
@@ -14,7 +14,11 @@ SessionLocal = sessionmaker(
     bind=engine,
 )
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    """SQLAlchemy 2.0 declarative base using Mapped[] annotation style."""
+
+    pass
 
 
 def get_db() -> Generator[Session, None, None]:

--- a/app/main.py
+++ b/app/main.py
@@ -94,6 +94,19 @@ if entities_available and entities_mod:
 if analytics_available and analytics_mod:
     app.include_router(analytics_mod.router, prefix="/api/v1/analytics")
 
+# Register PostgreSQL analytics router (advanced SQL: window functions, CTEs, GROUPING SETS)
+db_analytics_available = False
+db_analytics_mod: Any = None
+try:
+    from app.routers import db_analytics as db_analytics_mod
+
+    db_analytics_available = True
+except Exception as e:
+    logger.warning(f"Could not import db_analytics router: {e}")
+
+if db_analytics_available and db_analytics_mod:
+    app.include_router(db_analytics_mod.router, prefix="/api/v1/db-analytics")
+
 
 @app.get("/")
 def root() -> dict[str, str]:
@@ -174,12 +187,12 @@ def metrics() -> dict[str, Any]:
         }
 
         sentiment_by_label = {
-            str(row.sentiment_label): row.count
+            str(row.label): row.count
             for row in db.execute(
                 select(
-                    SentimentAnalysis.sentiment_label,
+                    SentimentAnalysis.label,
                     func.count(SentimentAnalysis.id).label("count"),
-                ).group_by(SentimentAnalysis.sentiment_label)
+                ).group_by(SentimentAnalysis.label)
             )
         }
 

--- a/app/models/article.py
+++ b/app/models/article.py
@@ -1,62 +1,64 @@
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.source import Source  # noqa: F401
+
+if TYPE_CHECKING:
+    from app.models.article_category import ArticleCategory
+    from app.models.article_content import ArticleContent
+    from app.models.article_entity import ArticleEntity
+    from app.models.bookmark import Bookmark
+    from app.models.crawl_job import CrawlJob
+    from app.models.sentiment_analysis import SentimentAnalysis
+    from app.models.source import Source
 
 
 class Article(Base):
     __tablename__ = "articles"
 
-    id = Column(Integer, primary_key=True, index=True)
-    source_id = Column(
-        Integer, ForeignKey("sources.id", ondelete="CASCADE"), nullable=False
-    )
-    title = Column(String(255), nullable=False)
-    description = Column(String(1000), nullable=True)
-    url = Column(String(1000), unique=True, nullable=False)
-    image_url = Column(String(1000), nullable=True)
-    published_at = Column(DateTime(timezone=True), nullable=False, index=True)
-    language = Column(String(2), nullable=True)
-    country = Column(String(2), nullable=True)
-    category = Column(String(50), nullable=True)
-    sentiment_label = Column(String(20), nullable=True)
-    sentiment_score = Column(Float, nullable=True)
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    source_id: Mapped[int] = mapped_column(ForeignKey("sources.id", ondelete="CASCADE"))
+    title: Mapped[str] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(String(1000), default=None)
+    url: Mapped[str] = mapped_column(String(1000), unique=True)
+    image_url: Mapped[Optional[str]] = mapped_column(String(1000), default=None)
+    published_at: Mapped[datetime] = mapped_column(index=True)
+    language: Mapped[Optional[str]] = mapped_column(String(2), default=None)
+    country: Mapped[Optional[str]] = mapped_column(String(2), default=None)
+    category: Mapped[Optional[str]] = mapped_column(String(50), default=None)
+    sentiment_label: Mapped[Optional[str]] = mapped_column(String(20), default=None)
+    sentiment_score: Mapped[Optional[float]] = mapped_column(default=None)
 
-    source = relationship("Source", back_populates="articles")
-    bookmarks = relationship(
-        "Bookmark",
+    source: Mapped["Source"] = relationship(back_populates="articles")
+    bookmarks: Mapped[List["Bookmark"]] = relationship(
         back_populates="article",
         cascade="all, delete-orphan",
         lazy="select",
     )
-    crawl_jobs = relationship(
-        "CrawlJob",
+    crawl_jobs: Mapped[List["CrawlJob"]] = relationship(
         back_populates="article",
         cascade="all, delete-orphan",
         lazy="select",
     )
-    content = relationship(
-        "ArticleContent",
-        back_populates="article",
-        uselist=False,
-        cascade="all, delete-orphan",
-        lazy="select",
-    )
-    sentiment_analyses = relationship(
-        "SentimentAnalysis",
+    content: Mapped[Optional["ArticleContent"]] = relationship(
         back_populates="article",
         cascade="all, delete-orphan",
         lazy="select",
     )
-    article_entities = relationship(
-        "ArticleEntity",
+    sentiment_analyses: Mapped[List["SentimentAnalysis"]] = relationship(
         back_populates="article",
         cascade="all, delete-orphan",
         lazy="select",
     )
-    article_categories = relationship(
-        "ArticleCategory",
+    article_entities: Mapped[List["ArticleEntity"]] = relationship(
+        back_populates="article",
+        cascade="all, delete-orphan",
+        lazy="select",
+    )
+    article_categories: Mapped[List["ArticleCategory"]] = relationship(
         back_populates="article",
         cascade="all, delete-orphan",
         lazy="select",

--- a/app/models/article_category.py
+++ b/app/models/article_category.py
@@ -1,7 +1,13 @@
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String, func
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Index, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
 
 
 class ArticleCategory(Base):
@@ -14,17 +20,16 @@ class ArticleCategory(Base):
 
     __tablename__ = "article_categories"
 
-    id = Column(Integer, primary_key=True, index=True)
-    article_id = Column(
-        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE")
     )
-    name = Column(String(500), nullable=False)  # Taxonomy path: "/News/Business"
-    confidence = Column(Float, nullable=False)  # 0.0 to 1.0
-
-    analyzed_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+    name: Mapped[str] = mapped_column(String(500))  # Taxonomy path: "/News/Business"
+    confidence: Mapped[float] = mapped_column()  # 0.0 to 1.0
+    analyzed_at: Mapped[datetime] = mapped_column(default=func.now())
 
     # Relationships
-    article = relationship("Article", back_populates="article_categories")
+    article: Mapped["Article"] = relationship(back_populates="article_categories")
 
     __table_args__ = (
         Index("ix_article_categories_article_id", "article_id"),

--- a/app/models/article_content.py
+++ b/app/models/article_content.py
@@ -1,29 +1,32 @@
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text, func
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Index, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
 
 
 class ArticleContent(Base):
     __tablename__ = "article_contents"
 
-    id = Column(Integer, primary_key=True, index=True)
-    article_id = Column(
-        Integer,
-        ForeignKey("articles.id", ondelete="CASCADE"),
-        nullable=False,
-        unique=True,
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE"), unique=True
     )
-    content_text = Column(Text, nullable=False)  # TRUNCATED to max 1024 chars
-    content_hash = Column(String(64), nullable=False)  # SHA-256 hash
-    content_length = Column(
-        Integer, nullable=False
+    content_text: Mapped[str] = mapped_column(Text)  # TRUNCATED to max 1024 chars
+    content_hash: Mapped[str] = mapped_column(String(64))  # SHA-256 hash
+    content_length: Mapped[int] = (
+        mapped_column()
     )  # Original full length before truncation
-    extracted_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
-    expires_at = Column(DateTime(timezone=True), nullable=False)  # TTL cleanup
+    extracted_at: Mapped[datetime] = mapped_column(default=func.now())
+    expires_at: Mapped[datetime] = mapped_column()  # TTL cleanup
 
     # Relationships
-    article = relationship("Article", back_populates="content")
+    article: Mapped["Article"] = relationship(back_populates="content")
 
     __table_args__ = (
         Index("ix_article_contents_expires_at", "expires_at"),

--- a/app/models/article_entity.py
+++ b/app/models/article_entity.py
@@ -1,7 +1,14 @@
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, func
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Index, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
+    from app.models.entity import Entity
 
 
 class ArticleEntity(Base):
@@ -14,20 +21,20 @@ class ArticleEntity(Base):
 
     __tablename__ = "article_entities"
 
-    id = Column(Integer, primary_key=True, index=True)
-    article_id = Column(
-        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE")
     )
-    entity_id = Column(
-        Integer, ForeignKey("entities.id", ondelete="CASCADE"), nullable=False
+    entity_id: Mapped[int] = mapped_column(
+        ForeignKey("entities.id", ondelete="CASCADE")
     )
-    salience = Column(Float, nullable=False)  # 0.0 to 1.0 relevance score
-    mention_count = Column(Integer, nullable=False, default=1)  # Times entity appears
-    analyzed_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+    salience: Mapped[float] = mapped_column()  # 0.0 to 1.0 relevance score
+    mention_count: Mapped[int] = mapped_column(default=1)  # Times entity appears
+    analyzed_at: Mapped[datetime] = mapped_column(default=func.now())
 
     # Relationships
-    article = relationship("Article", back_populates="article_entities")
-    entity = relationship("Entity", back_populates="article_entities")
+    article: Mapped["Article"] = relationship(back_populates="article_entities")
+    entity: Mapped["Entity"] = relationship(back_populates="article_entities")
 
     __table_args__ = (
         Index("ix_article_entities_article_id", "article_id"),

--- a/app/models/bookmark.py
+++ b/app/models/bookmark.py
@@ -1,19 +1,28 @@
-from sqlalchemy import Column, ForeignKey, Integer
-from sqlalchemy.orm import relationship
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
+    from app.models.user import User
 
 
 class Bookmark(Base):
     __tablename__ = "bookmarks"
 
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
-    article_id = Column(
-        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE")
     )
 
-    user = relationship("User", back_populates="bookmarks")
-    article = relationship("Article", back_populates="bookmarks")
+    user: Mapped["User"] = relationship(back_populates="bookmarks")
+    article: Mapped["Article"] = relationship(back_populates="bookmarks")
+
+    __table_args__ = (
+        Index("ix_bookmarks_user_id", "user_id"),
+        Index("ix_bookmarks_article_id", "article_id"),
+    )

--- a/app/models/crawl_job.py
+++ b/app/models/crawl_job.py
@@ -1,20 +1,14 @@
 import enum
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    Enum,
-    ForeignKey,
-    Index,
-    Integer,
-    String,
-    Text,
-    func,
-)
-from sqlalchemy.orm import relationship
+from sqlalchemy import Enum, ForeignKey, Index, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
 
 
 class CrawlStatus(enum.Enum):
@@ -29,26 +23,26 @@ class CrawlStatus(enum.Enum):
 class CrawlJob(Base):
     __tablename__ = "crawl_jobs"
 
-    id = Column(Integer, primary_key=True, index=True)
-    article_id = Column(
-        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE")
     )
-    status: CrawlStatus = Column(
-        Enum(CrawlStatus), nullable=False, default=CrawlStatus.PENDING
-    )  # type: ignore[assignment]
-    robots_allowed = Column(Boolean, nullable=True)
-    http_status = Column(Integer, nullable=True)
-    fetched_at = Column(DateTime(timezone=True), nullable=True)
-    bytes_downloaded = Column(Integer, nullable=True)
-    error_code = Column(String(50), nullable=True)
-    error_message = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
-    updated_at = Column(
-        DateTime(timezone=True), nullable=False, default=func.now(), onupdate=func.now()
+    status: Mapped[CrawlStatus] = mapped_column(
+        Enum(CrawlStatus), default=CrawlStatus.PENDING
+    )
+    robots_allowed: Mapped[Optional[bool]] = mapped_column(default=None)
+    http_status: Mapped[Optional[int]] = mapped_column(default=None)
+    fetched_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+    bytes_downloaded: Mapped[Optional[int]] = mapped_column(default=None)
+    error_code: Mapped[Optional[str]] = mapped_column(String(50), default=None)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, default=None)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        default=func.now(), onupdate=func.now()
     )
 
     # Relationships
-    article = relationship("Article", back_populates="crawl_jobs")
+    article: Mapped["Article"] = relationship(back_populates="crawl_jobs")
 
     __table_args__ = (
         Index("ix_crawl_jobs_status", "status"),

--- a/app/models/entity.py
+++ b/app/models/entity.py
@@ -1,7 +1,13 @@
-from sqlalchemy import Column, DateTime, Index, Integer, String, func
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import Index, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article_entity import ArticleEntity
 
 
 class Entity(Base):
@@ -15,17 +21,15 @@ class Entity(Base):
 
     __tablename__ = "entities"
 
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(255), nullable=False)
-    type = Column(String(50), nullable=False)
-    wikipedia_url = Column(String(1000), nullable=True)
-    mid = Column(String(100), nullable=True)
-
-    created_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255))
+    type: Mapped[str] = mapped_column(String(50))
+    wikipedia_url: Mapped[Optional[str]] = mapped_column(String(1000), default=None)
+    mid: Mapped[Optional[str]] = mapped_column(String(100), default=None)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
 
     # M2M relationship via association table
-    article_entities = relationship(
-        "ArticleEntity",
+    article_entities: Mapped[List["ArticleEntity"]] = relationship(
         back_populates="entity",
         cascade="all, delete-orphan",
         lazy="select",

--- a/app/models/sentiment_analysis.py
+++ b/app/models/sentiment_analysis.py
@@ -1,36 +1,37 @@
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String, func
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import ForeignKey, Index, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
 
 
 class SentimentAnalysis(Base):
     __tablename__ = "sentiment_analyses"
 
-    id = Column(Integer, primary_key=True, index=True)
-    article_id = Column(
-        Integer, ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE")
     )
-    provider = Column(
-        String(50), nullable=False
-    )  # e.g., 'VADER', 'GCP_NL', 'AZURE_TEXT'
-    model_name = Column(
-        String(100), nullable=True
-    )  # e.g., 'vader_lexicon', 'gcp_nl_v1'
-    score = Column(Float, nullable=False)  # Sentiment score (-1.0 to 1.0)
-    magnitude = Column(Float, nullable=True)  # GCP NL magnitude (0.0 to infinity)
-    label = Column(String(20), nullable=False)  # 'positive', 'negative', 'neutral'
-    language = Column(String(10), nullable=True)  # Detected language code
-    analyzed_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+    provider: Mapped[str] = mapped_column(String(50))  # e.g., 'VADER', 'GCP_NL'
+    model_name: Mapped[Optional[str]] = mapped_column(String(100), default=None)
+    score: Mapped[float] = mapped_column()  # Sentiment score (-1.0 to 1.0)
+    magnitude: Mapped[Optional[float]] = mapped_column(default=None)  # GCP NL magnitude
+    label: Mapped[str] = mapped_column(String(20))  # 'positive', 'negative', 'neutral'
+    language: Mapped[Optional[str]] = mapped_column(String(10), default=None)
+    analyzed_at: Mapped[datetime] = mapped_column(default=func.now())
 
     # Relationships
-    article = relationship("Article", back_populates="sentiment_analyses")
+    article: Mapped["Article"] = relationship(back_populates="sentiment_analyses")
 
     __table_args__ = (
         Index("ix_sentiment_analyses_article_id", "article_id"),
         Index("ix_sentiment_analyses_provider", "provider"),
         Index("ix_sentiment_analyses_analyzed_at", "analyzed_at"),
         Index("ix_sentiment_analyses_label", "label"),
-        # Composite index for provider + article lookups
         Index("ix_sentiment_analyses_provider_article", "provider", "article_id"),
     )

--- a/app/models/source.py
+++ b/app/models/source.py
@@ -1,7 +1,13 @@
-from sqlalchemy import Column, DateTime, Integer, String, func
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING, List
+
+from sqlalchemy import String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.article import Article
 
 
 class Source(Base):
@@ -9,39 +15,29 @@ class Source(Base):
 
     __tablename__ = "sources"
 
-    id = Column(Integer, primary_key=True, index=True)
-
-    # Core source information (what Mediastack provides)
-    name = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(
         String(255),
         unique=True,
-        nullable=False,
-        index=True,  # Index for source lookups
+        index=True,
         comment="Mediastack source identifier (e.g., 'bbc', 'cnn', 'independent')",
     )
-
-    # Audit fields (best practice)
-    created_at = Column(
-        DateTime(timezone=True),
-        nullable=False,
+    created_at: Mapped[datetime] = mapped_column(
         server_default=func.now(),
         comment="When the source was added to our system",
     )
-    updated_at = Column(
-        DateTime(timezone=True),
-        nullable=False,
+    updated_at: Mapped[datetime] = mapped_column(
         server_default=func.now(),
         onupdate=func.now(),
         comment="When the source was last updated",
     )
 
     # Relationships
-    articles = relationship(
-        "Article",
+    articles: Mapped[List["Article"]] = relationship(
         back_populates="source",
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
 
     def __repr__(self) -> str:
-        return f"<Source id={self.id!r} name={self.name!r} domain={self.domain!r}>"
+        return f"<Source id={self.id!r} name={self.name!r}>"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,14 +1,24 @@
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import relationship
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.bookmark import Bookmark
 
 
 class User(Base):
     __tablename__ = "users"
-    id = Column(Integer, primary_key=True, index=True)
-    email = Column(String(255), unique=True, nullable=False, index=True)
-    hashed_password = Column(String, nullable=True)
-    firebase_uid = Column(String, unique=True, index=True, nullable=True)
 
-    bookmarks = relationship("Bookmark", back_populates="user", cascade="all, delete")
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    hashed_password: Mapped[Optional[str]] = mapped_column(String, default=None)
+    firebase_uid: Mapped[Optional[str]] = mapped_column(
+        String, unique=True, index=True, default=None
+    )
+
+    bookmarks: Mapped[List["Bookmark"]] = relationship(
+        back_populates="user", cascade="all, delete"
+    )

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -15,6 +15,14 @@ router = APIRouter(tags=["Articles"])
 def get_articles(db: Session = Depends(get_db), limit: int = 20) -> List[ArticleRead]:
     articles = (
         db.query(ArticleModel)
+        .options(
+            joinedload(ArticleModel.source),
+            joinedload(ArticleModel.sentiment_analyses),
+            subqueryload(ArticleModel.article_entities).joinedload(
+                ArticleEntity.entity
+            ),
+            subqueryload(ArticleModel.article_categories),
+        )
         .order_by(ArticleModel.published_at.desc())
         .limit(limit)
         .all()

--- a/app/routers/bookmarks.py
+++ b/app/routers/bookmarks.py
@@ -22,7 +22,7 @@ def create_bookmark(
     db.add(bookmark)
     db.commit()
     db.refresh(bookmark)
-    return bookmark
+    return bookmark  # type: ignore[return-value]
 
 
 @router.get("/", response_model=List[BookmarkRead])

--- a/app/routers/db_analytics.py
+++ b/app/routers/db_analytics.py
@@ -1,0 +1,68 @@
+"""PostgreSQL-powered analytics endpoints (advanced SQL demonstrations).
+
+These endpoints query the operational database directly using window
+functions, CTEs, and GROUPING SETS. They complement the BigQuery
+analytics router which handles long-term trend analysis.
+"""
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.crud.analytics import (
+    daily_category_sentiment_pivot,
+    entity_momentum,
+    sentiment_grouping_sets,
+    sentiment_rolling_average,
+    source_sentiment_ranked,
+)
+from app.database import get_db
+
+router = APIRouter(tags=["DB Analytics"])
+
+
+@router.get("/sentiment/rolling", response_model=List[Dict[str, Any]])
+def get_sentiment_rolling(
+    days: int = Query(30, ge=7, le=365),
+    window: int = Query(7, ge=3, le=30, description="Rolling window size in days"),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """7-day rolling average sentiment trend (window function)."""
+    return sentiment_rolling_average(db, days=days, window=window)
+
+
+@router.get("/sources/ranked", response_model=List[Dict[str, Any]])
+def get_sources_ranked(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """Sources ranked by average sentiment (CTE + RANK window function)."""
+    return source_sentiment_ranked(db, days=days)
+
+
+@router.get("/sentiment/breakdown", response_model=List[Dict[str, Any]])
+def get_sentiment_breakdown(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """Multi-dimensional sentiment breakdown (GROUPING SETS)."""
+    return sentiment_grouping_sets(db, days=days)
+
+
+@router.get("/entities/momentum", response_model=List[Dict[str, Any]])
+def get_entity_momentum(
+    days: int = Query(14, ge=4, le=60),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """Entity mention momentum: this period vs previous period."""
+    return entity_momentum(db, days=days)
+
+
+@router.get("/categories/daily", response_model=List[Dict[str, Any]])
+def get_categories_daily(
+    days: int = Query(14, ge=1, le=90),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """Daily sentiment per category with cumulative totals (window function)."""
+    return daily_category_sentiment_pivot(db, days=days)

--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -19,7 +19,7 @@ def create_source(source_in: SourceCreate, db: Session = Depends(get_db)) -> Sou
     db.add(src)
     db.commit()
     db.refresh(src)
-    return src
+    return src  # type: ignore[return-value]
 
 
 @router.get("/", response_model=List[SourceRead])


### PR DESCRIPTION
## Summary
- **B.2** Migrate all 10 SQLAlchemy models from `Column()` to `Mapped[]` syntax (SQLAlchemy 2.0)
- **B.1** Fix N+1 query on `GET /articles/` (1+4N queries → ~6), add FK indexes on `bookmarks`
- **B.3–B.5** Alembic migration with 4 PostgreSQL views, 2 PL/pgSQL stored functions, 2 triggers
- **B.6** New `app/crud/analytics.py` with 5 advanced SQL queries: window functions (`AVG OVER`, `RANK`, `SUM OVER`), CTEs, `GROUPING SETS`, `FULL OUTER JOIN`
- **Bugfix** `/metrics` endpoint referenced non-existent `SentimentAnalysis.sentiment_label` → corrected to `.label`

## DB objects added (Alembic migration `e1f2a3b4c5d6`)
- **Views:** `v_article_summary`, `v_source_stats`, `v_daily_sentiment`, `v_trending_entities`
- **Functions:** `fn_sentiment_distribution(days)`, `fn_source_performance(days)`
- **Triggers:** `trg_update_source_timestamp` (auto-update source on article insert), `trg_prevent_duplicate_bookmark` (DB-level duplicate guard)

## New endpoints
- `GET /api/v1/db-analytics/sentiment/rolling` — rolling average (window function)
- `GET /api/v1/db-analytics/sources/ranked` — source ranking (CTE + RANK)
- `GET /api/v1/db-analytics/sentiment/breakdown` — GROUPING SETS
- `GET /api/v1/db-analytics/entities/momentum` — entity trend comparison
- `GET /api/v1/db-analytics/categories/daily` — cumulative daily pivot

## Test plan
- [ ] `pytest tests/ -v` — 23/23 passing locally
- [ ] Verify Alembic migration applies cleanly on PostgreSQL (`alembic upgrade head`)
- [ ] Confirm new endpoints return data against populated DB