### PR TITLE
fix(ci+app): unbreak production migrations via Cloud SQL Auth Proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,12 @@ env:
   REGION: europe-west1
   AR_REGISTRY: europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews
 
+# Minimum permissions for the workflow. Individual jobs may add more (e.g.
+# build-and-deploy needs id-token for OIDC and issues:write for the
+# auto-failure-issue creator).
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -92,12 +98,45 @@ jobs:
         docker push $AR_REGISTRY/$SERVICE:$GITHUB_SHA
         docker push $AR_REGISTRY/$SERVICE:latest
 
+    # Run alembic against the production Cloud SQL instance via the Cloud SQL
+    # Auth Proxy (TCP on 127.0.0.1:5432) using the same SA the Cloud Run
+    # service uses. The DB password is pulled from Secret Manager at job time
+    # so no DB credentials live in GitHub secrets.
+    - name: Start Cloud SQL Auth Proxy
+      run: |
+        curl -sSL -o cloud-sql-proxy \
+          https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.1/cloud-sql-proxy.linux.amd64
+        chmod +x cloud-sql-proxy
+        ./cloud-sql-proxy --port=5432 \
+          ${{ env.PROJECT_ID }}:${{ env.REGION }}:aifeelnews-db &
+        for i in $(seq 1 15); do
+          if nc -z 127.0.0.1 5432; then
+            echo "Cloud SQL Proxy is listening"
+            break
+          fi
+          [ $i -eq 15 ] && echo "::error::Cloud SQL Proxy failed to start" && exit 1
+          sleep 1
+        done
+
+    - name: Fetch DB password from Secret Manager
+      id: dbpass
+      run: |
+        PASSWORD=$(gcloud secrets versions access latest \
+          --secret=db-password --project=${{ env.PROJECT_ID }})
+        if [ -z "$PASSWORD" ]; then
+          echo "::error::db-password secret is empty"
+          exit 1
+        fi
+        echo "::add-mask::$PASSWORD"
+        echo "password=$PASSWORD" >> $GITHUB_OUTPUT
+
     - name: Run database migrations
       run: |
         pip install -r requirements.txt
         alembic upgrade head
       env:
-        DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
+        ENV: production
+        DATABASE_URL: postgresql://aifeelnews:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
 
     - name: Deploy to Cloud Run
       id: deploy

--- a/app/database.py
+++ b/app/database.py
@@ -1,18 +1,10 @@
-from typing import Generator
+from typing import Any, Generator, Optional
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from app.config import settings
-
-# pick the URL based on ENV
-engine = create_engine(settings.SQLALCHEMY_DATABASE_URL, echo=True)
-
-SessionLocal = sessionmaker(
-    autocommit=False,
-    autoflush=False,
-    bind=engine,
-)
 
 
 class Base(DeclarativeBase):
@@ -21,8 +13,41 @@ class Base(DeclarativeBase):
     pass
 
 
