### PR TITLE
fix(ci): use postgres user for migrations (unblock release)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,7 +136,11 @@ jobs:
         alembic upgrade head
       env:
         ENV: production
-        DATABASE_URL: postgresql://aifeelnews:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
+        # Uses the postgres superuser to match the live Cloud Run revision —
+        # only `postgres` exists on the instance today. A follow-up PR creates
+        # a least-privilege `aifeelnews` user via Terraform and switches both
+        # runtime + migrations to it.
+        DATABASE_URL: postgresql://postgres:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
 
     - name: Deploy to Cloud Run
       id: deploy


### PR DESCRIPTION
## Summary
One-line fix to unblock production deploy.

PR #48 introduced the Cloud SQL Auth Proxy migration pattern using DB user \`aifeelnews\`, but **no such user exists** — only the \`postgres\` superuser does. The live Cloud Run revision (\`aifeelnews-web-00082-lwj\` from 2026-03-16) already connects as \`postgres\` with the same password we now pull from Secret Manager.

The release run (#49 → 25276941626) failed at the migration step with:
\`\`\`
FATAL: password authentication failed for user \"aifeelnews\"
\`\`\`

This PR changes the username to \`postgres\` to match reality and unblock today's release.

## Path B follow-up (separate PR, queued)
A real \`aifeelnews\` least-privilege DB user will be created via Terraform, granted ownership of the \`aifeelnews\` database, and used for both runtime + migrations. Bundled with the Terraform IAM-binding codification + doc sync.

## Test plan
- [ ] CI test job passes
- [ ] Merge → cherry-pick / fast-forward to main → production deploy succeeds end-to-end