### PR TITLE
feat(ci): harden deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ jobs:
         github.head_ref != 'develop' &&
         !startsWith(github.head_ref, 'fix/')
       run: |
+        # Skip enforcement if develop branch doesn't exist yet (bootstrap)
+        if ! git ls-remote --exit-code --heads origin develop > /dev/null 2>&1; then
+          echo "develop branch not found — skipping merge policy (bootstrap mode)"
+          exit 0
+        fi
         echo "::error::Only 'develop' or 'fix/*' branches can merge into main. Feature branches must target develop."
         exit 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@ name: Deploy to Cloud Run
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 env:
   PROJECT_ID: aifeelnews-prod
@@ -17,6 +17,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Enforce merge policy
+      if: |
+        github.event_name == 'pull_request' &&
+        github.base_ref == 'main' &&
+        github.head_ref != 'develop' &&
+        !startsWith(github.head_ref, 'fix/')
+      run: |
+        echo "::error::Only 'develop' or 'fix/*' branches can merge into main. Feature branches must target develop."
+        exit 1
+
     - name: Checkout code
       uses: actions/checkout@v6
 
@@ -49,9 +59,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+
     permissions:
       contents: read
       id-token: write
+      issues: write
 
     steps:
     - name: Checkout code
@@ -77,6 +92,13 @@ jobs:
         docker push $AR_REGISTRY/$SERVICE:$GITHUB_SHA
         docker push $AR_REGISTRY/$SERVICE:latest
 
+    - name: Run database migrations
+      run: |
+        pip install -r requirements.txt
+        alembic upgrade head
+      env:
+        DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
+
     - name: Deploy to Cloud Run
       id: deploy
       uses: google-github-actions/deploy-cloudrun@v2
@@ -87,6 +109,7 @@ jobs:
         env_vars: |
           BIGQUERY_ENABLE_BIGQUERY=true
           ENV=production
+          APP_VERSION=${{ github.sha }}
         secrets: |
           MEDIASTACK_API_KEY=mediastack-api-key:latest
         flags: |
@@ -99,11 +122,202 @@ jobs:
           --concurrency=80
           --timeout=300
 
-    - name: Show deployment URL
-      run: echo "Deployed to ${{ steps.deploy.outputs.url }}"
-
-    - name: Test deployment health
+    - name: Verify deployment
+      id: verify
       run: |