+_engine: Optional[Engine] = None
+_SessionLocal: Optional[sessionmaker[Session]] = None
+
+
+def _initialize() -> None:
+    global _engine, _SessionLocal
+    url = settings.SQLALCHEMY_DATABASE_URL
+    if not url:
+        raise RuntimeError(
+            "DATABASE_URL is not configured. "
+            "Set DATABASE_URL (production) or LOCAL_DATABASE_URL (local) "
+            "before instantiating a database session."
+        )
+    _engine = create_engine(url, echo=False)
+    _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy module-level attribute resolution (PEP 562).
+
+    Defers engine + sessionmaker creation until first access of `engine` or
+    `SessionLocal`, so importing this module never requires DATABASE_URL.
+    """
+    if name in ("engine", "SessionLocal"):
+        if _engine is None:
+            _initialize()
+        return _engine if name == "engine" else _SessionLocal
+    raise AttributeError(f"module 'app.database' has no attribute {name!r}")
+
+
 def get_db() -> Generator[Session, None, None]:
-    db = SessionLocal()
+    if _SessionLocal is None:
+        _initialize()
+    assert _SessionLocal is not None
+    db = _SessionLocal()
     try:
         yield db
     finally:


### PR DESCRIPTION
## Summary

Production deploy on \`main\` has been failing since 2026-03-17 (see issue #29) at the **Run database migrations** step:

\`\`\`
sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from string ''
\`\`\`

This PR fixes it via two layered changes — a code refactor for resilient imports and a workflow rewrite using Cloud SQL Auth Proxy + Secret Manager. **No DB credentials live in GitHub secrets anymore.**

This unblocks the upcoming \`develop → main\` release PR (Phase A + B + Phase H + Dependabot bumps + deployment hardening + preview-deploy removal — 22 commits queued on develop).

## Root cause (two compounding bugs)

1. **\`MIGRATION_DATABASE_URL\` secret resolved to an empty string at runtime.** Likely never received a real value (the slot was created on 2026-03-17 alongside the broken deploy but the value field stays blank when edited).
2. **\`app/database.py:9\` created the SQLAlchemy engine at module import time.** With an empty URL, SQLAlchemy raised \`ArgumentError\` before alembic could even load \`env.py\`. So *any* code path that imports \`app.database\` (alembic, ad-hoc CLI scripts, future migration jobs) needed a valid URL just to import — fragile.

## Changes

### \`app/database.py\` — lazy init via PEP 562

- \`engine\` and \`SessionLocal\` are now resolved lazily via module-level \`__getattr__\`. Importing the module no longer requires \`DATABASE_URL\`.
- Empty URL now raises a clear \`RuntimeError\` with a helpful message instead of leaking SQLAlchemy's cryptic \`ArgumentError\`.
- All 22 existing import sites work unchanged (verified by grep + tests).
- Drops \`echo=True\` (was logging every SQL statement to stdout — noisy in production).

### \`.github/workflows/deploy.yml\`

- Adds top-level \`permissions: contents: read\` block (clears CodeQL alert #1).
- Replaces the broken migration step with a Cloud SQL Auth Proxy + Secret Manager pattern:
  1. **Start Cloud SQL Auth Proxy** on \`127.0.0.1:5432\` using the existing OIDC-authenticated SA, with a 15s readiness wait
  2. **Fetch \`db-password\` from Secret Manager** via \`gcloud secrets versions access\` (output masked with \`::add-mask::\`)
  3. **Run alembic** with \`ENV=production\` and a constructed connection string against the proxy
- **Drops the \`MIGRATION_DATABASE_URL\` secret reference entirely.**

## Verification

Verified locally before commit:

| Check | Result |
|---|---|
| \`python -c \"from app.database import Base, get_db\"\` (no env vars) | ✅ imports cleanly (this is what alembic needs) |
| \`python -c \"from app.database import engine\"\` (empty URL) | ✅ raises clear \`RuntimeError\` with helpful message |
| \`python -c \"from app.database import engine\"\` (\`LOCAL_DATABASE_URL=...\`) | ✅ engine constructs |
| \`pytest tests/ -v\` | ✅ all 23 tests pass |
| \`ruff check app/database.py\` | ✅ clean |
| \`mypy app/database.py\` | ✅ clean |
| \`yaml.safe_load\` on deploy.yml | ✅ parses |

The full production deploy can only be verified post-merge (the \`build-and-deploy\` job is gated to \`if: github.ref == 'refs/heads/main' && github.event_name == 'push'\`). Expected sequence on the next merge to main:
1. Google Auth, build, push (already worked)
2. **Start Cloud SQL Auth Proxy** — new step → \"Cloud SQL Proxy is listening\"
3. **Fetch DB password from Secret Manager** — new step → masked output
4. **Run database migrations** — alembic prints \"Running upgrade ...\"
5. Deploy to Cloud Run (unchanged)
6. Verify deployment (unchanged)
7. Issue #29 can be closed manually

## Manual GitHub UI steps required (do these before/after merge)

These are NOT code changes — they need to be done in the GitHub UI to complete the security hardening:

### 1. Move \`GCP_SA_KEY\` to production environment scope

The \`build-and-deploy\` job already declares \`environment: production\`. Moving the SA key to environment scope means it's only accessible to jobs in that environment — defense in depth.

- Go to https://github.com/cardox6/aifeelnews/settings/environments/production
- Click **\"Add environment secret\"**
- Name: \`GCP_SA_KEY\`, paste the same JSON value as the current repo-level secret
- Then go to https://github.com/cardox6/aifeelnews/settings/secrets/actions
- Click the trash icon next to the repo-level \`GCP_SA_KEY\`

### 2. Delete the dead \`MIGRATION_DATABASE_URL\` secret

After this PR merges, nothing in the repo references \`MIGRATION_DATABASE_URL\` anymore.

- https://github.com/cardox6/aifeelnews/settings/secrets/actions → trash icon next to \`MIGRATION_DATABASE_URL\`

## Security story (for the Phase C threat model)

- ✅ DB password never crosses GitHub's boundary — pulled from Secret Manager at job time
- ✅ DB connection only on \`localhost\` via Auth Proxy (no public IP exposure for migrations)
- ✅ Same SA the Cloud Run service uses (single point of trust)
- ✅ Production-scoped SA key (after manual step) — non-production jobs cannot deploy
- ✅ Workflow has minimum required permissions (CodeQL alert #1 cleared)

## Out of scope (separate follow-up PRs)

- The other 7 CodeQL alerts (Layer B follow-up)
- The actual \`develop → main\` release PR
- Closing issue #29 (will be done manually after the next successful main deploy)
- Moving Firebase secrets to environment scope (deferred to Phase D)
- Adding production environment protection rules (deferred to Phase D)

## Test plan
- [ ] CI \`test\` job passes on this PR
- [ ] User performs the two manual GitHub UI steps before/after merge
- [ ] After merge to develop + subsequent develop → main release: production \`build-and-deploy\` succeeds end-to-end
- [ ] Issue #29 manually closed with link to successful run