### PR TITLE
fix(ci): wire Cloud Run runtime config + fix verify/rollback steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,10 +136,7 @@ jobs:
         alembic upgrade head
       env:
         ENV: production
-        # Uses the postgres superuser to match the live Cloud Run revision —
-        # only `postgres` exists on the instance today. A follow-up PR creates
-        # a least-privilege `aifeelnews` user via Terraform and switches both
-        # runtime + migrations to it.
+        # postgres superuser used here because no other DB user exists yet.
         DATABASE_URL: postgresql://postgres:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
 
     - name: Deploy to Cloud Run
@@ -149,15 +146,22 @@ jobs:
         service: ${{ env.SERVICE }}
         region: ${{ env.REGION }}
         image: ${{ env.AR_REGISTRY }}/${{ env.SERVICE }}:${{ github.sha }}
+        # DATABASE_URL uses the Unix-socket form mounted by --add-cloudsql-instances.
         env_vars: |
-          BIGQUERY_ENABLE_BIGQUERY=true
           ENV=production
           APP_VERSION=${{ github.sha }}
+          GCP_PROJECT_ID=${{ env.PROJECT_ID }}
+          SENTIMENT_PROVIDER=GCP_NL
+          BIGQUERY_ENABLE_BIGQUERY=true
+          DATABASE_URL=postgresql://postgres:${{ steps.dbpass.outputs.password }}@/aifeelnews?host=/cloudsql/${{ env.PROJECT_ID }}:${{ env.REGION }}:aifeelnews-db
         secrets: |
           MEDIASTACK_API_KEY=mediastack-api-key:latest
+          GCP_NLP_KEY_JSON=aifeelnews-gcp-nlp-key:latest
+          FIREBASE_SERVICE_ACCOUNT_JSON=firebase-service-account-json:latest
         flags: |
           --allow-unauthenticated
           --service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com
+          --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:aifeelnews-db
           --memory=512Mi
           --cpu=1
           --min-instances=0
@@ -187,13 +191,21 @@ jobs:
           sleep $RETRY_INTERVAL
         done
 
-        # 2. Verify correct version deployed
-        DEPLOYED_VERSION=$(curl -sf "$URL/version" | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
-        if [ "$DEPLOYED_VERSION" != "$GITHUB_SHA" ]; then
-          echo "::error::Version mismatch: expected $GITHUB_SHA, got $DEPLOYED_VERSION"
+        # /version is hardcoded — check Cloud Run revision identity instead.
+        SERVING_REV=$(gcloud run services describe $SERVICE --region=$REGION \
+          --format='value(status.traffic[0].revisionName)')
+        DEPLOYED_REV="${{ steps.deploy.outputs.revision }}"
+        if [ -z "$DEPLOYED_REV" ]; then
+          DEPLOYED_REV=$(gcloud run revisions list --service=$SERVICE \
+            --region=$REGION --limit=1 \
+            --sort-by='~metadata.creationTimestamp' \
+            --format='value(metadata.name)')
+        fi
+        if [ "$SERVING_REV" != "$DEPLOYED_REV" ]; then
+          echo "::error::Revision mismatch: deployed $DEPLOYED_REV but $SERVING_REV is serving"
           exit 1
         fi
-        echo "Version verified: $DEPLOYED_VERSION"
+        echo "Revision verified: $SERVING_REV is serving 100% traffic"
 
         # 3. Verify metrics endpoint (confirms multi-table DB access)
         METRICS=$(curl -sf "$URL/metrics")
@@ -217,9 +229,14 @@ jobs:
       if: failure() && steps.deploy.outcome == 'success'
       run: |
         echo "Deployment verification failed — rolling back..."
+        # Skip the just-deployed broken revision; status filter excludes
+        # tagged-only previews that never went healthy.
+        DEPLOYED_REV="${{ steps.deploy.outputs.revision }}"
         PREV_REV=$(gcloud run revisions list \
           --service=$SERVICE --region=$REGION \
-          --limit=2 --format='value(REVISION)' | tail -1)
+          --filter="status.conditions.status=True AND metadata.name!=$DEPLOYED_REV" \
+          --sort-by='~metadata.creationTimestamp' \
+          --limit=1 --format='value(metadata.name)')
         if [ -n "$PREV_REV" ]; then
           gcloud run services update-traffic $SERVICE \
             --region=$REGION --to-revisions=$PREV_REV=100


### PR DESCRIPTION
## Summary
Hotfix to make the production Cloud Run revision actually boot. The previous deploy in run [25277494482](https://github.com/cardox6/aifeelnews/actions/runs/25277494482) finished migrations + Cloud Run deploy successfully, but the new revision crashed at startup with:

\`\`\`
RuntimeError: DATABASE_URL is not configured.
\`\`\`

The Deploy to Cloud Run step was missing the runtime configuration the live 2026-03-16 revision (\`aifeelnews-web-00082-lwj\`) had. Production stayed on the old revision.

## Fixes

**Runtime env (matches the working live revision):**
- \`DATABASE_URL\` (Unix-socket form, mounted by \`--add-cloudsql-instances\`)
- \`GCP_PROJECT_ID\`, \`SENTIMENT_PROVIDER=GCP_NL\`
- Secret refs: \`GCP_NLP_KEY_JSON\`, \`FIREBASE_SERVICE_ACCOUNT_JSON\`
- \`--add-cloudsql-instances\` flag so Cloud Run mounts the socket

**Verify deployment step:** Was comparing \`\$GITHUB_SHA\` against the app's hardcoded \`/version\` response (\`1.0.1\`) — guaranteed mismatch. Now checks Cloud Run revision identity via \`gcloud\`.

**Rollback step:** Was picking the second-to-last revision regardless of state, so it tried to "roll back" to the orphan \`pr-45\` preview that never booted. Now filters to revisions with \`status.conditions.status=True\` and excludes the just-deployed one.

## Why this PR exists
Multiple gaps surfaced sequentially as deeper issues were unblocked:
1. PR #48: Cloud SQL Auth Proxy + lazy-init engine for migrations (✅ unblocked migrations)
2. PR #53: switch migration user from \`aifeelnews\` to \`postgres\` (✅ matches reality)
3. (manual) IAM grants: \`secretmanager.secretAccessor\` + \`cloudsql.client\` on \`github-actions-sa\`
4. (manual) Password rotation x3 to clear \`\r\` and \`%\` chars
5. **This PR:** runtime env + verify/rollback bugs

## Path B (separate, not in this PR)
- Replace \`postgres\` superuser with least-privilege \`aifeelnews\` user (Terraform)
- Move \`DATABASE_URL\` connection string into Secret Manager (no password in revision spec)
- Codify all manual IAM grants in \`infra/main.tf\`
- Sync \`docs/CICD_PIPELINE.md\` and \`docs/CLOUD_SERVICE_CODE_MAP.md\`
- Add \`%%\` escape in \`alembic/env.py\` for password robustness
- Disable broken \`db-password\` versions 1-4 in Secret Manager

## Test plan
- [ ] CI \`test\` job passes
- [ ] Merge → production deploy on main succeeds end-to-end
- [ ] Verify \`/health\`, \`/api/v1/articles/?limit=1\` return 200 against new revision
- [ ] Confirm new revision serving 100% traffic
- [ ] Issue #29 manually closed