-        sleep 10  # Wait for service to be ready
-        curl -f ${{ steps.deploy.outputs.url }}/health || exit 1
-        echo "✅ Deployment health check passed"
+        URL="${{ steps.deploy.outputs.url }}"
+        MAX_RETRIES=12
+        RETRY_INTERVAL=5
+
+        # 1. Wait for service readiness (handles cold-start from min-instances=0)
+        echo "Waiting for service to be ready..."
+        for i in $(seq 1 $MAX_RETRIES); do
+          if curl -sf "$URL/health" > /dev/null 2>&1; then
+            echo "Service is healthy (attempt $i/$MAX_RETRIES)"
+            break
+          fi
+          if [ $i -eq $MAX_RETRIES ]; then
+            echo "::error::Service failed to become healthy after $((MAX_RETRIES * RETRY_INTERVAL))s"
+            exit 1
+          fi
+          echo "Attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_INTERVAL}s..."
+          sleep $RETRY_INTERVAL
+        done
+
+        # 2. Verify correct version deployed
+        DEPLOYED_VERSION=$(curl -sf "$URL/version" | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
+        if [ "$DEPLOYED_VERSION" != "$GITHUB_SHA" ]; then
+          echo "::error::Version mismatch: expected $GITHUB_SHA, got $DEPLOYED_VERSION"
+          exit 1
+        fi
+        echo "Version verified: $DEPLOYED_VERSION"
+
+        # 3. Verify metrics endpoint (confirms multi-table DB access)
+        METRICS=$(curl -sf "$URL/metrics")
+        if echo "$METRICS" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(1 if 'error' in d else 0)"; then
+          echo "Metrics endpoint healthy"
+        else
+          echo "::error::Metrics endpoint returned an error"
+          exit 1
+        fi
+
+        # 4. Verify primary API router
+        if curl -sf "$URL/api/v1/articles/?skip=0&limit=1" > /dev/null 2>&1; then
+          echo "Articles API responding"
+        else
+          echo "::warning::Articles API check failed (may be empty DB — non-fatal)"
+        fi
+
+        echo "All deployment checks passed"
+
+    - name: Rollback on failure
+      if: failure() && steps.deploy.outcome == 'success'
+      run: |
+        echo "Deployment verification failed — rolling back..."
+        PREV_REV=$(gcloud run revisions list \
+          --service=$SERVICE --region=$REGION \
+          --limit=2 --format='value(REVISION)' | tail -1)
+        if [ -n "$PREV_REV" ]; then
+          gcloud run services update-traffic $SERVICE \
+            --region=$REGION --to-revisions=$PREV_REV=100
+          echo "Rolled back to revision: $PREV_REV"
+          echo "## Rollback Executed" >> $GITHUB_STEP_SUMMARY
+          echo "Rolled back to revision: \`$PREV_REV\`" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "::warning::No previous revision found for rollback"
+        fi
+
+    - name: Deployment summary
+      if: always()
+      run: |
+        echo "## Deployment Report" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| **Service** | \`$SERVICE\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Region** | \`$REGION\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Commit** | \`${GITHUB_SHA::7}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **URL** | ${{ steps.deploy.outputs.url }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Status** | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |" >> $GITHUB_STEP_SUMMARY
+
+    - name: Create failure issue
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `Deploy failed: ${context.sha.substring(0, 7)}`,
+            body: `## Deployment Failure\n\n` +
+              `**Commit:** ${context.sha}\n` +
+              `**Branch:** ${context.ref}\n` +
+              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n` +
+              `Please investigate and fix the issue.`,
+            labels: ['deploy-failure']
+          })
+
+  # Preview deploy for PRs targeting develop — Cloud Run tagged revision (no traffic, free when idle)
+  preview-deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Google Auth
+      id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: Configure Docker for Artifact Registry
+      run: |
+        gcloud auth configure-docker europe-west1-docker.pkg.dev
+
+    - name: Build Docker image
+      run: |
+        docker build -f docker/Dockerfile.web \
+          -t $AR_REGISTRY/$SERVICE:pr-${{ github.event.pull_request.number }} .
+
+    - name: Push Docker image
+      run: |
+        docker push $AR_REGISTRY/$SERVICE:pr-${{ github.event.pull_request.number }}
+
+    - name: Deploy preview revision
+      id: preview
+      run: |
+        PR_NUM=${{ github.event.pull_request.number }}
+        gcloud run deploy $SERVICE \
+          --image=$AR_REGISTRY/$SERVICE:pr-$PR_NUM \
+          --region=$REGION \
+          --tag=pr-$PR_NUM \
+          --no-traffic \
+          --env-vars="ENV=preview,APP_VERSION=$GITHUB_SHA" \
+          --service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com \
+          --memory=512Mi \
+          --cpu=1 \
+          --min-instances=0 \
+          --max-instances=2 \
+          --allow-unauthenticated
+        PREVIEW_URL=$(gcloud run services describe $SERVICE --region=$REGION \
+          --format='value(status.traffic[tag=pr-'$PR_NUM'].url)')
+        echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+
+    - name: Smoke test preview
+      run: |
+        URL="${{ steps.preview.outputs.preview_url }}"
+        for i in $(seq 1 12); do
+          if curl -sf "$URL/health" > /dev/null 2>&1; then
+            echo "Preview is healthy"
+            break
+          fi
+          [ $i -eq 12 ] && echo "::warning::Preview health check timed out" && exit 1
+          sleep 5
+        done
+
+    - name: Post preview URL to PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const url = '${{ steps.preview.outputs.preview_url }}';
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            body: `## Preview Deployment\n\n` +
+              `**URL:** ${url}\n` +
+              `**Commit:** \`${context.sha.substring(0, 7)}\`\n\n` +
+              `This preview receives no production traffic and will be cleaned up when the PR is closed.`
+          })
+
+  # Cleanup preview revision when PR is closed
+  preview-cleanup:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Google Auth
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: Remove preview tag
+      run: |
+        PR_NUM=${{ github.event.pull_request.number }}
+        gcloud run services update-traffic $SERVICE \
+          --region=$REGION \
+          --remove-tags=pr-$PR_NUM || true
+        echo "Cleaned up preview for PR #$PR_NUM"

