### PR TITLE
fix(ci): skip Firebase preview deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 jobs:
   build_and_preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Adds a Dependabot guard to the [\`build_and_preview\`](.github/workflows/firebase-hosting-pull-request.yml#L11) job in the Firebase preview workflow.

GitHub does not pass repo secrets to workflows triggered by Dependabot. The Firebase preview-deploy step needs \`secrets.FIREBASE_SERVICE_ACCOUNT_AIFEELNEWS_FRONT\` to authenticate, so it fails on every Dependabot PR with:

\`\`\`
Error: Input required and not supplied: firebaseServiceAccount
...secrets are not passed to workflows triggered from forks, including Dependabot.
\`\`\`

This is environmental (no real failure of the dependency bumps) — the \`test\` job (ruff + mypy + pytest) and the npm build still run and provide the relevant signal.

## Why \`github.actor != 'dependabot[bot]'\` rather than other options
- \`pull_request_target\` would expose secrets to fork workflows — security risk, especially for Dependabot which runs untrusted dep updates. Rejected.
- Marking the check non-required keeps the red X on every Dependabot PR forever — noisy. Rejected.
- The chosen approach lets human PRs continue to get preview deploys, and Dependabot PRs get the test+build signal that actually matters for them.

## Independent of #45
This PR is branched from develop, not stacked on #45. Merge order doesn't matter — they fix two independent failures.

## Test plan
- [ ] After merge, re-run checks on Dependabot PRs (#37–#43) and confirm \`build_and_preview\` is skipped (not failed)
- [ ] Confirm a non-Dependabot PR still gets a Firebase preview URL (e.g. PR #44 or #45 once they re-run)