--- a/app/main.py
+++ b/app/main.py
@@ -149,8 +149,21 @@ def get_version() -> dict[str, str]:
 
 @app.get("/ready")
 def readiness_check() -> dict[str, str]:
-    """Readiness check for Kubernetes deployments."""
-    return {"status": "ready", "service": "aifeelnews-api"}
+    """Readiness probe — verifies DB connectivity before accepting traffic."""
+    try:
+        from sqlalchemy import text
+
+        from app.database import SessionLocal
+
+        db = SessionLocal()
+        db.execute(text("SELECT 1"))
+        db.close()
+
+        return {"status": "ready", "service": "aifeelnews-api"}
+    except Exception as e:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=503, detail=f"Service not ready: {e}")
 
 
 @app.get("/metrics", tags=["Meta"])

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,25 +1,8 @@
 #!/bin/sh
 set -e
 
-# Wait for database to be ready and run migrations
+# Migrations run in CI before deployment (see .github/workflows/deploy.yml).
+# This script only starts the web server.
 echo "Starting aiFeelNews web service..."
-
-# Retry database migration with backoff
-for i in 1 2 3 4 5; do
-    echo "Attempting database migration (attempt $i/5)..."
-    if alembic upgrade head; then
-        echo "Database migration successful!"
-        break
-    else
-        if [ $i -eq 5 ]; then
-            echo "Database migration failed after 5 attempts. Exiting."
-            exit 1
-        fi
-        echo "Migration failed, waiting ${i}0 seconds before retry..."
-        sleep $((i * 10))
-    fi
-done
-
-# Start the web server
 echo "Starting uvicorn server on port ${PORT:-8080}..."
 exec uvicorn app.main:app --host 0.0.0.0 --port "${PORT:-8080}"

--- a/docs/CICD_PIPELINE.md
+++ b/docs/CICD_PIPELINE.md
@@ -2,7 +2,29 @@
 
 ## Overview
 
-aiFeelNews uses **GitHub Actions** with 4 workflows that automate testing, building, and deploying both backend (Cloud Run) and frontend (Firebase Hosting) components.
+aiFeelNews uses **GitHub Actions** with 4 workflows that automate testing, building, and deploying both backend (Cloud Run) and frontend (Firebase Hosting) components. The pipeline enforces a **Simplified Git Flow** branching strategy with CI-gated merge policies, multi-endpoint smoke tests, automated rollback, and PR preview deploys.
+
+## Branching Strategy
+
+```
+feature/phase-b-db  ──┐
+feature/phase-c-cyber ─┤── PR into: develop (CI tests, NO deploy)
+feature/phase-d-auth  ─┘
+                           │
+                           └── when deploy-ready: PR develop → main (full deploy)
+
+fix/critical-bug  ────────── PR directly to main (hotfix escape hatch)
+                              └── after merge: sync main back into develop
+```
+
+| Branch | Purpose | Deploys? |
+|--------|---------|----------|
+| `main` | Production. Merge here = deploy. | Yes — Cloud Run + Firebase |
+| `develop` | Integration. Batch feature branches here. | No — tests only |
+| `feature/*` | Individual work. PRs target `develop`. | No — tests only |
+| `fix/*` | Urgent production hotfixes. PRs target `main`. | Yes — bypasses `develop` |
+
+**CI-enforced merge policy:** PRs from feature branches directly to `main` are blocked by a CI gate. Only `develop` and `fix/*` branches can merge into `main`.
 
 ## Pipeline Diagram
 
@@ -10,48 +32,62 @@ aiFeelNews uses **GitHub Actions** with 4 workflows that automate testing, build
 flowchart TB
     subgraph triggers["Triggers"]
         push_main["Push to main"]
+        push_develop["Push to develop"]
+        pr_develop["PR to develop"]
         pr_main["PR to main"]
         pr_any["PR opened"]
     end
 
     subgraph backend["Backend Pipeline (deploy.yml)"]
         direction TB
+        merge_gate["Merge Policy Gate<br/>───────────<br/>PRs to main must come<br/>from develop or fix/*"]
+
         test["Test Job<br/>───────────<br/>Python 3.13<br/>pip install<br/>ruff check app/<br/>mypy app/<br/>pytest tests/ -v"]
 
-        gate{"push to main?"}
+        deploy_gate{"push to main?"}
 
-        build["Build & Deploy Job<br/>───────────<br/>Google Auth (credentials_json)<br/>Configure Docker for AR<br/>docker build -f Dockerfile.web<br/>docker push to Artifact Registry<br/>deploy-cloudrun v2<br/>Health check: curl /health"]
+        migrate["Run Migrations<br/>───────────<br/>alembic upgrade head<br/>against Cloud SQL"]
+
+        build["Build & Deploy<br/>───────────<br/>Docker build + push to AR<br/>deploy-cloudrun v2<br/>APP_VERSION=$GITHUB_SHA"]
+
+        verify["Verify Deployment<br/>───────────<br/>Retry /health (60s)<br/>Check /version matches SHA<br/>Check /metrics (multi-table)<br/>Check /articles API"]
+
+        rollback["Rollback on Failure<br/>───────────<br/>Route traffic to<br/>previous revision"]
+
+        summary["Deployment Summary<br/>───────────<br/>Job summary + failure issue"]
+    end
+
+    subgraph preview["PR Preview (deploy.yml)"]
+        preview_build["Build & Deploy Preview<br/>───────────<br/>Docker build pr-N tag<br/>Cloud Run --no-traffic --tag<br/>Smoke test preview URL<br/>Post URL as PR comment"]
     end
 
     subgraph frontend_merge["Frontend Deploy (firebase-hosting-merge.yml)"]
-        fb_build_live["Build & Deploy<br/>───────────<br/>npm ci (frontend/)<br/>npm run build + VITE_ env vars<br/>Firebase deploy → live channel"]
+        fb_build_live["Build & Deploy<br/>───────────<br/>npm ci + npm run build<br/>Firebase deploy → live"]
     end
 
     subgraph frontend_pr["Frontend Preview (firebase-hosting-pull-request.yml)"]
-        fb_build_preview["Build & Preview<br/>───────────<br/>npm ci (frontend/)<br/>npm run build + VITE_ env vars<br/>Firebase deploy → preview channel<br/>Posts preview URL as PR comment"]
+        fb_build_preview["Build & Preview<br/>───────────<br/>npm ci + npm run build<br/>Firebase deploy → preview"]
     end
 
     subgraph review["Auto Review (auto-review.yml)"]
-        copilot["Request Copilot Review<br/>via github-script"]
+        copilot["Request Copilot Review"]
     end
 
+    pr_main --> merge_gate --> test
     push_main --> test
-    pr_main --> test
-    test --> gate
-    gate -->|Yes: push to main| build
-    gate -->|No: PR only| stop["Tests pass ✓<br/>No deploy"]
+    push_develop --> test
+    pr_develop --> test
+    test --> deploy_gate
+    deploy_gate -->|Yes: push to main| migrate --> build --> verify
+    verify -->|Failure| rollback
+    verify -->|Always| summary
+    deploy_gate -->|No| stop["Tests pass ✓<br/>No deploy"]
+
+    pr_develop --> preview_build
 
     push_main --> fb_build_live
     pr_any --> fb_build_preview
     pr_any --> copilot
-
-    subgraph artifacts["Artifact Flow"]
-        direction LR
-        code["Source Code"] --> image["Docker Image<br/>europe-west1-docker.pkg.dev/<br/>aifeelnews-prod/aifeelnews/<br/>aifeelnews-web:SHA"]
-        image --> revision["Cloud Run Revision<br/>europe-west1<br/>512Mi / 1 vCPU<br/>min=0, max=10"]
-    end
-
-    build --> artifacts
 ```
 
 ## Workflow Details
@@ -60,27 +96,44 @@ flowchart TB
 
 | Property | Value |
 |----------|-------|
-| **Trigger** | Push to `main` + PR to `main` |
+| **Trigger** | Push to `main`/`develop` + PR to `main`/`develop` |
+| **Merge policy** | CI gate: only `develop` or `fix/*` can PR into `main` |
 | **Python** | 3.13 (matches production Dockerfile) |
 | **Linting** | `ruff check app/` + `mypy app/` |
-| **Tests** | `pytest tests/ -v` with `ENV=test` and SQLite |
+| **Tests** | `pytest tests/ -v` with `ENV=test` |
 | **Registry** | Artifact Registry (`europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/`) |
+| **Migrations** | `alembic upgrade head` in CI (before deploy, not in startup.sh) |
 | **Deploy target** | Cloud Run `aifeelnews-web` in `europe-west1` |
 | **Deploy config** | 512Mi, 1 vCPU, min-instances=0, max=10, concurrency=80, timeout=300s |
-| **Env vars** | `BIGQUERY_ENABLE_BIGQUERY=true`, `ENV=production` |
-| **Secrets** | `MEDIASTACK_API_KEY` mounted from Secret Manager (`mediastack-api-key:latest`) |
+| **Env vars** | `BIGQUERY_ENABLE_BIGQUERY=true`, `ENV=production`, `APP_VERSION=$GITHUB_SHA` |
+| **Secrets** | `MEDIASTACK_API_KEY` from Secret Manager, `MIGRATION_DATABASE_URL` for CI |
 | **Service account** | `cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com` (least-privilege) |
-| **Health check** | `curl /health` after deployment |
-| **Deploy gate** | Only on push to main (PRs run tests only) |
+| **Smoke tests** | Multi-endpoint: `/health`, `/version`, `/metrics`, `/articles/` |
+| **Rollback** | Automatic on smoke test failure — routes traffic to previous revision |
+| **Notifications** | GitHub Environment status, job summary, auto-created issue on failure |
+| **Deploy gate** | Only on push to main (PRs + develop run tests only) |
 
 **Job dependency chain:**
 ```
-test (lint + type-check + unit tests)
-  └── build-and-deploy (only if test passes AND push to main)
-        ├── Google Auth via credentials_json
-        ├── Docker build + push to Artifact Registry
-        ├── Deploy to Cloud Run
-        └── Health check verification
+test (merge policy gate → lint + type-check + unit tests)
+  ├── build-and-deploy (only if test passes AND push to main)
+  │     ├── Google Auth via credentials_json
+  │     ├── Docker build + push to Artifact Registry
+  │     ├── Run database migrations (alembic via Cloud SQL)
+  │     ├── Deploy to Cloud Run with APP_VERSION
+  │     ├── Multi-endpoint smoke test verification
+  │     ├── Rollback on failure (route to previous revision)
+  │     ├── Deployment summary (GitHub job summary)
+  │     └── Create failure issue (if failed)
+  │
+  └── preview-deploy (only on PR to develop)
+        ├── Docker build + push with pr-N tag
+        ├── Deploy tagged revision (--no-traffic)
+        ├── Smoke test preview URL
+        └── Post preview URL as PR comment
+
+preview-cleanup (on PR close)
+  └── Remove Cloud Run tag for closed PR
 ```
 
 ### 2. Frontend Deploy (`firebase-hosting-merge.yml`)
@@ -114,8 +167,9 @@ test (lint + type-check + unit tests)
 
 | Secret | Used By | Purpose |
 |--------|---------|---------|
-| `GCP_SA_KEY` | `deploy.yml` | Google Cloud authentication for Artifact Registry + Cloud Run |
-| `mediastack-api-key` (GCP Secret Manager) | `deploy.yml` | Mounted as `MEDIASTACK_API_KEY` env var on Cloud Run at deploy time |
+| `GCP_SA_KEY` | `deploy.yml` | Google Cloud authentication for AR + Cloud Run + Cloud SQL Proxy |
+| `MIGRATION_DATABASE_URL` | `deploy.yml` | Cloud SQL connection for CI-based Alembic migrations |
+| `mediastack-api-key` (GCP SM) | `deploy.yml` | Mounted as `MEDIASTACK_API_KEY` env var on Cloud Run |
 | `VITE_FIREBASE_API_KEY` | Frontend workflows | Firebase client config (injected at build time) |
 | `VITE_FIREBASE_AUTH_DOMAIN` | Frontend workflows | Firebase auth domain |
 | `VITE_FIREBASE_PROJECT_ID` | Frontend workflows | Firebase project identifier |
@@ -126,14 +180,34 @@ test (lint + type-check + unit tests)
 ## Environment Gates
 
 ```
-PR created
-  ├── Backend tests run (ruff + mypy + pytest)
-  ├── Frontend preview deployed (preview URL in PR comment)
-  └── Copilot review requested
+Feature branch created from develop
+  └── PR to develop
+        ├── Backend tests run (merge policy + ruff + mypy + pytest)
+        ├── Backend preview deployed (Cloud Run tagged revision, no traffic)
+        ├── Frontend preview deployed (Firebase preview channel)
+        └── Copilot review requested
 
-PR merged to main
-  ├── Backend: tests → build Docker → push to AR → deploy to Cloud Run → health check
+Merged to develop (batch features here)
+  └── Tests re-run, no deployment
+
+PR develop → main (release)
+  └── Tests pass → Migrations → Build → Deploy → Smoke tests → Rollback if failed
+
+Push to main (after merge)
+  ├── Backend: test → migrate → build → push → deploy → verify → rollback/notify
   └── Frontend: build → deploy to Firebase Hosting live channel
 ```
 
-No code reaches production without passing all linting, type checking, and tests first.
+No code reaches production without passing all linting, type checking, and tests. Migrations run before the new image is deployed. Failed deployments automatically roll back to the previous revision.
+
+## Deployment Resilience
+
+| Safeguard | How It Works |
+|-----------|-------------|
+| **Merge policy** | CI blocks feature branches from merging directly to `main` |
+| **Migration safety** | Alembic runs in CI before deploy, not in `startup.sh` — bad migrations don't crash the service |
+| **Multi-endpoint smoke tests** | Verifies `/health`, `/version` (SHA match), `/metrics`, and `/articles/` API |
+| **Automated rollback** | On smoke test failure, traffic routes back to previous Cloud Run revision |
+| **Deployment notifications** | GitHub Environment status + job summary + auto-created issue on failure |
+| **PR previews** | Cloud Run tagged revisions with `--no-traffic` — free validation before merging |
+| **Hotfix escape hatch** | `fix/*` branches bypass `develop` for urgent production fixes |

--- a/docs/MULTI_ENVIRONMENT_STRATEGY.md
+++ b/docs/MULTI_ENVIRONMENT_STRATEGY.md
@@ -2,9 +2,53 @@
 
 ## Overview
 
-aiFeelNews supports multiple deployment environments (production, staging) through **Terraform variable files** (`tfvars`). Each environment gets an identical but isolated infrastructure stack, controlled entirely by which variable file is passed to `terraform plan/apply`.
+aiFeelNews implements environment separation through two complementary mechanisms:
 
-## How It Works
+1. **Terraform variable files** (`tfvars`) — infrastructure-level environment isolation (production vs staging)
+2. **Git branching + Cloud Run tagged revisions** — cost-free preview environments for every PR
+
+A dedicated staging environment is not deployed due to cost (~$7-9/month for Cloud SQL alone). Instead, the project uses **PR preview deploys** on Cloud Run as a zero-cost staging alternative.
+
+## Branching Strategy (Simplified Git Flow)
+
+```
+feature/phase-b-db  ──┐
+feature/phase-c-cyber ─┤── PR into: develop (CI tests + PR preview)
+feature/phase-d-auth  ─┘
+                           │
+                           └── when deploy-ready: PR develop → main (production deploy)
+
+fix/critical-bug  ────────── PR directly to main (hotfix escape hatch)
+```
+
+| Branch | Tests? | Deploys? | Target |
+|--------|--------|----------|--------|
+| `main` | Yes | Yes — production Cloud Run + Firebase | Production |
+| `develop` | Yes | No — integration only | None |
+| `feature/*` | Yes (on PR) | PR preview (Cloud Run tagged revision) | Preview URL |
+| `fix/*` | Yes | Yes — direct to production (emergency) | Production |
+
+**CI-enforced merge policy:** A CI gate in the `test` job blocks PRs from feature branches directly to `main`. Only `develop` and `fix/*` branches are allowed. This is enforced without GitHub Enterprise — purely through a workflow step that exits with an error.
+
+## PR Preview Deploys (Zero-Cost Staging Alternative)
+
+When a PR targets `develop`, the CI pipeline:
+
+1. Builds a Docker image tagged `pr-<number>`
+2. Deploys it to Cloud Run with `--tag=pr-<number> --no-traffic`
+3. The revision gets its own URL: `pr-42---aifeelnews-web-xxxxx.run.app`
+4. Posts the preview URL as a PR comment
+5. Cleans up the tagged revision when the PR is closed
+
+**Why this is free:** Cloud Run charges per request. Tagged revisions with `--no-traffic` and `min-instances=0` cost nothing when idle. They share the same Cloud SQL instance, Secret Manager secrets, and service account — no duplicate infrastructure.
+
+**What this validates:**
+- Docker image builds successfully
+- Application starts and passes health checks
+- Database connectivity works (same Cloud SQL)
+- API endpoints respond correctly
+
+## Terraform Multi-Environment Support
 
 All infrastructure is defined once in `infra/main.tf`. Environment-specific values live in separate files:
 
@@ -24,21 +68,21 @@ terraform plan  -var-file=envs/prod.tfvars
 terraform apply -var-file=envs/prod.tfvars
 ```
 
-**Deploy staging:**
+**Deploy staging (if needed):**
 ```bash
+terraform workspace new staging
 terraform plan  -var-file=envs/staging.tfvars
 terraform apply -var-file=envs/staging.tfvars
 ```
 
-## Environment Comparison
+### Environment Comparison
 
-| Resource | Production | Staging |
+| Resource | Production | Staging (not deployed) |
 |----------|-----------|---------|
 | **Environment tag** | `prod` | `staging` |
 | **Cloud SQL instance** | `aifeelnews-db` | `aifeelnews-db-staging` |
 | **Database name** | `aifeelnews` | `aifeelnews_staging` |
 | **Cloud SQL tier** | `db-f1-micro` | `db-f1-micro` |
-| **Cloud Run URL** | `aifeelnews-web-813...run.app` | `aifeelnews-web-staging...run.app` |
 | **Ingestion schedule** | Every 8 hours (`0 */8 * * *`) | Once daily at noon (`0 12 * * *`) |
 | **Cleanup schedule** | Daily at 2 AM | Daily at 3 AM |
 | **BigQuery dataset** | `aifeelnews` | `aifeelnews_staging` |
@@ -48,55 +92,45 @@ terraform apply -var-file=envs/staging.tfvars
 
 The staging configuration exists as a **design artifact** demonstrating multi-environment capability. It is not actively deployed because:
 
-1. **Cost**: Cloud SQL alone costs ~$7-9/month (always-on, no free tier). Deploying staging would double the infrastructure cost for no production benefit.
-2. **Scale**: For a student project with <10 users, a single production environment with proper CI/CD testing gates is sufficient.
-3. **Risk mitigation**: The backend pipeline runs full tests (lint + type-check + unit tests) before any deployment, catching issues before they reach production.
+1. **Cost**: Cloud SQL alone costs ~$7-9/month (always-on, no free tier). Deploying staging would double the infrastructure cost with no production benefit.
+2. **Scale**: For a student project with <10 users, PR previews + proper CI testing gates provide sufficient pre-production validation.
+3. **Risk mitigation**: The backend pipeline runs full tests (lint + type-check + unit tests), multi-endpoint smoke tests, and automated rollback — catching issues before and after deployment.
 
-**This is a deliberate cost/value trade-off**, not a limitation. The architecture fully supports staging activation with a single `terraform apply` command.
-
-## Activating Staging (3 Steps)
-
-If staging were needed (e.g., before a major release or for team testing):
-
-```bash
-# 1. Initialize Terraform for the staging workspace
-cd infra
-terraform workspace new staging   # or: terraform workspace select staging
-
-# 2. Review what will be created
-terraform plan -var-file=envs/staging.tfvars
-
-# 3. Create the staging stack
-terraform apply -var-file=envs/staging.tfvars
-```
-
-This creates a completely isolated Cloud SQL instance, Cloud Scheduler jobs, BigQuery dataset, and Secret Manager secrets for staging. No production resources are affected.
-
-## CI/CD Extension Path
-
-To enable automatic staging deployments, the GitHub Actions workflow could be extended with branch-based routing:
-
-```yaml
-# Conceptual extension (not implemented — cost trade-off)
-build-and-deploy:
-  if: github.ref == 'refs/heads/main'
-  # → Deploy to production Cloud Run
-
-staging-deploy:
-  if: github.ref == 'refs/heads/develop'
-  # → Deploy to staging Cloud Run with staging env vars
-```
-
-This pattern would enable:
-- **`main` branch** → production deployment (current behavior)
-- **`develop` branch** → staging deployment (future, if needed)
-- **Feature branches** → tests only, no deployment
+**This is a deliberate cost/value trade-off**, not a limitation. The architecture supports staging activation with a single `terraform apply`.
 
 ## Isolation Guarantees
 
-Each environment is fully isolated:
-- **Separate Cloud SQL instances** (different instance names, different databases)
-- **Separate BigQuery datasets** (no cross-contamination of analytics data)
-- **Separate Cloud Scheduler jobs** (different frequencies appropriate to environment purpose)
-- **Shared IAM service accounts** (single GCP project, but services are isolated by name)
-- **Same region** (`europe-west1`) to keep latency consistent and simplify networking
+**Terraform environments** (if both deployed):
+- Separate Cloud SQL instances (different names, different databases)
+- Separate BigQuery datasets (no cross-contamination)
+- Separate Cloud Scheduler jobs (different frequencies)
+- Shared IAM service accounts (single GCP project, isolated by service name)
+- Same region (`europe-west1`)
+
+**PR preview revisions:**
+- Isolated application code (separate Docker image tag per PR)
+- Shared database (same Cloud SQL — acceptable for previews)
+- No production traffic (enforced by `--no-traffic` flag)
+- Automatic cleanup on PR close
+
+## Deployment Safety Chain
+
+```
+Feature branch
+  │
+  ├── PR to develop
+  │     ├── CI: ruff + mypy + pytest (quality gate)
+  │     ├── Cloud Run PR preview (functional validation)
+  │     └── Firebase Hosting preview (frontend validation)
+  │
+  ├── Merged to develop (batched with other features)
+  │
+  └── PR develop → main (release)
+        ├── CI tests re-run
+        ├── Alembic migrations run in CI (before deploy)
+        ├── Docker image built and pushed
+        ├── Cloud Run deploy
+        ├── Multi-endpoint smoke tests (/health, /version, /metrics, /articles)
+        ├── Automated rollback on failure
+        └── Deployment notification (GitHub Environment + job summary + failure issue)
+```


### PR DESCRIPTION
## Summary

- **Git branching strategy**: develop integration branch with CI-enforced merge policy - only develop or fix/* can merge into main. Feature branches target develop to batch changes before deploying.
- **Enhanced smoke tests**: Multi-endpoint verification (/health, /version SHA match, /metrics, /articles/) with retry logic for cold starts, replacing the single curl /health.
- **Automated rollback**: On smoke test failure, traffic routes back to previous Cloud Run revision automatically.
- **Migration safety**: Alembic migrations run in CI before deploy (not in startup.sh on every container start), preventing race conditions and bad-migration crashes.
- **Deploy notifications**: GitHub Environment status, markdown job summary, and auto-created GitHub Issue on failure.
- **PR preview deploys**: Cloud Run tagged revisions (--no-traffic) for PRs targeting develop - zero cost when idle, preview URL posted as PR comment, auto-cleaned on PR close.
- **/ready endpoint fix**: Now performs real DB connectivity check instead of unconditionally returning 200.
- **Docs updated**: CICD_PIPELINE.md and MULTI_ENVIRONMENT_STRATEGY.md rewritten to reflect the new pipeline.

## Post-merge setup required

1. Create develop branch from main and push it
2. Set develop as default branch on GitHub
3. Add MIGRATION_DATABASE_URL secret in GitHub Actions settings
4. Create deploy-failure label on GitHub

## Test plan

- [ ] YAML validates
- [ ] Pre-commit hooks pass (ruff, mypy, trailing whitespace)
- [ ] After merge: create develop branch from main
- [ ] Verify merge policy gate blocks feature to main PRs
- [ ] Verify push to develop runs tests but does not deploy
- [ ] Verify push to main triggers full deploy pipeline
