### PR TITLE
fix: security controls + observability + cybersecurity & DB submission docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot — automated dependency upgrade PRs.
+#
+# GitHub's default security alerts already raise PRs for known CVEs in
+# any tracked manifest. This file adds *scheduled* version updates so we
+# also pick up routine maintenance releases (not just security ones)
+# before they accumulate into one big bump.
+#
+# Update cadence is weekly on Monday morning UTC so the queue is small
+# and reviewable in one sitting at the start of the week.
+version: 2
+
+updates:
+  # Backend (FastAPI + SQLAlchemy + GCP SDKs).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Frontend (Svelte + Vite + Firebase SDK).
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions versions in workflow files. Without this entry,
+  # third-party actions float on tag pointers and a hijacked tag could
+  # ship malicious steps. SHA-pinning + Dependabot updates closes that.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,59 @@
+name: Security Scanning
+
+# Triggered on every push/PR against protected branches and once per
+# week so newly disclosed CVEs in pinned dependencies surface within 7
+# days even if no code changes ship. Manual runs are also allowed via
+# workflow_dispatch so a maintainer can re-scan after a CVE notification
+# without pushing.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC
+  workflow_dispatch:
+
+# Read-only by default — individual jobs grant only what they need.
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: pip-audit (CVE scan on pinned deps)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      # --strict makes the job fail on the first vulnerability so CI
+      # turns red rather than silently warning. Use --ignore-vuln to
+      # suppress a specific advisory while a fix is in progress.
+      - name: Run pip-audit against requirements.txt
+        run: pip-audit -r requirements.txt --strict
+
+  gitleaks:
+    name: gitleaks (secret-leak scan)
+    runs-on: ubuntu-latest
+    permissions:
+      # gitleaks-action posts a comment summary on PRs.
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout (full history for full-repo scan)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,15 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
 
+  # Secret-leak scanner. Catches AWS keys, GCP service-account JSON,
+  # Firebase secrets, generic high-entropy strings, etc., before they
+  # land in a commit. Pinned to a tagged release so behaviour is
+  # reproducible across contributor machines.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.7
     hooks:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ pre-commit run --all-files        # All hooks
 | [CI/CD Pipeline](docs/CICD_PIPELINE.md) | Pipeline diagram, workflow details, secrets inventory |
 | [Multi-Environment Strategy](docs/MULTI_ENVIRONMENT_STRATEGY.md) | Terraform tfvars approach, prod vs staging |
 | [Cost & Scalability](docs/COST_AND_SCALABILITY.md) | Monthly breakdown, scaling analysis, cost projections |
+| [Threat Model](docs/THREAT_MODEL.md) | STRIDE per component (web, DB, auth, scheduler, CI/CD, ingestion) |
+| [Security Measures](docs/SECURITY_MEASURES.md) | Implemented controls catalogued by layer with code citations |
 
 ## Key Design Decisions
 
@@ -174,20 +176,25 @@ pre-commit run --all-files        # All hooks
 
 ## Security
 
+Detailed STRIDE analysis in [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md); the implemented controls are catalogued in [docs/SECURITY_MEASURES.md](docs/SECURITY_MEASURES.md). Quick summary below.
+
 ### Authentication & Authorization
 - Firebase Auth (Google Sign-In) with server-side ID token verification (`app/deps/auth.py`)
 - Protected endpoints require `Authorization: Bearer <firebase-id-token>` header
 - User records created on first authenticated request, linked by Firebase UID
+- Cloud Scheduler endpoints (`/api/v1/trigger-ingestion`, `/api/v1/cleanup`) require a Google-signed OIDC token verified server-side (`app/deps/oidc.py`)
 
 ### Secret Management
-- Production: GCP Secret Manager (`db-password`, `mediastack-api-key`, `firebase-service-account-json`)
+- Production: GCP Secret Manager (6 secrets — `db-password`, `mediastack-api-key`, `firebase-service-account-json`, `aifeelnews-gcp-nlp-key`, `aifeelnews-db-password`, `aifeelnews-database-url`)
+- `DATABASE_URL` is mounted as a `secretKeyRef` in the Cloud Run revision spec (not a literal env var)
 - Cascading lookup: Secret Manager → environment variable → default (`app/utils/secrets.py`)
-- No secrets in code or version control — `.env` is gitignored
+- No secrets in code or version control — `.env` is gitignored, gitleaks pre-commit + CI scans every commit
 
 ### API Security
 - CORS restricted to specific origins (Firebase Hosting URLs + localhost) — no wildcard
 - Parameterized queries only — no f-string SQL anywhere (BigQuery uses `@param` + `QueryJobConfig`)
 - Input validation via Pydantic schemas on all request/response models
+- Per-IP rate limiting via `slowapi` — 30/min analytics, 60/min sentiment, 6/h scheduler endpoints
 
 ### Data Protection
 - Article content truncated to 1024 chars with 7-day TTL expiry (data minimization)
@@ -195,10 +202,17 @@ pre-commit run --all-files        # All hooks
 - Never store full article bodies (copyright + privacy)
 
 ### Infrastructure Security
-- Least-privilege IAM: `cloudrun-sa` (5 roles), `github-actions-sa` (2 roles)
-- Cloud SQL: SSL/TLS enforced (`require_ssl = true` in Terraform) — rejects unencrypted connections
+- Least-privilege IAM: `cloudrun-sa` (5 roles — `secretmanager.secretAccessor`, `cloudsql.client`, `serviceusage.serviceUsageConsumer`, `bigquery.dataEditor`, `bigquery.jobUser`)
+- `github-actions-sa` (6 roles — `run.admin`, `artifactregistry.writer`, `iam.serviceAccountUser` on `cloudrun-sa`, `secretmanager.secretAccessor`, `cloudsql.client`, `serviceusage.serviceUsageConsumer`)
+- Cloud SQL: SSL enforced (`ssl_mode = "ENCRYPTED_ONLY"` in Terraform) — rejects unencrypted connections
+- Migrations run as least-privilege `aifeelnews` Postgres role (no SUPERUSER, no CREATEDB)
 - Non-root container users (`app`, `worker`, `scheduler`) in all Docker images
-- CI/CD secrets stored in GitHub Secrets, injected at build time only
+- CI/CD secrets stored in GitHub Secrets, `GCP_SA_KEY` scoped to the `production` GitHub environment
+
+### Supply-Chain Security
+- Dependabot (active) — automated security upgrade PRs for `pip` + `npm`
+- `pip-audit` weekly + on every PR — fails CI on any pinned dep with a known CVE (`.github/workflows/security.yml`)
+- `gitleaks` pre-commit + CI — secret-leak scanner runs locally and on every push (full-history scan + weekly cron)
 
 ## License
 

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -3,6 +3,7 @@ from .crawler import CrawlerConfig
 from .database import DatabaseConfig
 from .ingestion import IngestionConfig
 from .scheduler import SchedulerConfig
+from .security import SecurityConfig
 from .sentiment import SentimentConfig
 from .ui import UIConfig
 
@@ -16,6 +17,7 @@ class AppConfig:
         self.sentiment = SentimentConfig()
         self.ui = UIConfig()
         self.bigquery = BigQueryConfig()
+        self.security = SecurityConfig()
 
     @property
     def env(self) -> str:

--- a/app/config/security.py
+++ b/app/config/security.py
@@ -1,0 +1,54 @@
+"""Security-related runtime configuration.
+
+Centralises the inputs needed for OIDC token verification on Cloud
+Scheduler endpoints and for the slowapi rate limiter. Kept as a separate
+Pydantic settings module so other concerns (database, ingestion) remain
+unaware of security wiring.
+"""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SecurityConfig(BaseSettings):
+    """Security configuration loaded from environment variables.
+
+    Notes on defaults:
+    - ``cloud_run_url`` defaults to the production service URL so OIDC
+      audience verification works out of the box on Cloud Run. Override
+      with the ``CLOUD_RUN_URL`` env var for staging or a different
+      project.
+    - ``scheduler_service_account`` is the email of the GCP service
+      account Cloud Scheduler is configured with (see ``infra/main.tf``
+      ``oidc_token`` block). If a token is signed by any other service
+      account, OIDC verification will reject it.
+    - ``env`` mirrors the global ``ENV`` variable. When it is anything
+      other than ``production`` the OIDC dependency bypasses verification
+      with a logged warning so local development against ``uvicorn`` and
+      the test suite continue to work.
+    """
+
+    env: str = Field(default="local", alias="ENV")
+    cloud_run_url: str = Field(
+        default="https://aifeelnews-web-813770885946.europe-west1.run.app",
+        alias="CLOUD_RUN_URL",
+    )
+    scheduler_service_account: str = Field(
+        default="cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com",
+        alias="SCHEDULER_SERVICE_ACCOUNT",
+    )
+
+    # Rate limit defaults — overridable per-environment without code change
+    rate_limit_analytics: str = Field(default="30/minute", alias="RATE_LIMIT_ANALYTICS")
+    rate_limit_sentiment: str = Field(default="60/minute", alias="RATE_LIMIT_SENTIMENT")
+    rate_limit_scheduler: str = Field(default="6/hour", alias="RATE_LIMIT_SCHEDULER")
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    @property
+    def is_production(self) -> bool:
+        return self.env == "production"

--- a/app/database.py
+++ b/app/database.py
@@ -26,7 +26,10 @@ def _initialize() -> None:
             "Set DATABASE_URL (production) or LOCAL_DATABASE_URL (local) "
             "before instantiating a database session."
         )
-    _engine = create_engine(url, echo=False)
+    # pool_pre_ping detects connections killed by Cloud SQL idle-timeout
+    # before SQLAlchemy hands them to a request; pool_recycle forces a
+    # refresh every hour so long-lived idle pools don't hit DB-side TTLs.
+    _engine = create_engine(url, echo=False, pool_pre_ping=True, pool_recycle=3600)
     _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
 
 

--- a/app/deps/auth.py
+++ b/app/deps/auth.py
@@ -1,9 +1,13 @@
+import logging
+
 from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.user import User
 from app.services.firebase_admin import verify_firebase_token
+
+logger = logging.getLogger(__name__)
 
 
 def get_current_user(
@@ -18,7 +22,10 @@ def get_current_user(
 
     try:
         decoded = verify_firebase_token(token)
-    except Exception:
+    except Exception as e:
+        # Log the underlying cause for forensics; the client only sees
+        # the generic "Invalid token" so we don't leak which step failed.
+        logger.warning("Firebase token verification failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
         )

--- a/app/deps/oidc.py
+++ b/app/deps/oidc.py
@@ -1,0 +1,131 @@
+"""OIDC token verification for Cloud Scheduler-triggered endpoints.
+
+Cloud Scheduler can attach a Google-signed OIDC ID token to outbound
+HTTP requests when a job is configured with ``oidc_token``. The token's
+``aud`` claim is the configured audience (we use the Cloud Run service
+URL) and the token's ``email`` claim is the service account that signed
+it.
+
+This module provides a FastAPI dependency that extracts the bearer
+token, verifies its signature against Google's public keys, and asserts
+both the audience and the signing service account match what we expect
+in production. In any non-production environment the dependency logs a
+warning and lets the request through so ``pytest`` and local
+``uvicorn`` runs do not require a real GCP token.
+
+Reference:
+- https://cloud.google.com/run/docs/triggering/using-scheduler#authentication
+- https://google-auth.readthedocs.io/en/master/reference/google.oauth2.id_token.html
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Header, HTTPException, status
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+
+from app.config import config
+
+logger = logging.getLogger(__name__)
+
+
+def _bypass_for_non_production() -> bool:
+    """Return True if OIDC verification should be skipped in this env.
+
+    Verification is skipped for any ``ENV`` other than ``production``.
+    A warning is logged the first time per request so the bypass is
+    visible in test output and local dev logs but not silent.
+    """
+
+    if config.security.is_production:
+        return False
+    logger.warning(
+        "OIDC verification bypassed (ENV=%s). This must never happen in production.",
+        config.security.env,
+    )
+    return True
+
+
+def verify_scheduler_oidc(
+    authorization: str | None = Header(default=None),
+) -> dict[str, str]:
+    """FastAPI dependency that verifies a Cloud Scheduler OIDC token.
+
+    Behaviour:
+    - In non-production environments, returns a stub claims dict and
+      logs a warning. This keeps unit tests and local development
+      runnable without GCP credentials.
+    - In production, requires an ``Authorization: Bearer <token>``
+      header. The token is verified against the configured audience
+      (the Cloud Run service URL) using ``google-auth``. The signing
+      service account email must match
+      ``config.security.scheduler_service_account``.
+    - Any failure (missing header, malformed token, bad signature,
+      wrong audience, wrong signer) raises ``HTTPException(401)`` with
+      a non-leaky message.
+
+    Returns:
+        The verified token claims dict on success. Routes that don't
+        need the claims can ignore the return value; the dependency's
+        side effect is the 401 raised on failure.
+    """
+
+    if _bypass_for_non_production():
+        return {"sub": "local-dev", "email": "local-dev@example.com"}
+
+    if not authorization or not authorization.startswith("Bearer "):
+        # 401 over 403 because the request never produced a valid
+        # credential — auth is missing, not insufficient.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing OIDC bearer token",
+        )
+
+    token = authorization.split(" ", 1)[1].strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Empty OIDC bearer token",
+        )
+
+    expected_audience = config.security.cloud_run_url
+    expected_service_account = config.security.scheduler_service_account
+
+    try:
+        claims = id_token.verify_oauth2_token(
+            token,
+            google_requests.Request(),
+            audience=expected_audience,
+        )
+    except ValueError as exc:
+        # google-auth raises ValueError for any verification failure
+        # (expired, bad signature, wrong audience). We log the cause
+        # but only return a generic message to the caller.
+        logger.warning("OIDC token rejected: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid OIDC token",
+        ) from exc
+
+    signer_email = claims.get("email", "")
+    if signer_email != expected_service_account:
+        logger.warning(
+            "OIDC token signer %s does not match expected %s",
+            signer_email,
+            expected_service_account,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Untrusted OIDC token signer",
+        )
+
+    if not claims.get("email_verified", False):
+        logger.warning("OIDC token signer email not verified: %s", signer_email)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="OIDC token signer email not verified",
+        )
+
+    return dict(claims)

--- a/app/jobs/backfill_bigquery.py
+++ b/app/jobs/backfill_bigquery.py
@@ -25,8 +25,11 @@ from app.models.article_entity import ArticleEntity
 from app.models.entity import Entity
 from app.models.sentiment_analysis import SentimentAnalysis
 from app.models.source import Source
+from app.utils.logging import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
+# Use the central structured-logging setup so standalone backfill runs
+# emit the same Cloud-Logging-friendly JSON as the web app.
+setup_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -26,6 +26,7 @@ from app.models.article import Article
 from app.models.article_content import ArticleContent
 from app.models.crawl_job import CrawlJob, CrawlStatus
 from app.models.sentiment_analysis import SentimentAnalysis
+from app.utils.logging import setup_logging
 from app.utils.robots import (
     check_robots_compliance,
     get_domain_from_url,
@@ -34,8 +35,9 @@ from app.utils.robots import (
 from app.utils.sentiment import analyze_sentiment
 from app.utils.ttl import calculate_content_expiry
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Use the central structured-logging setup so standalone worker runs
+# emit the same Cloud-Logging-friendly JSON as the web app.
+setup_logging()
 logger = logging.getLogger(__name__)
 
 # Track last crawl time per domain for rate limiting
@@ -111,7 +113,7 @@ def extract_article_text(html_content: str, url: str) -> Optional[str]:
         return None
 
     except Exception as e:
-        logger.error(f"Error extracting text from {url}: {e}")
+        logger.error("Error extracting text from %s: %s", url, e, exc_info=True)
         return None
 
 
@@ -311,8 +313,10 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                             )
                             if not canonical:
                                 logger.error(
-                                    f"Entity {entity_name[:80]}/{ent.type} "
-                                    "missing after IntegrityError"
+                                    "Entity %s/%s missing after IntegrityError",
+                                    entity_name[:80],
+                                    ent.type,
+                                    exc_info=True,
                                 )
                                 continue
 
@@ -431,7 +435,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                         sentiment_score=sentiment_score,
                     )
         except Exception as e:
-            logger.debug(f"BigQuery streaming failed (this is optional): {e}")
+            logger.warning("BigQuery streaming failed: %s", e, exc_info=True)
 
         logger.info(f"✅ Successfully crawled and processed: {url}")
         magnitude_info = f", magnitude={magnitude:.3f}" if magnitude else ""
@@ -450,7 +454,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
         return True
 
     except requests.RequestException as e:
-        logger.error(f"❌ Network error crawling {url}: {e}")
+        logger.error("Network error crawling %s: %s", url, e, exc_info=True)
         # Order matters: rollback FIRST clears any aborted-session state from
         # an earlier failed commit (e.g. an IntegrityError on the success
         # path), THEN we set fields on crawl_job, THEN we commit. Setting
@@ -463,12 +467,14 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
         try:
             db.commit()
         except Exception as commit_err:
-            logger.error(f"Failed to record crawl failure: {commit_err}")
+            logger.error(
+                "Failed to record crawl failure: %s", commit_err, exc_info=True
+            )
             db.rollback()
         return False
 
     except Exception as e:
-        logger.error(f"❌ Unexpected error crawling {url}: {e}")
+        logger.error("Unexpected error crawling %s: %s", url, e, exc_info=True)
         # See above — rollback before re-mutating crawl_job. Without this,
         # a failed earlier commit leaves the session in PendingRollbackError
         # and the second commit propagates, the job stays in its prior
@@ -481,7 +487,9 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
         try:
             db.commit()
         except Exception as commit_err:
-            logger.error(f"Failed to record crawl failure: {commit_err}")
+            logger.error(
+                "Failed to record crawl failure: %s", commit_err, exc_info=True
+            )
             db.rollback()
         return False
 
@@ -592,7 +600,9 @@ def run_crawl_worker(max_jobs: int = 5) -> Dict[str, Any]:
                 time.sleep(0.5)
 
             except Exception as e:
-                logger.error(f"❌ Error processing crawl job {job.id}: {e}")
+                logger.error(
+                    "Error processing crawl job %s: %s", job.id, e, exc_info=True
+                )
                 failed_crawls += 1
 
         total_time = time.time() - start_time

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -451,24 +451,38 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
 
     except requests.RequestException as e:
         logger.error(f"❌ Network error crawling {url}: {e}")
-
+        # Order matters: rollback FIRST clears any aborted-session state from
+        # an earlier failed commit (e.g. an IntegrityError on the success
+        # path), THEN we set fields on crawl_job, THEN we commit. Setting
+        # fields before rollback would discard them.
+        db.rollback()
         crawl_job.status = CrawlStatus.FAILED  # type: ignore[assignment]
         crawl_job.error_code = "NETWORK_ERROR"  # type: ignore[assignment]
         crawl_job.error_message = f"Network error: {str(e)}"  # type: ignore[assignment]
         crawl_job.updated_at = datetime.now(timezone.utc)  # type: ignore[assignment]
-        db.commit()
-
+        try:
+            db.commit()
+        except Exception as commit_err:
+            logger.error(f"Failed to record crawl failure: {commit_err}")
+            db.rollback()
         return False
 
     except Exception as e:
         logger.error(f"❌ Unexpected error crawling {url}: {e}")
-
+        # See above — rollback before re-mutating crawl_job. Without this,
+        # a failed earlier commit leaves the session in PendingRollbackError
+        # and the second commit propagates, the job stays in its prior
+        # status (often IN_PROGRESS), and the worker retries it forever.
+        db.rollback()
         crawl_job.status = CrawlStatus.FAILED  # type: ignore
         crawl_job.error_code = "PROCESSING_ERROR"  # type: ignore
         crawl_job.error_message = f"Processing error: {str(e)}"  # type: ignore
         crawl_job.updated_at = datetime.now(timezone.utc)  # type: ignore
-        db.commit()
-
+        try:
+            db.commit()
+        except Exception as commit_err:
+            logger.error(f"Failed to record crawl failure: {commit_err}")
+            db.rollback()
         return False
 
 

--- a/app/jobs/fetch_from_mediastack.py
+++ b/app/jobs/fetch_from_mediastack.py
@@ -82,12 +82,14 @@ def fetch_articles_from_source(source: str) -> list[dict]:
         return data  # type: ignore[no-any-return]
 
     except MediastackAPIError as e:
-        logger.error("Mediastack API error for %s: %s", source, e)
+        logger.error("Mediastack API error for %s: %s", source, e, exc_info=True)
         return []
 
     except (requests.RequestException, requests.HTTPError) as e:
         if _is_production():
-            logger.error("Mediastack request failed for %s: %s", source, e)
+            logger.error(
+                "Mediastack request failed for %s: %s", source, e, exc_info=True
+            )
             return []
         logger.warning(
             "Mediastack request failed for %s: %s — using mock data", source, e
@@ -118,7 +120,7 @@ def fetch_all_sources() -> list[dict]:
             elif articles:
                 real_count += 1
         except Exception as e:
-            logger.error("Unexpected error fetching %s: %s", src, e)
+            logger.error("Unexpected error fetching %s: %s", src, e, exc_info=True)
 
     empty_count = len(SOURCES) - real_count - mock_count
     logger.info(

--- a/app/jobs/normalize_articles.py
+++ b/app/jobs/normalize_articles.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Dict, List
 from urllib.parse import urlparse, urlunparse
 
 from dateutil import parser
 
 from app.utils.sentiment import analyze_sentiment
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_articles(raw: List[Dict]) -> List[Dict]:
@@ -25,10 +28,14 @@ def normalize_articles(raw: List[Dict]) -> List[Dict]:
             continue
         seen.add(key)
 
-        # parse date
+        # parse date — dateutil raises ValueError on bad strings, TypeError
+        # when passed something non-stringy (None, int) and OverflowError
+        # on absurd values. Catch the data-shape failures, let anything
+        # else propagate.
         try:
             published = parser.isoparse(item["published_at"])
-        except Exception:
+        except (ValueError, TypeError, OverflowError) as e:
+            logger.warning("Failed to parse published_at for article %s: %s", canon, e)
             published = None
 
         # sentiment

--- a/app/jobs/run_ingestion.py
+++ b/app/jobs/run_ingestion.py
@@ -8,8 +8,11 @@ from app.jobs.crawl_worker import run_crawl_worker
 from app.jobs.fetch_from_mediastack import fetch_all_sources
 from app.jobs.ingest_articles import ingest_articles
 from app.jobs.normalize_articles import normalize_articles
+from app.utils.logging import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
+# Use the central structured-logging setup so standalone job runs emit
+# the same Cloud-Logging-friendly JSON as the web app.
+setup_logging()
 # silence all INFO‐level SQL logs:
 logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 

--- a/app/jobs/ttl_cleanup.py
+++ b/app/jobs/ttl_cleanup.py
@@ -13,10 +13,12 @@ from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
 from app.models.article_content import ArticleContent
+from app.utils.logging import setup_logging
 from app.utils.ttl import get_ttl_info
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Use the central structured-logging setup so standalone cleanup runs
+# emit the same Cloud-Logging-friendly JSON as the web app.
+setup_logging()
 logger = logging.getLogger(__name__)
 
 
@@ -69,7 +71,7 @@ def cleanup_expired_content(db: Session | None = None) -> dict:
 
     except Exception as e:
         db.rollback()
-        logger.error(f"Error during TTL cleanup: {str(e)}")
+        logger.error("Error during TTL cleanup: %s", e, exc_info=True)
         error_time = datetime.now(timezone.utc)
         return {
             "status": "error",
@@ -121,7 +123,7 @@ def get_content_statistics(db: Session | None = None) -> dict:
         }
 
     except Exception as e:
-        logger.error(f"Error getting content statistics: {str(e)}")
+        logger.error("Error getting content statistics: %s", e, exc_info=True)
         error_time = datetime.now(timezone.utc)
         return {"error": str(e), "check_time": error_time.isoformat()}
     finally:

--- a/app/main.py
+++ b/app/main.py
@@ -3,20 +3,22 @@ import os
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 
 from app import models  # noqa: F401
+from app.config import config as _app_config
 from app.database import Base, engine  # noqa: F401
+from app.deps.oidc import verify_scheduler_oidc
 from app.routers import articles, bookmarks, sources, users
 from app.utils.logging import setup_logging
 
 # Structured logging (JSON in production, plain text locally)
 setup_logging()
 logger = logging.getLogger(__name__)
-
-# Log config status at startup for early detection of misconfiguration
-from app.config import config as _app_config  # noqa: E402
 
 logger.info(
     "aiFeelNews starting [env=%s, mediastack_key=%s]",
@@ -59,6 +61,24 @@ except Exception as e:
 
 APP_VERSION = os.getenv("APP_VERSION", "1.0.1")
 app = FastAPI(title="aiFeelNews API", version=APP_VERSION)
+
+# --- Rate limiting (slowapi) -------------------------------------------------
+# `get_remote_address` keys requests by client IP. Cloud Run forwards the real
+# client IP via X-Forwarded-For; slowapi reads the request object's `client.host`
+# which Starlette populates from that header when running behind a proxy.
+# We register the limiter on app.state so route decorators can find it via
+# `request.app.state.limiter` and add a handler that translates the
+# RateLimitExceeded exception into a clean 429 response.
+limiter = Limiter(key_func=get_remote_address)
+app.state.limiter = limiter
+# slowapi's handler signature is `(Request, RateLimitExceeded) -> Response`
+# whereas Starlette's `add_exception_handler` expects the second arg to be
+# typed as `Exception`. The function itself works at runtime (RateLimitExceeded
+# IS-A Exception); we cast away the false-positive type mismatch here.
+app.add_exception_handler(
+    RateLimitExceeded,
+    _rate_limit_exceeded_handler,  # type: ignore[arg-type]
+)
 
 # Allowed origins for CORS (production Firebase Hosting + local dev)
 ALLOWED_ORIGINS = [
@@ -227,8 +247,18 @@ def metrics() -> dict[str, Any]:
 
 
 @app.post("/api/v1/trigger-ingestion")
-def trigger_ingestion() -> dict[str, str]:
-    """Trigger news ingestion pipeline - used by Cloud Scheduler."""
+@limiter.limit(_app_config.security.rate_limit_scheduler)
+def trigger_ingestion(
+    request: Request,
+    _claims: dict[str, str] = Depends(verify_scheduler_oidc),
+) -> dict[str, str]:
+    """Trigger news ingestion pipeline - used by Cloud Scheduler.
+
+    Protected by Cloud Scheduler OIDC verification (see
+    ``app/deps/oidc.py``) so only Scheduler running as ``cloudrun-sa``
+    can hit this. Rate limited to 6/hour by default to defend against
+    accidental loops; Scheduler's own cadence is every 8 hours.
+    """
     try:
         from app.config import config
         from app.jobs.run_ingestion import run_ingestion
@@ -254,8 +284,17 @@ def trigger_ingestion() -> dict[str, str]:
 
 
 @app.post("/api/v1/cleanup")
-def trigger_cleanup() -> dict[str, Any]:
-    """Trigger database cleanup - used by Cloud Scheduler for maintenance."""
+@limiter.limit(_app_config.security.rate_limit_scheduler)
+def trigger_cleanup(
+    request: Request,
+    _claims: dict[str, str] = Depends(verify_scheduler_oidc),
+) -> dict[str, Any]:
+    """Trigger database cleanup - used by Cloud Scheduler for maintenance.
+
+    Protected by Cloud Scheduler OIDC verification (see
+    ``app/deps/oidc.py``). Rate limited to 6/hour as a defence-in-depth
+    measure; Scheduler runs cleanup once per day.
+    """
     try:
         from app.database import SessionLocal
         from app.utils.cleanup import full_database_cleanup

--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,7 @@ try:
 
     sentiment_available = True
 except Exception as e:
-    logger.warning(f"Could not import sentiment router: {e}")
+    logger.warning("Could not import sentiment router: %s", e, exc_info=True)
     sentiment_available = False
 
 # Import entities router with error handling
@@ -45,7 +45,7 @@ try:
 
     entities_available = True
 except Exception as e:
-    logger.warning(f"Could not import entities router: {e}")
+    logger.warning("Could not import entities router: %s", e, exc_info=True)
     entities_available = False
 
 # Import analytics router with error handling
@@ -56,7 +56,7 @@ try:
 
     analytics_available = True
 except Exception as e:
-    logger.warning(f"Could not import analytics router: {e}")
+    logger.warning("Could not import analytics router: %s", e, exc_info=True)
     analytics_available = False
 
 APP_VERSION = os.getenv("APP_VERSION", "1.0.1")
@@ -122,7 +122,7 @@ try:
 
     db_analytics_available = True
 except Exception as e:
-    logger.warning(f"Could not import db_analytics router: {e}")
+    logger.warning("Could not import db_analytics router: %s", e, exc_info=True)
 
 if db_analytics_available and db_analytics_mod:
     app.include_router(db_analytics_mod.router, prefix="/api/v1/db-analytics")
@@ -154,7 +154,11 @@ def health_check() -> dict[str, str]:
     except Exception as e:
         from fastapi import HTTPException
 
-        raise HTTPException(status_code=503, detail=f"Service unhealthy: {e}")
+        logger.error("Service unavailable at health DB check: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable",
+        )
 
 
 # Version endpoint for deployment verification
@@ -183,7 +187,11 @@ def readiness_check() -> dict[str, str]:
     except Exception as e:
         from fastapi import HTTPException
 
-        raise HTTPException(status_code=503, detail=f"Service not ready: {e}")
+        logger.error("Service unavailable at readiness DB check: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable",
+        )
 
 
 @app.get("/metrics", tags=["Meta"])
@@ -237,7 +245,7 @@ def metrics() -> dict[str, Any]:
             "database": {"status": "connected"},
         }
     except Exception as e:
-        logger.error(f"Metrics collection failed: {e}")
+        logger.error("Metrics collection failed: %s", e, exc_info=True)
         return {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e),
@@ -278,8 +286,10 @@ def trigger_ingestion(
     except Exception as e:
         from fastapi import HTTPException
 
+        logger.error("Service unavailable at trigger-ingestion: %s", e, exc_info=True)
         raise HTTPException(
-            status_code=500, detail=f"Ingestion pipeline failed: {str(e)}"
+            status_code=503,
+            detail="Service temporarily unavailable",
         )
 
 
@@ -316,6 +326,8 @@ def trigger_cleanup(
     except Exception as e:
         from fastapi import HTTPException
 
+        logger.error("Service unavailable at cleanup: %s", e, exc_info=True)
         raise HTTPException(
-            status_code=500, detail=f"Database cleanup failed: {str(e)}"
+            status_code=503,
+            detail="Service temporarily unavailable",
         )

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -1,8 +1,15 @@
-"""BigQuery-powered analytics endpoints for dashboard consumption."""
+"""BigQuery-powered analytics endpoints for dashboard consumption.
+
+Rate limit: ``config.security.rate_limit_analytics`` (default 30/minute)
+applied per-IP via slowapi. Decorators look up the limiter via
+``request.app.state.limiter`` set in ``app/main.py``.
+"""
 
 from typing import Dict, List, Optional, Union
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
 from app.config import config
 from app.schemas.analytics import (
@@ -26,6 +33,13 @@ from app.services.bigquery import (
 
 router = APIRouter(tags=["Analytics"])
 
+# Local limiter handle. The limiter object on app.state is the canonical
+# one (registered in app/main.py); keeping a module-level Limiter here
+# keeps the decorators readable and works because slowapi looks up the
+# canonical limiter via request.app.state.limiter at call time.
+_limiter = Limiter(key_func=get_remote_address)
+_RATE = config.security.rate_limit_analytics
+
 
 def _disabled_response() -> Dict[str, str]:
     return {"message": "BigQuery analytics is not enabled"}
@@ -35,7 +49,9 @@ def _disabled_response() -> Dict[str, str]:
     "/trends",
     response_model=Union[List[SentimentTrendPoint], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def sentiment_trends(
+    request: Request,
     days: int = Query(30, ge=1, le=365, description="Lookback window in days"),
     source: Optional[str] = Query(None, description="Filter by source name"),
 ) -> Union[List[SentimentTrendPoint], Dict[str, str]]:
@@ -49,7 +65,9 @@ def sentiment_trends(
     "/sources",
     response_model=Union[List[SourceComparison], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def source_comparison(
+    request: Request,
     days: int = Query(30, ge=1, le=365),
 ) -> Union[List[SourceComparison], Dict[str, str]]:
     """Compare sentiment distribution across news sources."""
@@ -62,7 +80,9 @@ def source_comparison(
     "/categories",
     response_model=Union[List[CategoryBreakdown], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def category_breakdown(
+    request: Request,
     days: int = Query(30, ge=1, le=365),
 ) -> Union[List[CategoryBreakdown], Dict[str, str]]:
     """Sentiment breakdown by article category."""
@@ -75,7 +95,9 @@ def category_breakdown(
     "/pipeline",
     response_model=Union[List[PipelineRun], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def pipeline_health(
+    request: Request,
     days: int = Query(7, ge=1, le=90),
 ) -> Union[List[PipelineRun], Dict[str, str]]:
     """Ingestion pipeline run history and health metrics."""
@@ -88,7 +110,9 @@ def pipeline_health(
     "/entities/top",
     response_model=Union[List[TopEntity], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def top_entities(
+    request: Request,
     days: int = Query(30, ge=1, le=365),
     entity_type: Optional[str] = Query(None, description="Filter by entity type"),
     limit: int = Query(20, ge=1, le=100),
@@ -103,7 +127,9 @@ def top_entities(
     "/entities/sentiment",
     response_model=Union[List[EntitySentiment], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def entity_sentiment(
+    request: Request,
     days: int = Query(30, ge=1, le=365),
     entity_type: Optional[str] = Query(None, description="Filter by entity type"),
     limit: int = Query(20, ge=1, le=100),
@@ -120,7 +146,9 @@ def entity_sentiment(
     "/categories/nlp",
     response_model=Union[List[NlpCategoryBreakdown], Dict[str, str]],
 )
+@_limiter.limit(_RATE)
 def nlp_categories(
+    request: Request,
     days: int = Query(30, ge=1, le=365),
     limit: int = Query(20, ge=1, le=100),
 ) -> Union[List[NlpCategoryBreakdown], Dict[str, str]]:

--- a/app/routers/bookmarks.py
+++ b/app/routers/bookmarks.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -20,7 +21,17 @@ def create_bookmark(
 ) -> BookmarkRead:
     bookmark = BookmarkModel(user_id=current_user.id, article_id=bm.article_id)
     db.add(bookmark)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # The trg_prevent_duplicate_bookmark trigger (migration e1f2a3b4c5d6)
+        # raises on a duplicate (user_id, article_id). Translate the DB-layer
+        # constraint violation into the correct HTTP semantics: 409 Conflict.
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Bookmark already exists for this article",
+        )
     db.refresh(bookmark)
     return bookmark  # type: ignore[return-value]
 

--- a/app/routers/sentiment.py
+++ b/app/routers/sentiment.py
@@ -1,19 +1,32 @@
 """
 Sentiment analysis API endpoints.
+
+Rate limit: ``config.security.rate_limit_sentiment`` (default 60/minute)
+applied per-IP via slowapi.
 """
 
 from typing import Dict, List, Union
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.config import config
 
 # Import at module level to catch import errors early
 from app.utils.sentiment import get_sentiment_provider_info
 
 router = APIRouter(tags=["sentiment"])
 
+_limiter = Limiter(key_func=get_remote_address)
+_RATE = config.security.rate_limit_sentiment
+
 
 @router.get("/info")
-def get_provider_info() -> Dict[str, Union[str, float, bool, List[str], None]]:
+@_limiter.limit(_RATE)
+def get_provider_info(
+    request: Request,
+) -> Dict[str, Union[str, float, bool, List[str], None]]:
     """
     Get information about the current sentiment analysis provider.
 

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -436,6 +436,7 @@ def _flush_buffer(buffer: List[Dict[str, Any]], table_id: str) -> bool:
 
         errors = client.insert_rows_json(table, list(buffer))
         if errors:
+            # Not in an except block — no exception object to attach.
             logger.error("BigQuery insert errors for %s: %s", table_id, errors)
             return False
 
@@ -449,7 +450,7 @@ def _flush_buffer(buffer: List[Dict[str, Any]], table_id: str) -> bool:
         return True
 
     except Exception as e:
-        logger.error("BigQuery flush failed for %s: %s", table_id, e)
+        logger.error("BigQuery flush failed for %s: %s", table_id, e, exc_info=True)
         return False
 
 
@@ -502,7 +503,7 @@ def get_sentiment_trends(
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("Sentiment trends query failed: %s", e)
+        logger.error("Sentiment trends query failed: %s", e, exc_info=True)
         return []
 
 
@@ -542,7 +543,7 @@ def get_source_comparison(days: int = 30) -> List[Dict[str, Any]]:
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("Source comparison query failed: %s", e)
+        logger.error("Source comparison query failed: %s", e, exc_info=True)
         return []
 
 
@@ -578,7 +579,7 @@ def get_category_breakdown(days: int = 30) -> List[Dict[str, Any]]:
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("Category breakdown query failed: %s", e)
+        logger.error("Category breakdown query failed: %s", e, exc_info=True)
         return []
 
 
@@ -617,7 +618,7 @@ def get_pipeline_stats(days: int = 7) -> List[Dict[str, Any]]:
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("Pipeline stats query failed: %s", e)
+        logger.error("Pipeline stats query failed: %s", e, exc_info=True)
         return []
 
 
@@ -667,7 +668,7 @@ def get_top_entities(
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("Top entities query failed: %s", e)
+        logger.error("Top entities query failed: %s", e, exc_info=True)
         return []
 
 
@@ -712,7 +713,7 @@ def get_entity_sentiment(
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("Entity sentiment query failed: %s", e)
+        logger.error("Entity sentiment query failed: %s", e, exc_info=True)
         return []
 
 
@@ -753,5 +754,5 @@ def get_nlp_categories(
         results = _get_client().query(query, job_config=job_config)
         return [dict(row) for row in results]
     except Exception as e:
-        logger.error("NLP categories query failed: %s", e)
+        logger.error("NLP categories query failed: %s", e, exc_info=True)
         return []

--- a/app/utils/gcp_nlp.py
+++ b/app/utils/gcp_nlp.py
@@ -90,7 +90,7 @@ class GcpNlpClient:
                 self._client = language_v1.LanguageServiceClient()
                 logger.info("Initialized Google Cloud Natural Language client")
             except Exception as e:
-                logger.error(f"Failed to initialize GCP NL client: {e}")
+                logger.error("Failed to initialize GCP NL client: %s", e, exc_info=True)
                 raise
         return self._client
 
@@ -160,20 +160,24 @@ class GcpNlpClient:
             return label, score, magnitude
 
         except gcp_exceptions.InvalidArgument as e:
-            logger.error(f"Invalid argument for GCP NL API: {e}")
+            logger.error("Invalid argument for GCP NL API: %s", e, exc_info=True)
             return "neutral", 0.0, None
 
         except gcp_exceptions.ResourceExhausted as e:
-            logger.error(f"GCP NL API quota exceeded: {e}")
+            logger.error("GCP NL API quota exceeded: %s", e, exc_info=True)
             # Fall back to neutral sentiment when quota exceeded
             return "neutral", 0.0, None
 
         except gcp_exceptions.DeadlineExceeded as e:
-            logger.error(f"GCP NL API timeout: {e}")
+            logger.error("GCP NL API timeout: %s", e, exc_info=True)
             return "neutral", 0.0, None
 
         except Exception as e:
-            logger.error(f"Unexpected error in GCP NL sentiment analysis: {e}")
+            logger.error(
+                "Unexpected error in GCP NL sentiment analysis: %s",
+                e,
+                exc_info=True,
+            )
             # Don't fail the entire process for sentiment analysis errors
             return "neutral", 0.0, None
 
@@ -324,7 +328,9 @@ class GcpNlpClient:
             )
 
         except gcp_exceptions.InvalidArgument as e:
-            logger.error(f"Invalid argument for GCP NL annotateText: {e}")
+            logger.error(
+                "Invalid argument for GCP NL annotateText: %s", e, exc_info=True
+            )
             return AnnotateTextResult(
                 sentiment_label="neutral",
                 sentiment_score=0.0,
@@ -332,7 +338,7 @@ class GcpNlpClient:
             )
 
         except gcp_exceptions.ResourceExhausted as e:
-            logger.error(f"GCP NL API quota exceeded: {e}")
+            logger.error("GCP NL API quota exceeded: %s", e, exc_info=True)
             return AnnotateTextResult(
                 sentiment_label="neutral",
                 sentiment_score=0.0,
@@ -340,7 +346,7 @@ class GcpNlpClient:
             )
 
         except gcp_exceptions.DeadlineExceeded as e:
-            logger.error(f"GCP NL API timeout: {e}")
+            logger.error("GCP NL API timeout: %s", e, exc_info=True)
             return AnnotateTextResult(
                 sentiment_label="neutral",
                 sentiment_score=0.0,
@@ -348,7 +354,9 @@ class GcpNlpClient:
             )
 
         except Exception as e:
-            logger.error(f"Unexpected error in GCP NL annotateText: {e}")
+            logger.error(
+                "Unexpected error in GCP NL annotateText: %s", e, exc_info=True
+            )
             return AnnotateTextResult(
                 sentiment_label="neutral",
                 sentiment_score=0.0,

--- a/app/utils/robots.py
+++ b/app/utils/robots.py
@@ -124,7 +124,9 @@ def fetch_robots_txt(domain: str) -> Optional[RobotFileParser]:
         return rp
 
     except requests.RequestException as e:
-        logger.warning(f"Failed to fetch robots.txt for {domain}: {e}")
+        logger.warning(
+            "Failed to fetch robots.txt for %s: %s", domain, e, exc_info=True
+        )
 
         # Try HTTP fallback if HTTPS failed
         if robots_url.startswith("https://"):
@@ -166,7 +168,7 @@ def fetch_robots_txt(domain: str) -> Optional[RobotFileParser]:
         return None
 
     except Exception as e:
-        logger.error(f"Error parsing robots.txt for {domain}: {e}")
+        logger.error("Error parsing robots.txt for %s: %s", domain, e, exc_info=True)
         return None
 
 
@@ -232,7 +234,7 @@ def is_url_allowed(
             return False, f"Disallowed by robots.txt for user-agent '{user_agent}'"
 
     except Exception as e:
-        logger.error(f"Error checking robots.txt for {url}: {e}")
+        logger.error("Error checking robots.txt for %s: %s", url, e, exc_info=True)
         # On error, be permissive
         return True, f"Error checking robots.txt: {e} (assuming allowed)"
 
@@ -262,7 +264,7 @@ def get_crawl_delay(domain: str, user_agent: str = USER_AGENT) -> Optional[float
             return None
 
     except Exception as e:
-        logger.error(f"Error getting crawl delay for {domain}: {e}")
+        logger.error("Error getting crawl delay for %s: %s", domain, e, exc_info=True)
         return None
 
 
@@ -327,8 +329,11 @@ def check_robots_compliance(url: str) -> Dict[str, Any]:
 if __name__ == "__main__":
     """Test robots.txt compliance with sample URLs."""
 
-    # Configure logging for testing
-    logging.basicConfig(level=logging.INFO)
+    # Use the central structured-logging setup for the standalone
+    # test harness so output matches the production format.
+    from app.utils.logging import setup_logging
+
+    setup_logging()
 
     test_urls = [
         "https://www.bbc.com/news/technology",

--- a/app/utils/sentiment.py
+++ b/app/utils/sentiment.py
@@ -48,10 +48,13 @@ def analyze_sentiment_gcp_nl(text: str) -> Tuple[str, float, Optional[float]]:
         label, score = analyze_sentiment_vader(text)
         return label, score, None
     except Exception as e:
-        logger.error(f"Error in GCP NL sentiment analysis: {e}")
+        logger.warning(
+            "GCP NL analyzeSentiment failed: %s; falling back to VADER",
+            e,
+            exc_info=True,
+        )
         # Fall back to VADER
         if config.sentiment.enable_fallback:
-            logger.info("Falling back to VADER sentiment analysis")
             label, score = analyze_sentiment_vader(text)
             return label, score, None
         else:
@@ -73,9 +76,11 @@ def annotate_text_gcp_nl(text: str) -> Optional[AnnotateTextResult]:
         logger.warning(f"GCP NL client not available: {e}")
         return None
     except Exception as e:
-        logger.error(f"Error in GCP NL annotateText: {e}")
-        if config.sentiment.enable_fallback:
-            logger.info("annotateText failed, caller should fallback to VADER")
+        logger.warning(
+            "GCP NL annotateText failed: %s; falling back to VADER",
+            e,
+            exc_info=True,
+        )
         return None
 
 

--- a/docs/COST_AND_SCALABILITY.md
+++ b/docs/COST_AND_SCALABILITY.md
@@ -33,10 +33,10 @@ Every architectural choice was evaluated for cost impact:
   - *Serverless (Neon, Supabase)*: Would reduce cost but adds vendor lock-in beyond GCP. Cloud SQL keeps the stack on one platform.
   - *Firestore*: Free tier is generous, but the data model is inherently relational (articles, sources, entities, bookmarks). Shoehorning into a document DB would compromise the database module assessment.
 
-### PITR Disabled (Point-in-Time Recovery)
-- **Cost impact**: Saves ~30% on Cloud SQL backup costs
-- **Risk**: Can only restore to daily backup snapshots, not arbitrary points in time
-- **Why acceptable**: Article data is recoverable by re-running ingestion from Mediastack. No user-generated content would be lost (bookmarks are low-volume).
+### PITR Enabled (Point-in-Time Recovery)
+- **Cost impact**: ~$0.15/month additional at current data volume (10GB disk on `db-f1-micro`). PITR retains write-ahead-log segments for the backup retention window so recovery can target a specific timestamp, not just the last nightly snapshot.
+- **Why acceptable**: At this disk size the additional backup-storage charge is negligible relative to the ~$8/month base instance cost, and the recovery semantics it provides (down to a specific second within the retention window) are worth the rounding error.
+- **Configuration:** [infra/main.tf:75-79](../infra/main.tf#L75-L79) — `point_in_time_recovery_enabled = true` under `backup_configuration`.
 
 ### BigQuery for Analytics (OLAP Separation)
 - **Cost impact**: $0 at current scale (well within free tier)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -162,6 +162,47 @@ Composite and performance indexes are listed in [ER_Diagram.md § Composite & Pe
 
 ---
 
+## 4A. Transactions and ACID
+
+The application uses SQLAlchemy 2.0 sessions configured with `autocommit=False, autoflush=False` ([app/database.py:32-33](../app/database.py#L32-L33)). Each request scope yields a session via `get_db()` ([app/database.py:49-57](../app/database.py#L49-L57)); the route handler runs inside it; the session is closed in a `finally` block — pending changes are implicitly rolled back on any unhandled exception.
+
+**Atomicity policies by component:**
+
+| Component | Commit policy | Rationale |
+|-----------|---------------|-----------|
+| API write routes ([app/routers/bookmarks.py](../app/routers/bookmarks.py), [app/routers/sources.py](../app/routers/sources.py), [app/deps/auth.py](../app/deps/auth.py)) | Per-request | Single logical operation per HTTP request. The implicit transaction commits at the end of the handler. |
+| Batch ingest job ([app/jobs/ingest_articles.py](../app/jobs/ingest_articles.py)) | Per-batch | Whole-batch atomicity — partial inserts on failure are undesirable. The implicit transaction rolls back the entire batch if any insert fails the URL UNIQUE check. |
+| Crawl worker ([app/jobs/crawl_worker.py](../app/jobs/crawl_worker.py)) | Per-article | Bounds the work lost on worker crash to one article. Status updates commit at each decision point so a retry can resume. |
+| TTL cleanup ([app/utils/cleanup.py](../app/utils/cleanup.py), [app/jobs/ttl_cleanup.py](../app/jobs/ttl_cleanup.py)) | Per-job | Idempotent bulk DELETEs; partial completion is harmless on retry. |
+
+**Constraint enforcement and HTTP-status mapping:**
+
+The `trg_prevent_duplicate_bookmark` trigger raises `IntegrityError` on a duplicate `(user_id, article_id)`. The bookmark create handler catches that exception, calls `db.rollback()`, and translates it into HTTP 409 Conflict ([app/routers/bookmarks.py:16-36](../app/routers/bookmarks.py#L16-L36)):
+
+```python
+try:
+    db.commit()
+except IntegrityError:
+    db.rollback()
+    raise HTTPException(status_code=409, detail="Bookmark already exists for this article")
+```
+
+This is the textbook ACID example for the project: a database-layer constraint (the trigger) is the source of truth for "no duplicates"; the application layer treats `IntegrityError` as the canonical signal and maps it to the correct HTTP semantics. Pre-checking with a `SELECT` before the `INSERT` would still need the same trigger as the safety net for concurrent requests, so the code skips the pre-check and relies on the trigger directly.
+
+UNIQUE constraints on `articles.url`, `sources.name`, and `entities (name, type)` are enforced at the database layer; application code does not assume uniqueness from pre-`SELECT`s alone.
+
+**Session aborted-state handling:**
+
+After a failed `db.commit()`, a SQLAlchemy session is in `PendingRollbackError` state — any subsequent `commit()` will fail until `db.rollback()` is called. The crawl-worker exception handlers ([app/jobs/crawl_worker.py:456-494](../app/jobs/crawl_worker.py#L456-L494)) call `db.rollback()` *before* mutating `crawl_job` and re-committing the failure record, in this order:
+
+1. `db.rollback()` — clear the aborted session.
+2. Set `crawl_job.status = FAILED`, `error_code`, `error_message`.
+3. `db.commit()` — record the failure.
+
+Without step 1 the second commit propagates, the job stays in its prior status (often `IN_PROGRESS`), and the worker retries it on the next tick — which is the same poisoned job — forever. Setting the fields before the rollback would also be wrong, because the rollback would discard the assignments.
+
+---
+
 ## 5. Data Lifecycle
 
 The high-level pipeline is in [ER_Diagram.md § Data Lifecycle](ER_Diagram.md#data-lifecycle). What follows are the operational details — frequencies, configurations, and what is **not** stored.
@@ -210,7 +251,7 @@ PostgreSQL is the operational store; BigQuery is the analytics warehouse. Sentim
 
 ## 6. Backup & Recovery
 
-Cloud SQL is configured with **daily automated backups at 03:00 UTC** ([infra/main.tf:75-79](../infra/main.tf#L75-L79)). Point-in-time recovery is **disabled** as a deliberate cost trade-off appropriate for a student-project workload — a 24-hour RPO is acceptable. Deletion protection is on, so the instance cannot be removed by accident.
+Cloud SQL is configured with **daily automated backups at 03:00 UTC** and **point-in-time recovery enabled** ([infra/main.tf:75-79](../infra/main.tf#L75-L79)). PITR replays write-ahead-log segments retained on the backup, so the recovery point can be a specific timestamp within the retention window — not just the last nightly snapshot. Deletion protection is on, so the instance cannot be removed by accident.
 
 Restore from the latest backup:
 
@@ -219,7 +260,14 @@ gcloud sql backups restore <BACKUP_ID> \
   --restore-instance=aifeelnews-db
 ```
 
-For a production workload the right call would be `point_in_time_recovery_enabled = true` plus binary log archiving — that is documented in [COST_AND_SCALABILITY.md](COST_AND_SCALABILITY.md) as a future scaling step.
+PITR clone to a fresh instance at a specific moment:
+
+```bash
+gcloud sql instances clone aifeelnews-db aifeelnews-db-clone \
+  --point-in-time='2026-05-03T10:00:00.000Z'
+```
+
+The clone-then-promote flow is the safer path versus restoring in place: the clone is verified, then the application's `DATABASE_URL` secret is rotated to the clone's connection name.
 
 ---
 

--- a/docs/SECURITY_MEASURES.md
+++ b/docs/SECURITY_MEASURES.md
@@ -1,0 +1,469 @@
+# Security Measures — aiFeelNews
+
+Implemented controls, organised by layer. Each entry cites the code
+or Terraform resource and links to the threat(s) it mitigates in
+[THREAT_MODEL.md](THREAT_MODEL.md).
+
+---
+
+## Layers
+
+1. [Identity & Access](#1-identity--access)
+2. [Secrets & Key Management](#2-secrets--key-management)
+3. [Transport & Network](#3-transport--network)
+4. [Application Layer](#4-application-layer)
+5. [Data Protection](#5-data-protection)
+6. [Container & Runtime](#6-container--runtime)
+7. [CI/CD & Supply Chain](#7-cicd--supply-chain)
+8. [Monitoring & Detection](#8-monitoring--detection)
+
+---
+
+## 1. Identity & Access
+
+### 1.1 Firebase Auth (Google Sign-In)
+
+End users authenticate via Google through Firebase. The frontend
+(`frontend/src/lib/firebase.ts`) obtains an ID token; the backend
+never receives a password because the flow is federated.
+
+- **Code:** `app/services/firebase_admin.py`
+- **Threats:** [3.S1](THREAT_MODEL.md#3-firebase-auth),
+  [1.S1](THREAT_MODEL.md#1-cloud-run-web-service)
+
+### 1.2 Server-side Firebase ID token verification
+
+Protected routes depend on `get_current_user`, which extracts the
+bearer token, verifies it via `auth.verify_id_token` (Firebase Admin
+SDK), and resolves the Firebase UID to a User row. Bad signature,
+wrong audience, or expired exp → 401.
+
+- **Code:** `app/deps/auth.py:13-43`, `app/services/firebase_admin.py:25-27`
+- **Threats:** [1.S1, 1.E1](THREAT_MODEL.md#1-cloud-run-web-service),
+  [3.S1, 3.T1](THREAT_MODEL.md#3-firebase-auth)
+
+### 1.3 OIDC verification on Scheduler endpoints
+
+`/api/v1/trigger-ingestion` and `/api/v1/cleanup` require a
+Google-signed OIDC token whose audience equals the Cloud Run URL and
+whose `email` claim equals
+`cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com`. Verification
+uses `google.oauth2.id_token.verify_oauth2_token`. In non-prod ENV the
+dependency bypasses with a warning so local dev and pytest work
+without GCP credentials.
+
+- **Code:** [app/deps/oidc.py:51-131](../app/deps/oidc.py#L51-L131),
+  wired in [app/main.py:257-331](../app/main.py#L257-L331)
+- **Config:** [app/config/security.py](../app/config/security.py) —
+  `cloud_run_url`, `scheduler_service_account` (env-overridable)
+- **Threats:** [4.S1, 4.E1](THREAT_MODEL.md#4-cloud-scheduler--api)
+
+### 1.4 Least-privilege application DB user
+
+Migrations and runtime queries connect as `aifeelnews`, a dedicated
+Postgres role with `LOGIN` only — no `SUPERUSER`, no `CREATEDB`, no
+extension creation. `postgres` is reserved for emergency operator
+access. A SQL injection that escapes the ORM still cannot drop the
+schema or read other DBs' system catalogs.
+
+- **Code:** [infra/main.tf:115-123](../infra/main.tf#L115-L123),
+  `alembic/env.py` (reads creds from Secret Manager)
+- **Threats:** [2.E1, 2.T2](THREAT_MODEL.md#2-cloud-sql-postgresql)
+
+### 1.5 Least-privilege Cloud Run service account
+
+`cloudrun-sa` has 5 IAM roles ([infra/main.tf:374-414](../infra/main.tf#L374-L414)):
+`secretmanager.secretAccessor`, `cloudsql.client`,
+`serviceusage.serviceUsageConsumer` (Cloud NL API),
+`bigquery.dataEditor`, `bigquery.jobUser`. No project admin, no IAM
+admin, no broad storage role.
+
+- **Code:** [infra/main.tf:374-414](../infra/main.tf#L374-L414)
+- **Threats:** [1.E1](THREAT_MODEL.md#1-cloud-run-web-service),
+  [4.S1](THREAT_MODEL.md#4-cloud-scheduler--api)
+
+### 1.6 Firebase UID linkage on user records
+
+`User` has a unique `firebase_uid` index, so an upstream email rotation
+doesn't orphan bookmarks. Auto-create on first authenticated request
+([app/deps/auth.py:36-41](../app/deps/auth.py#L36-L41)) keeps the DB
+in sync without a separate sign-up step.
+
+- **Code:** `app/models/user.py`
+- **Threats:** [3.E1](THREAT_MODEL.md#3-firebase-auth)
+
+---
+
+## 2. Secrets & Key Management
+
+### 2.1 GCP Secret Manager (6 secrets)
+
+`db-password`, `mediastack-api-key`, `firebase-service-account-json`,
+`aifeelnews-gcp-nlp-key`, `aifeelnews-db-password`,
+`aifeelnews-database-url`. Cloud Run mounts them as `secretKeyRef`
+on the revision spec — never written to disk in CI.
+
+- **Config:** `infra/main.tf` (`google_secret_manager_secret`),
+  Cloud Run revision env block
+- **Threats:** [2.I2, 3.I1](THREAT_MODEL.md#3-firebase-auth)
+
+### 2.2 DATABASE_URL as `secretKeyRef`
+
+The connection string contains the password. As a literal env var it
+would appear in `terraform plan` output and in revision metadata in
+the GCP console. Mounted as `secretKeyRef` it stays in Secret Manager.
+
+- **Config:** `infra/main.tf` (Cloud Run revision spec, `env` block)
+- **Threats:** [2.I2](THREAT_MODEL.md#2-cloud-sql-postgresql),
+  [5.I1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 2.3 Cascading secret lookup
+
+`get_secret_or_env(secret_name, env_var, default)` tries Secret
+Manager first, then the named env var, then the default. Used
+everywhere a secret is needed; nothing reaches into `os.environ`
+directly for sensitive values, so the source can be swapped (e.g. in
+tests) in one place.
+
+- **Code:** `app/utils/secrets.py:113-142`
+- **Threats:** [2.I2](THREAT_MODEL.md#2-cloud-sql-postgresql),
+  [5.I1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 2.4 GitHub Secrets, build/deploy time only
+
+`GCP_SA_KEY`, `FIREBASE_SERVICE_ACCOUNT`, etc. are GitHub Secrets
+exposed only to specific workflow jobs. `GCP_SA_KEY` is scoped to the
+`production` GitHub environment, which requires a manual approval
+before the deploy job can read it.
+
+- **Config:** `.github/workflows/deploy.yml` (`environment.name: production` block)
+- **Threats:** [5.I1, 5.E1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 2.5 No secrets in VCS
+
+`.env`, `*-key.json`, `*-credentials.json` are gitignored. The
+gitleaks pre-commit hook ([.pre-commit-config.yaml:16-19](../.pre-commit-config.yaml#L16-L19))
+scans every commit for AWS keys, GCP service-account JSON, Firebase
+secrets, and high-entropy strings. The same scan runs in CI on every
+PR plus a weekly Monday cron — newly disclosed scan rules apply
+retroactively to historical commits.
+
+- **Config:** [.pre-commit-config.yaml](../.pre-commit-config.yaml),
+  [.github/workflows/security.yml](../.github/workflows/security.yml)
+- **Threats:** [3.I1](THREAT_MODEL.md#3-firebase-auth),
+  [5.I1](THREAT_MODEL.md#5-cicd-pipeline)
+
+---
+
+## 3. Transport & Network
+
+### 3.1 HTTPS-only on Cloud Run
+
+Cloud Run terminates HTTPS with a Google-managed cert. No HTTP
+listener; HTTP requests redirect to HTTPS at the LB. Frontend Firebase
+Hosting is also HTTPS-only.
+
+- **Config:** Cloud Run default, Firebase Hosting default
+- **Threats:** [1.I1](THREAT_MODEL.md#1-cloud-run-web-service),
+  [3.T1](THREAT_MODEL.md#3-firebase-auth)
+
+### 3.2 Cloud SQL `ssl_mode = ENCRYPTED_ONLY`
+
+Cloud SQL rejects unencrypted connections at the listener. A
+misconfigured local proxy still cannot send plaintext to the DB.
+
+- **Config:** [infra/main.tf:81-84](../infra/main.tf#L81-L84)
+- **Threats:** [2.I1](THREAT_MODEL.md#2-cloud-sql-postgresql)
+
+### 3.3 CORS allowlist (no wildcard)
+
+[app/main.py:83-97](../app/main.py#L83-L97) lists 4 allowed origins:
+production Firebase Hosting (`web.app` + `firebaseapp.com`) and the
+two Vite dev URLs. `allow_credentials=True` requires explicit
+origins. Disallowed origins get HTTP 400 with no
+`Access-Control-Allow-Origin`.
+
+- **Code:** [app/main.py:83-97](../app/main.py#L83-L97)
+- **Threats:** [1.I1](THREAT_MODEL.md#1-cloud-run-web-service)
+
+### 3.4 Cloud SQL via Unix socket (not TCP)
+
+Cloud Run's `--add-cloudsql-instances` exposes the DB as a Unix socket
+inside Google's network. No TCP path from Cloud Run to Cloud SQL — a
+routing misconfig cannot expose the DB on the public internet.
+
+- **Config:** `infra/main.tf` Cloud Run revision, `cloudsql_instances`
+- **Threats:** [2.S1, 2.I1](THREAT_MODEL.md#2-cloud-sql-postgresql)
+
+---
+
+## 4. Application Layer
+
+### 4.1 Pydantic input validation
+
+Request bodies are Pydantic models (`app/schemas/*.py`). Type
+mismatches and missing fields produce 422 before the handler runs.
+Query params use `Query(..., ge=1, le=365)` on analytics for the same
+reason.
+
+- **Code:** `app/schemas/`, `app/routers/*.py` `Query(...)`
+- **Threats:** [1.T1](THREAT_MODEL.md#1-cloud-run-web-service),
+  partial [2.T1](THREAT_MODEL.md#2-cloud-sql-postgresql)
+
+### 4.2 Parameterized SQL only
+
+ORM ops use SQLAlchemy 2.0 typed `select()` / `insert()` builders.
+BigQuery uses `QueryJobConfig` with `@param` placeholders (e.g.
+`get_sentiment_trends` in `app/services/bigquery.py`). f-string SQL is
+forbidden in review; raw `text()` calls are reviewed individually.
+
+- **Code:** `app/services/bigquery.py`, `app/routers/*.py`
+- **Threats:** [1.T1, 2.T1](THREAT_MODEL.md#2-cloud-sql-postgresql)
+
+### 4.3 slowapi rate limiting
+
+Per-IP buckets via `get_remote_address`. Limits in
+`app/config/security.py`, applied as decorators:
+
+- `/api/v1/analytics/*` — 30/min (BigQuery cost)
+- `/api/v1/sentiment/*` — 60/min (Cloud NL API cost + spam)
+- `/api/v1/trigger-ingestion` — 6/h (Scheduler fires 3×/day)
+- `/api/v1/cleanup` — 6/h (Scheduler fires 1×/day)
+
+slowapi's default handler returns 429.
+
+- **Code:** [app/main.py:65-81](../app/main.py#L65-L81) (setup),
+  `app/routers/analytics.py`, `app/routers/sentiment.py`,
+  [app/main.py:257-331](../app/main.py#L257-L331) (scheduler decorators)
+- **Threats:** [1.D1](THREAT_MODEL.md#1-cloud-run-web-service),
+  [4.D1](THREAT_MODEL.md#4-cloud-scheduler--api)
+
+### 4.4 robots.txt + honest User-Agent
+
+Each crawl fetches `/robots.txt` first via `app/utils/robots.py` and
+respects `User-agent: aifeelnews-bot` and `User-agent: *`. The UA
+`aifeelnews-bot/1.0` is in `config.crawler.crawler_user_agent`. A
+per-domain semaphore + `crawler_default_delay` keeps us off any one
+origin's neck.
+
+- **Code:** `app/utils/robots.py`, `app/jobs/crawl_worker.py`,
+  `app/config/crawler.py`
+- **Threats:** [6.R1, 6.D1](THREAT_MODEL.md#6-external-data-ingestion--crawling)
+
+---
+
+## 5. Data Protection
+
+### 5.1 Article content truncation (1024 chars) + 7-day TTL
+
+`ArticleContent` stores at most 1024 chars of any article body. After
+7 days (`config.ingestion.article_content_ttl_hours`, default 168) the
+cleanup job deletes the row. This is the copyright + privacy boundary
+— the system is an analysis pipeline, not a content archive.
+
+- **Code:** `app/jobs/crawl_worker.py` (truncation),
+  `app/utils/cleanup.py` (TTL),
+  `app/jobs/ttl_cleanup.py`
+- **Threats:** [6.I1](THREAT_MODEL.md#6-external-data-ingestion--crawling)
+
+### 5.2 No full article bodies stored
+
+Title and description (Mediastack excerpts) are kept indefinitely;
+the crawled body is the 1024-char truncation. Truncation is enforced
+at write time, so a future DB consumer cannot surface a full body.
+
+- **Code:** `app/jobs/crawl_worker.py` (write-side truncation)
+- **Threats:** [6.I1](THREAT_MODEL.md#6-external-data-ingestion--crawling)
+
+### 5.3 Minimal user PII
+
+`User` stores `email`, `firebase_uid`, and a placeholder
+`hashed_password` (empty — auth is federated). No name, no profile
+picture, no address.
+
+- **Code:** `app/models/user.py`, `app/deps/auth.py:36-41`
+- **Threats:** [3.I1](THREAT_MODEL.md#3-firebase-auth)
+
+### 5.4 Cloud SQL automated backups + PITR
+
+Daily backups + 7-day point-in-time recovery. A successful DB-tamper
+(e.g. via 2.T2) is recoverable to the last known-good state.
+
+- **Config:** [infra/main.tf:75-79](../infra/main.tf#L75-L79)
+  (`backup_configuration` with `point_in_time_recovery_enabled = true`)
+- **Threats:** [2.T2](THREAT_MODEL.md#2-cloud-sql-postgresql) (recovery, not prevention)
+
+---
+
+## 6. Container & Runtime
+
+### 6.1 Non-root container users
+
+`Dockerfile.web`, `Dockerfile.worker`, `Dockerfile.scheduler` each
+declare a dedicated user (`app`, `worker`, `scheduler`) and switch
+via `USER` before the entrypoint. RCE inside the container runs as
+that user, not root.
+
+- **Code:** `docker/Dockerfile.web`, `docker/Dockerfile.worker`,
+  `docker/Dockerfile.scheduler`
+- **Threats:** [6.E1](THREAT_MODEL.md#6-external-data-ingestion--crawling)
+
+### 6.2 Distroless-leaning base images
+
+Web and worker run on `python:3.13-slim` (no shell utilities beyond
+`/bin/sh`). Smaller image, smaller attack surface for a foothold
+inside the container.
+
+- **Code:** `docker/Dockerfile.*` `FROM` directives
+- **Threats:** [1.E1, 6.E1](THREAT_MODEL.md#6-external-data-ingestion--crawling)
+
+### 6.3 Cloud Run scale-to-zero
+
+`min_instances = 0` means there's no running container most of the
+time. RCE blast radius is the lifetime of one instance — under 15
+minutes between requests in low-traffic mode.
+
+- **Config:** `infra/main.tf` `google_cloud_run_v2_service.web` → `template.scaling`
+- **Threats:** [1.E1](THREAT_MODEL.md#1-cloud-run-web-service) (defence in depth)
+
+---
+
+## 7. CI/CD & Supply Chain
+
+### 7.1 Dependabot
+
+Active for `pip` (`requirements.txt`), `npm`
+(`frontend/package.json`), and `github-actions`. Raises PRs for
+security upgrades within ~24h of CVE disclosure. Recent merges
+include `postcss`, `python-dotenv`, `protobufjs`.
+
+- **Config:** `.github/dependabot.yml`
+- **Threats:** [5.T1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 7.2 pip-audit (CI)
+
+Scans `requirements.txt` against the PyPI advisory DB on every push,
+every PR to `main`/`develop`, and weekly Monday 06:00 UTC. `--strict`
+fails the job on any known CVE.
+
+- **Config:** [.github/workflows/security.yml](../.github/workflows/security.yml)
+- **Threats:** [5.T1](THREAT_MODEL.md#5-cicd-pipeline) — complements
+  7.1: Dependabot opens upgrade PRs, pip-audit fails CI on un-merged
+  ones so the window between disclosure and fix is bounded.
+
+### 7.3 gitleaks (pre-commit + CI)
+
+Pre-commit hook ([.pre-commit-config.yaml](../.pre-commit-config.yaml))
+catches secrets before they enter local history. CI workflow
+([.github/workflows/security.yml](../.github/workflows/security.yml))
+runs a full-history scan on every push/PR plus a weekly cron — a leak
+that slipped through pre-commit gets caught at review time, and old
+commits are re-scanned against new rules.
+
+- **Config:** `.pre-commit-config.yaml`, `.github/workflows/security.yml`
+- **Threats:** [5.I1](THREAT_MODEL.md#5-cicd-pipeline),
+  [3.I1](THREAT_MODEL.md#3-firebase-auth)
+
+### 7.4 Ruff
+
+Style + lint + a small set of bug patterns (B-rules,
+unused-imports). Runs in pre-commit and CI. Could enable S608 to
+catch accidental `text()` SQL; currently relying on code review.
+
+- **Config:** `.pre-commit-config.yaml`, `pyproject.toml`,
+  `.github/workflows/deploy.yml` (test job)
+- **Threats:** code-quality side-effect on
+  [1.T1, 5.T2](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 7.5 mypy
+
+Static type checking on `app/`. Runs in pre-commit and CI. Bad route
+signatures (e.g. dependency wired wrong) fail the build before merge.
+
+- **Config:** `.pre-commit-config.yaml`, `.github/workflows/deploy.yml`
+- **Threats:** code-quality side-effect on
+  [1.E1](THREAT_MODEL.md#1-cloud-run-web-service)
+
+### 7.6 GCP_SA_KEY scoped to `production` GitHub environment
+
+Deploy job credentials are not repo-wide; they live in the
+`production` GitHub environment, which can require manual approval
+and a protected branch. PR runs from forks cannot access this secret.
+
+- **Config:** `.github/workflows/deploy.yml` (`environment.name: production`)
+- **Threats:** [5.I1, 5.E1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 7.7 SHA-pinned third-party actions
+
+Deploy pins `google-github-actions/auth`, `setup-gcloud`, etc. to
+SHAs/tagged majors so a tag hijack on an action repo cannot inject
+malicious steps.
+
+- **Config:** `.github/workflows/deploy.yml`
+- **Threats:** [5.T2](THREAT_MODEL.md#5-cicd-pipeline)
+
+---
+
+## 8. Monitoring & Detection
+
+### 8.1 Cloud Logging
+
+`setup_logging()` in `app/utils/logging.py` emits structured JSON in
+production (Cloud Run's expected format) and plain text locally.
+Errors, auth rejects, OIDC bypasses, rate-limit hits are logged at
+appropriate levels.
+
+- **Code:** `app/utils/logging.py`, called from `app/main.py:20`
+- **Threats:** [1.R1, 4.R1](THREAT_MODEL.md#4-cloud-scheduler--api),
+  [5.R1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 8.2 Cloud Monitoring dashboard
+
+Terraform provisions a dashboard: request count, latency p50/p95,
+error rate, instance count, CPU, memory, DB connection count,
+ingestion job freshness. Alert policies fire on deploy failure and
+abnormal error rate.
+
+- **Config:** `infra/main.tf` (`google_monitoring_dashboard`,
+  `google_monitoring_alert_policy`)
+- **Threats:** detection layer for
+  [1.D1](THREAT_MODEL.md#1-cloud-run-web-service),
+  [2.D1](THREAT_MODEL.md#2-cloud-sql-postgresql)
+
+### 8.3 Auto-issue on deploy failure
+
+A failing deploy opens a GitHub issue with the run URL, failing step,
+and SHA. A botched deploy is never silently lost.
+
+- **Config:** `.github/workflows/deploy.yml` (post-failure step)
+- **Threats:** detection layer for
+  [5.D1](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 8.4 Cloud Run revision identity check on deploy
+
+After deploy, the workflow verifies the new revision is serving
+traffic and that its SHA matches the build's. If not, rollback runs
+automatically.
+
+- **Config:** `.github/workflows/deploy.yml` (final verification step)
+- **Threats:** detection layer for
+  [5.T2](THREAT_MODEL.md#5-cicd-pipeline)
+
+---
+
+## Known Gaps
+
+See [THREAT_MODEL.md → Known gaps](THREAT_MODEL.md#known-gaps-consolidated)
+for the tradeoff on each:
+
+- No WAF / Cloud Armor.
+- No SAST in CI (CodeQL, Semgrep).
+- No SLSA attestation / SBOM.
+- Cloud SQL `cloudsql.iam_authentication` not enabled.
+- No formal pen-test history.
+- Cloud SQL HA = ZONAL.
+- TOCTOU in `get_or_create_source` ([app/jobs/ingest_articles.py:9-15](../app/jobs/ingest_articles.py#L9-L15)).
+- TOCTOU in `delete_bookmark` ([app/routers/bookmarks.py:47-61](../app/routers/bookmarks.py#L47-L61)).
+- No JWT replay-detection.
+- No tamper-evident log sink.
+- Worker container not seccomp / read-only-FS hardened.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,243 @@
+# Threat Model — aiFeelNews
+
+STRIDE per component. Scope is the production deployment
+(`aifeelnews-prod`, `europe-west1`) and the CI/CD pipeline that ships
+to it. Frontend supply-chain risk is covered via Dependabot.
+
+See also: [SECURITY_MEASURES.md](SECURITY_MEASURES.md),
+[CICD_PIPELINE.md](CICD_PIPELINE.md),
+[MULTI_ENVIRONMENT_STRATEGY.md](MULTI_ENVIRONMENT_STRATEGY.md).
+
+---
+
+## Components covered
+
+1. [Cloud Run web service](#1-cloud-run-web-service) — the FastAPI
+   app, public HTTPS endpoint.
+2. [Cloud SQL PostgreSQL](#2-cloud-sql-postgresql) — the OLTP data
+   layer.
+3. [Firebase Auth](#3-firebase-auth) — the identity provider for end
+   users.
+4. [Cloud Scheduler → API](#4-cloud-scheduler--api) — the automation
+   surface (`/trigger-ingestion`, `/cleanup`).
+5. [CI/CD pipeline](#5-cicd-pipeline) — GitHub Actions → Artifact
+   Registry → Cloud Run.
+6. [External data ingestion + crawling](#6-external-data-ingestion--crawling)
+   — Mediastack pulls + outbound HTTP to news sites.
+
+Trust-boundary diagram at the end.
+
+---
+
+## 1. Cloud Run web service
+
+FastAPI in a slim Python image ([docker/Dockerfile.web](../docker/Dockerfile.web)),
+non-root user, fronted by Cloud Run's managed HTTPS LB. Runs as the
+least-priv `cloudrun-sa`.
+
+| ID | Threat | Description | Mitigation | Residual |
+|----|--------|-------------|------------|----------|
+| 1.S1 | Spoofing | Attacker impersonates a real user to call protected endpoints (e.g. `/bookmarks`). | Firebase ID token verification on every protected route — see [app/deps/auth.py:13-43](../app/deps/auth.py#L13-L43). Tokens are signed by Firebase, audience-bound to the project. | None — Firebase rotates signing keys automatically and the SDK re-fetches on every request. |
+| 1.T1 | Tampering | Attacker modifies request payloads to inject SQL or NoSQL fragments. | All DB writes/reads go through SQLAlchemy ORM with parameterized queries. BigQuery analytics use `@param` + `QueryJobConfig` ([app/services/bigquery.py](../app/services/bigquery.py)). Pydantic schemas validate every request body. | None known. SQLAlchemy `text()` with f-strings would reintroduce risk — guarded by code review. |
+| 1.R1 | Repudiation | A user denies they bookmarked an article. | Cloud Logging captures every authenticated request with the Firebase UID. [app/utils/logging.py](../app/utils/logging.py) emits structured JSON in production. Logs are retained for 30 days by default. | Logs are not exported to a tamper-evident sink (BigQuery). Tradeoff: log-sink storage cost vs. forensic value at the current scale; revisit if regulatory requirements appear. |
+| 1.I1 | Information disclosure | Attacker reads sensitive response data via overly permissive CORS. | CORS allowlist at [app/main.py:83-97](../app/main.py#L83-L97) (Firebase Hosting URLs + localhost dev). No wildcard. Disallowed origins get HTTP 400 with no `Access-Control-Allow-Origin`. | Allowlist is small and PR-reviewed. |
+| 1.I2 | Information disclosure | Stack traces leak DB schema or internal paths to clients. | FastAPI raises `HTTPException(detail=…)` with curated messages; Starlette returns 500 with no stacktrace by default. Errors logged server-side via `setup_logging()`. | If `DEBUG` were ever enabled in prod, stack traces would leak. Guarded by config — `ENV=production` is read from Cloud Run env. |
+| 1.D1 | Denial of service | Attacker spams `/api/v1/sentiment/*` to drive Cloud Run CPU to max and exhaust the monthly quota. | slowapi rate limits (60/min sentiment, 30/min analytics, 6/h scheduler) keyed on `get_remote_address` — [app/main.py:65-81](../app/main.py#L65-L81), `app/routers/analytics.py`, `app/routers/sentiment.py`. Cloud Run instance cap is `max=10`. | Per-IP limiting is bypassable via a botnet. No WAF / Cloud Armor configured — see Known Gaps. |
+| 1.E1 | Elevation of privilege | A bug in the auth dep lets an unauthenticated request reach a protected handler. | `get_current_user` raises 401 before the handler runs ([app/deps/auth.py:13-31](../app/deps/auth.py#L13-L31)). | None known. mypy + ruff catch broken signatures pre-merge. |
+
+Component 1 gaps: no WAF/Cloud Armor; no JWT replay detection (stolen
+token is valid for its 1h TTL).
+
+---
+
+## 2. Cloud SQL PostgreSQL
+
+Postgres 14 ([infra/main.tf:64-103](../infra/main.tf#L64-L103)). Public
+IP enabled but Cloud Run reaches it through the Cloud SQL Auth Proxy
+over a Unix socket; `ssl_mode = "ENCRYPTED_ONLY"` rejects plaintext.
+Migrations and runtime queries run as `aifeelnews` (not `postgres`).
+Password in Secret Manager; `DATABASE_URL` is a `secretKeyRef` on the
+Cloud Run revision.
+
+| ID | Threat | Description | Mitigation | Residual |
+|----|--------|-------------|------------|----------|
+| 2.S1 | Spoofing | Attacker connects to the DB pretending to be the application. | Connections require `cloudsql.client` IAM (granted only to `cloudrun-sa` and `github-actions-sa` — [infra/main.tf:388-393](../infra/main.tf#L388-L393) and [:443-448](../infra/main.tf#L443-L448)). Password from Secret Manager (`aifeelnews-db-password`). | None — IAM-based authentication is the trust anchor. |
+| 2.T1 | Tampering | SQL injection via crafted user input. | Same mitigation as 1.T1: ORM + Pydantic + parameterized BigQuery. | None known. |
+| 2.T2 | Tampering | Migration scripts write malicious schema changes. | Alembic migrations run as `aifeelnews` (NOT `postgres`), so a hijacked migration cannot create extensions or drop superuser-owned objects. `alembic/env.py` reads creds from Secret Manager via `get_secret_or_env`. | The `aifeelnews` role still has CREATE/DROP on its own schema. Mitigated by code review on all migration PRs. |
+| 2.R1 | Repudiation | A row was changed but no audit trail exists. | `Article` and similar models carry `created_at` / `updated_at`; the `trg_update_source_timestamp` trigger keeps `updated_at` honest. Cloud SQL has automatic backups + PITR ([infra/main.tf:75-79](../infra/main.tf#L75-L79)). | No application-level audit log (who-did-what). Tradeoff: per-row audit infra vs. current write volume. PITR covers recovery; audit is the attribution axis and is not implemented. |
+| 2.I1 | Information disclosure | Network sniffer reads SQL traffic. | Cloud SQL `ssl_mode = "ENCRYPTED_ONLY"` ([infra/main.tf:83](../infra/main.tf#L83)). Cloud Run connects via Unix socket, not TCP, eliminating the network sniff threat for the prod path. | None. |
+| 2.I2 | Information disclosure | A leaked DB password gives full read access. | Password lives in Secret Manager. The runtime user (`aifeelnews`) is not a superuser; even with the password, an attacker cannot create extensions or read system catalogs of other DBs. | A password leak still gives application-data read+write. Mitigated by Secret Manager IAM (only `cloudrun-sa` and `github-actions-sa` can read). |
+| 2.D1 | Denial of service | Connection-pool exhaustion driven by a bug or attack. | SQLAlchemy pool tuned with `pool_pre_ping=True` and `pool_recycle=3600` ([app/database.py:29-33](../app/database.py#L29-L33)). PostgreSQL `max_connections=50` ([infra/main.tf:86-89](../infra/main.tf#L86-L89)). `log_min_duration_statement=1000` ([infra/main.tf:94-97](../infra/main.tf#L94-L97)) flags slow queries to Cloud Logging for review. | A pathologically slow query could still saturate. No formal per-query cost budget. |
+| 2.E1 | Elevation of privilege | Application user gains `postgres` superuser. | `aifeelnews` is provisioned with `LOGIN` only — no `SUPERUSER`, no `CREATEDB` ([infra/main.tf:115-123](../infra/main.tf#L115-L123)). Migrations run as `aifeelnews`. `postgres` is reserved for emergency operator access. | None known. |
+
+Component 2 gaps: no row-level security; no query-cost killer beyond
+Cloud SQL's defaults; no automated DB-vuln scan (Cloud SQL handles
+patching).
+
+---
+
+## 3. Firebase Auth
+
+Identity provider for end users (Google Sign-In). Frontend gets a
+Firebase ID token; backend verifies it via the Admin SDK.
+
+| ID | Threat | Description | Mitigation | Residual |
+|----|--------|-------------|------------|----------|
+| 3.S1 | Spoofing | Attacker forges a Firebase token. | `verify_firebase_token` calls `auth.verify_id_token` from the Admin SDK — verifies signature against Firebase's public keys, audience claim against the project, and expiry ([app/services/firebase_admin.py](../app/services/firebase_admin.py)). | Firebase signing-key compromise is Google's responsibility. |
+| 3.T1 | Tampering | Attacker modifies a captured ID token. | Modification breaks the JWT signature → verification fails → 401. | None. |
+| 3.R1 | Repudiation | User denies a session existed. | Firebase keeps an audit log of sign-in events. Backend additionally logs the Firebase UID on every protected request. | Frontend-only events (page views without API calls) are not logged. |
+| 3.I1 | Information disclosure | A leaked Firebase service-account JSON gives admin powers. | The JSON is stored in Secret Manager (`firebase-service-account-json`) and mounted into Cloud Run via `secretKeyRef`, never written to disk in CI. `.gitignore` excludes `*-key.json`. gitleaks pre-commit + CI rejects accidental commits. | A compromised CI runner could read the secret. Mitigated by GitHub Actions OIDC (see component 5). |
+| 3.D1 | Denial of service | Auth provider downtime breaks login. | None at the application layer — Firebase is the SLA provider. The API still serves anonymous endpoints when Firebase is down. | Single-provider dependency. Mitigated only by Firebase's own redundancy. |
+| 3.E1 | Elevation of privilege | A regular user becomes admin. | The system has no admin role today. The only privileged capability is the OIDC-protected scheduler endpoints, and those reject anything not signed by `cloudrun-sa` regardless of Firebase claims. | If admin roles are added later, Firebase custom claims will need explicit server-side validation. |
+
+Component 3 gaps: no email/password fallback (Google only); no MFA
+enforcement.
+
+---
+
+## 4. Cloud Scheduler → API
+
+Cloud Scheduler hits `/api/v1/trigger-ingestion` (every 8h) and
+`/api/v1/cleanup` (daily 02:00 UTC). Both require a Google-signed
+OIDC token whose audience equals the Cloud Run URL and whose `email`
+claim equals the configured Cloud Run SA.
+
+| ID | Threat | Description | Mitigation | Residual |
+|----|--------|-------------|------------|----------|
+| 4.S1 | Spoofing | Attacker discovers the URL and calls `/trigger-ingestion` repeatedly. | OIDC verification on both endpoints ([app/deps/oidc.py:51-131](../app/deps/oidc.py#L51-L131)). Audience must equal the Cloud Run URL; signer email must equal `cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com`. Anything else → 401. | A compromise of the signer SA still fires valid requests. Mitigated by least-priv on the SA. |
+| 4.T1 | Tampering | Attacker modifies the request body. | The endpoints accept no body — POST with empty payload. Anything sent is ignored. | None. |
+| 4.R1 | Repudiation | Cloud Run logs don't tie a request to a Scheduler job. | The verified OIDC claims dict (sub, email, aud) is available to the route handler. Claims are logged at debug level via `setup_logging()`. | Promotion to info-level would improve audit at the cost of log volume. Tradeoff vs. log-retention spend. |
+| 4.I1 | Information disclosure | Endpoint returns DB row counts in 200 response, leaking pipeline scale. | Response is intentionally generic: `{"status": "success", "results": {...counts...}}`. Counts are aggregate, not identifying. | None — no PII surfaces in the response body. |
+| 4.D1 | Denial of service | An attacker (or buggy caller) hits the endpoint thousands of times. | slowapi limits both endpoints to `6/hour` per IP ([app/config/security.py](../app/config/security.py) `rate_limit_scheduler`). Scheduler itself fires 3×/day for ingestion and 1×/day for cleanup, well within budget. | Per-IP limit applies in aggregate to legitimate Google Scheduler IPs; 6/h is well above the legitimate cadence so this is by-design. |
+| 4.E1 | Elevation of privilege | An attacker triggers cleanup to delete pre-TTL articles before forensics finishes. | OIDC verification blocks the call. Cleanup is bounded by the TTL config (`config.ingestion.article_content_ttl_hours`) so it cannot be coerced into deleting fresh data. | None known. |
+
+Component 4 gaps: no IP allowlist for Google's Scheduler ranges
+(Google does not publish a stable list); no replay-detection on OIDC
+tokens (default 1h TTL bounds the window).
+
+---
+
+## 5. CI/CD pipeline
+
+GitHub Actions builds the Docker images and deploys to Cloud Run.
+Workload Identity Federation where possible; the legacy path uses a
+scoped SA JSON stored in the `production` GitHub environment.
+
+| ID | Threat | Description | Mitigation | Residual |
+|----|--------|-------------|------------|----------|
+| 5.S1 | Spoofing | Attacker pushes to `main` impersonating a maintainer. | GitHub branch protection on `main` requires PR review + green CI. `develop` and `fix/*` are the only branches allowed to merge into `main` (workflow guard at [.github/workflows/deploy.yml:26-34](../.github/workflows/deploy.yml#L26-L34)). | A compromised maintainer account bypasses this. Mitigated by GitHub's 2FA enforcement. |
+| 5.T1 | Tampering | Attacker injects a malicious dependency via a typosquat. | `requirements.txt` pins exact versions. Dependabot ([.github/dependabot.yml](../.github/dependabot.yml)) raises PRs for upgrades; pip-audit ([.github/workflows/security.yml](../.github/workflows/security.yml)) fails CI on any pinned dep with a known CVE. | Typosquats with no published CVE are not caught. Manual review on dependency PRs is the compensating control. |
+| 5.T2 | Tampering | Attacker modifies the deploy workflow to ship malware. | All workflow changes require PR review; pre-commit checks YAML validity. `pull-requests: write` is granted only on the security workflow's gitleaks job. Workflow files are reviewed under the same branch protection as code. | None known. |
+| 5.R1 | Repudiation | Who deployed what is unclear. | GitHub Actions records the actor + commit SHA on every run. Cloud Run revision names embed the SHA. Auto-issue creation on deploy failure preserves the failing run for audit. | Pre-image (the actor's local commits before push) is not recorded. |
+| 5.I1 | Information disclosure | Secrets leak via workflow logs. | Secrets stored in GitHub Secrets are masked in logs. `GCP_SA_KEY` is scoped to the `production` GitHub environment, not repo-wide. gitleaks pre-commit + CI catches accidental commits of secrets to the tree. | A workflow that explicitly `echo $SECRET`s would still leak. Mitigated by review. |
+| 5.D1 | Denial of service | A flapping CI run blocks deploys. | Workflow has retry/backoff on transient steps. Deploy job is idempotent — re-running publishes the same image. | A persistent CI outage blocks emergency deploys; manual `gcloud run deploy` is the documented break-glass. |
+| 5.E1 | Elevation of privilege | A PR's workflow run gains write access to `main`. | `permissions: contents: read` is the default for the workflow file; PR runs from forks have no secrets and no write tokens. The deploy job runs on push to `main`/`develop` only. | Pwn requests / branch-injection are hard to fully eliminate; reviewed at merge time. |
+
+Component 5 gaps: no SLSA attestation; no SBOM published with
+releases; no SAST tool (CodeQL/Semgrep) on the Python source — Ruff
+catches style and a small set of bug patterns but is not a security
+scanner.
+
+---
+
+## 6. External data ingestion + crawling
+
+Ingestion pulls article metadata from Mediastack; the crawl worker
+fetches a subset of full bodies for sentiment analysis. All crawls
+honour `robots.txt` and use the `aifeelnews-bot/1.0` User-Agent.
+
+| ID | Threat | Description | Mitigation | Residual |
+|----|--------|-------------|------------|----------|
+| 6.S1 | Spoofing | A malicious server impersonates Mediastack. | All Mediastack calls go over HTTPS; certificate validation is the default. The base URL is pinned in `app/config/ingestion.py`. | DNS-level hijacking by a sufficiently capable adversary remains possible. Tradeoff: certificate pinning vs. cert-rotation operational cost. |
+| 6.T1 | Tampering | A crawled site returns malicious HTML to exploit BeautifulSoup. | BeautifulSoup uses the stdlib `html.parser` — no external XML/XSLT. Content is truncated to 1024 chars before storage ([app/jobs/crawl_worker.py:221](../app/jobs/crawl_worker.py#L221)). | Stdlib parser CVEs would still apply; covered by pip-audit on releases. |
+| 6.R1 | Repudiation | Source claims we crawled them after they disallowed it. | Every crawl checks `robots.txt` first via [app/utils/robots.py](../app/utils/robots.py). User-Agent is consistent and identifiable. Crawl attempts logged with URL + timestamp + outcome. | None — robots.txt compliance is documented. |
+| 6.I1 | Information disclosure | Storing full article bodies creates a copyright + privacy liability. | Content truncated to 1024 chars + 7-day TTL (`config.ingestion.article_content_ttl_hours`). Cleanup runs via `/api/v1/cleanup` (OIDC-protected) and the `ttl_cleanup` background job. | None — truncation + TTL is the design. |
+| 6.I2 | Information disclosure | Crawling exposes our outbound IP to news sites. | Cloud Run egress IPs rotate. Crawling runs on a separate `worker` revision and cron, uncorrelated with user-traffic egress. | Determined operators can still profile the crawler IP range over time. |
+| 6.D1 | Denial of service | A slow crawl target ties up the worker. | Request timeout (`crawler_request_timeout`, default 10s). Per-domain semaphore caps concurrent requests (default 2). Exception handlers ([app/jobs/crawl_worker.py:456-494](../app/jobs/crawl_worker.py#L456-L494)) `db.rollback()` before re-committing the failure record, so a poisoned job can't trap the worker in retry. | A farm of slow targets can still degrade throughput. Cap of 100 articles/run bounds impact. |
+| 6.E1 | Elevation of privilege | A crawl payload exploits a parser bug to run code in the worker. | Non-root user ([docker/Dockerfile.worker](../docker/Dockerfile.worker)); no shell entrypoint; no GCP creds beyond what Cloud Run mints. RCE would be sandboxed to the worker revision. | No seccomp profile, no read-only FS. Tradeoff: profile maintenance vs. exploit likelihood given the parser stack. |
+
+Component 6 gaps: no per-article hash / dedup across crawl history
+(re-crawl on TTL expiry is allowed); no robots.txt cache validation
+across runs.
+
+---
+
+## Trust boundaries
+
+```
++-------------+      HTTPS       +---------------------+      Unix socket    +-------------+
+|  Browser    | ---------------> |  Cloud Run          | ------------------> |  Cloud SQL  |
+|  (user)     |  Firebase ID JWT |  aifeelnews-web     |  Cloud SQL Proxy    |  Postgres   |
++-------------+                  |  cloudrun-sa        |                     +-------------+
+       ^                         +---------------------+
+       |                              ^         |
+       |   Google Sign-In             |         | annotateText, secrets
+       v                              |         v
++-------------+                  +---------------------+
+|  Firebase   |                  |  GCP services       |
+|  Auth       |                  |  - Cloud NL API     |
++-------------+                  |  - Secret Manager   |
+                                 |  - BigQuery         |
+                                 +---------------------+
+                                        ^
+                                        | OIDC bearer (audience-bound)
+                                        |
++-----------------+              +---------------------+
+| Cloud Scheduler | -----------> |  /api/v1/trigger-*  |
+| cloudrun-sa     |  HTTPS+OIDC  |                     |
++-----------------+              +---------------------+
+
+GitHub Actions (CI) ---WIF/SA-key---> Artifact Registry ---> Cloud Run revision
+```
+
+Each arrow crosses a trust boundary. Every boundary is mitigated by at
+least one control in the tables above.
+
+---
+
+## Known gaps (consolidated)
+
+Things that are not mitigated, with the tradeoff for each.
+
+- **No WAF / Cloud Armor.** Per-IP slowapi rate limiting is the only
+  layer-7 DoS defence. Tradeoff: Cloud Armor pricing (~$5/policy/month
+  + per-request cost) vs. current request volume; revisit if abuse
+  appears.
+- **No SAST tool in CI** (CodeQL, Semgrep). Tradeoff: per-PR runtime
+  + queue cost vs. current code-review coverage and the small bug-rule
+  subset Ruff already enforces.
+- **No SLSA attestation / SBOM.** Builds are reproducible (pinned
+  deps), but supply-chain provenance is not signed. Tradeoff: tooling
+  + verifier complexity vs. a single-team ownership model.
+- **Cloud SQL `cloudsql.iam_authentication` flag not enabled.**
+  Tradeoff: changing live DB auth mode after migrations stabilised
+  carries rollback risk; planned for a separate maintenance window.
+- **No formal pen-test / red-team history.** Dependabot + pip-audit
+  + gitleaks are automated; they do not replace human review.
+- **Cloud SQL HA = ZONAL** (single zone). Tradeoff: 24/7 cost
+  (REGIONAL roughly doubles instance price) vs. RTO target. Daily
+  backups + PITR cover the durability axis.
+- **TOCTOU race in `get_or_create_source`** ([app/jobs/ingest_articles.py:9-15](../app/jobs/ingest_articles.py#L9-L15)).
+  Two concurrent ingest jobs can both attempt to insert the same
+  source name; the second fails on the UNIQUE constraint and rolls
+  back its batch. Clean fix is `INSERT … ON CONFLICT (name) DO NOTHING
+  RETURNING id` (PostgreSQL-specific). Deferred because the SQLite-based
+  test suite cannot exercise the `ON CONFLICT` path; landing it
+  without a Postgres-CI safety net would risk silent regressions.
+  Cloud Scheduler currently runs non-overlapping ingest jobs, so the
+  race window is small in practice.
+- **TOCTOU semantics in `delete_bookmark`** ([app/routers/bookmarks.py:47-61](../app/routers/bookmarks.py#L47-L61)).
+  Two concurrent DELETE requests both pass the existence check; the
+  second commits a no-op DELETE and returns 204 instead of 404. No
+  data corruption — only HTTP semantics. Fix is a `rowcount` check
+  post-`db.delete()`.
+- **No JWT replay-detection.** Stolen Firebase tokens are valid for
+  their 1h TTL.
+- **No log-sink to a tamper-evident store.** Cloud Logging retains
+  for 30 days; nothing copies to BigQuery for long-term audit.
+- **Worker container is not seccomp / read-only-FS hardened.**
+  Defence-in-depth gap on top of the non-root user — RCE in the
+  crawler would still be Cloud-Run-sandboxed but could write to the FS.
+
+Mirror entry in [SECURITY_MEASURES.md](SECURITY_MEASURES.md) under
+"Known Gaps".

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -238,6 +238,19 @@ Things that are not mitigated, with the tradeoff for each.
 - **Worker container is not seccomp / read-only-FS hardened.**
   Defence-in-depth gap on top of the non-root user — RCE in the
   crawler would still be Cloud-Run-sandboxed but could write to the FS.
+- **Crawl-job claim is not race-safe.** [app/jobs/crawl_worker.py:497-515](../app/jobs/crawl_worker.py#L497-L515)
+  selects pending jobs without `FOR UPDATE SKIP LOCKED`. Two workers
+  running concurrently can claim the same job and both attempt the
+  same crawl. Production runs a single worker revision today, so the
+  window is closed by deployment shape rather than by code. Fix is
+  PostgreSQL-specific (`SELECT … FOR UPDATE SKIP LOCKED`); deferred
+  alongside the Postgres-CI dependency that blocks `get_or_create_source`.
+- **`robots.txt` check fails open on fetch error.** [app/utils/robots.py:226-228](../app/utils/robots.py#L226-L228)
+  treats a network error fetching `robots.txt` as "allowed" rather
+  than "disallowed". Honest-crawler stance argues for fail-closed.
+  Tradeoff: a flaky robots host would otherwise stall the crawl
+  queue indefinitely. Mitigated today by per-domain rate limiting
+  and a 10s request timeout that bounds retries.
 
 Mirror entry in [SECURITY_MEASURES.md](SECURITY_MEASURES.md) under
 "Known Gaps".

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -66,10 +66,8 @@ export type ArticleDto = {
 
 export async function fetchLatestArticles(limit = 40): Promise<ArticleDto[]> {
   const url = `${API_BASE}/articles/latest?limit=${limit}`;
-  console.log('Fetching from:', url);
 
   const res = await fetch(url);
-  console.log('Response status:', res.status);
 
   if (!res.ok) {
     const errorText = await res.text();
@@ -78,7 +76,6 @@ export async function fetchLatestArticles(limit = 40): Promise<ArticleDto[]> {
   }
 
   const data = await res.json();
-  console.log('API Response:', data);
   return data;
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -74,7 +74,7 @@ resource "google_sql_database_instance" "main" {
 
     backup_configuration {
       enabled                        = true
-      point_in_time_recovery_enabled = false   # Cost trade-off: not needed for this project scale
+      point_in_time_recovery_enabled = true    # WAL-based recovery within retention window
       start_time                     = "03:00" # 3 AM UTC — outside peak usage
     }
 
@@ -86,6 +86,14 @@ resource "google_sql_database_instance" "main" {
     database_flags {
       name  = "max_connections"
       value = "50" # Appropriate for scale-to-zero with connection pooling
+    }
+
+    # Slow-query audit. Hot-reloadable, no restart required. 1000ms is
+    # tight enough to catch missing indexes, loose enough to ignore
+    # cold-start latency on the first query of a Cloud Run revision.
+    database_flags {
+      name  = "log_min_duration_statement"
+      value = "1000"
     }
   }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ certifi==2025.1.31
 charset-normalizer==3.4.1
 click==8.1.8
 coverage==7.8.0
+Deprecated==1.3.1
 fastapi==0.132.0
 firebase-admin==7.1.0
 google-cloud-bigquery==3.28.0
@@ -16,6 +17,7 @@ greenlet==3.2.0
 h11==0.16.0
 idna==3.10
 iniconfig==2.1.0
+limits==5.8.0
 Mako==1.3.11
 MarkupSafe==3.0.2
 mypy==1.15.0
@@ -37,6 +39,7 @@ python-dotenv==1.2.2
 requests==2.33.0
 six==1.17.0
 sniffio==1.3.1
+slowapi==0.1.9
 SQLAlchemy==2.0.40
 types-beautifulsoup4==4.12.0.20241020
 types-python-dateutil==2.9.0.20241003
@@ -47,3 +50,4 @@ typing_extensions==4.13.2
 urllib3==2.6.3
 uvicorn==0.34.2
 vaderSentiment==3.3.2
+wrapt==2.1.2

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -1,0 +1,269 @@
+"""Auth, OIDC, CORS and rate-limit assertions.
+
+These tests prove that the security primitives shipped in Phases C and D
+behave the way the threat model claims they do. They run against the real
+FastAPI ``app`` via ``TestClient`` so the wiring (router include, middleware
+order, dependency overrides) is exercised end-to-end.
+
+Where a test depends on production semantics (e.g. OIDC enforcement only
+fires when ``ENV == "production"``), the test reloads ``app.config`` and
+``app.main`` under that environment and tears the override down at the
+end so other tests are not contaminated.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _reload_app_with_env(env_value: str) -> Any:
+    """Reload ``app.main`` (and the config singletons it depends on) under a
+    specific ``ENV`` value so OIDC behaviour can be exercised in both modes.
+
+    Returns the freshly imported app module so callers can grab ``.app``.
+    """
+
+    # Drop the cached modules so the new ENV is picked up at import time.
+    for mod_name in [
+        "app.main",
+        "app.deps.oidc",
+        "app.config",
+        "app.config.security",
+    ]:
+        sys.modules.pop(mod_name, None)
+
+    import os
+
+    os.environ["ENV"] = env_value
+    import app.config as _cfg  # noqa: F401 — force reload of singleton
+
+    importlib.reload(_cfg)
+    return importlib.import_module("app.main")
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """A TestClient bound to the default (``ENV=local``) app instance.
+
+    We deliberately import ``app.main`` lazily so other tests that mutate
+    the environment (via ``_reload_app_with_env``) do not poison this
+    fixture.
+    """
+
+    from app.main import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def production_client() -> Iterator[TestClient]:
+    """A TestClient backed by a freshly reloaded app with ENV=production.
+
+    This is the only way to exercise the OIDC enforcement path because
+    ``app/deps/oidc.py`` short-circuits in any non-production env.
+    """
+
+    import os
+
+    original_env = os.environ.get("ENV")
+    main_mod = _reload_app_with_env("production")
+    try:
+        yield TestClient(main_mod.app)
+    finally:
+        # Restore the original env and reload back to the default app so
+        # later tests in the session see the same instance they expect.
+        if original_env is None:
+            os.environ.pop("ENV", None)
+        else:
+            os.environ["ENV"] = original_env
+        _reload_app_with_env(original_env or "local")
+
+
+# -----------------------------------------------------------------------------
+# Firebase-protected routes
+# -----------------------------------------------------------------------------
+
+
+class TestFirebaseAuthGate:
+    """The bookmark routes use ``get_current_user`` — verify the gate."""
+
+    def test_protected_route_requires_token(self, client: TestClient) -> None:
+        """No Authorization header → 401."""
+        resp = client.get("/bookmarks/")
+        assert resp.status_code == 401
+        assert "token" in resp.json()["detail"].lower()
+
+    def test_protected_route_rejects_invalid_token(self, client: TestClient) -> None:
+        """Bogus bearer → 401 (Firebase verification is mocked to fail)."""
+        with patch(
+            "app.deps.auth.verify_firebase_token",
+            side_effect=Exception("invalid signature"),
+        ):
+            resp = client.get(
+                "/bookmarks/",
+                headers={"Authorization": "Bearer not-a-real-token"},
+            )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid token"
+
+    def test_protected_route_rejects_malformed_header(self, client: TestClient) -> None:
+        """Header without 'Bearer ' prefix → 401, never reaches Firebase."""
+        resp = client.get(
+            "/bookmarks/",
+            headers={"Authorization": "totally-bogus"},
+        )
+        assert resp.status_code == 401
+
+
+# -----------------------------------------------------------------------------
+# OIDC-protected scheduler endpoints
+# -----------------------------------------------------------------------------
+
+
+class TestSchedulerOidcGate:
+    """``/api/v1/cleanup`` and ``/api/v1/trigger-ingestion`` require OIDC
+    in production. In any other env the dep bypasses with a warning so
+    pytest can keep running without GCP credentials."""
+
+    def test_oidc_dependency_bypasses_in_local_env(self, client: TestClient) -> None:
+        """ENV=local → bypass; the request reaches the handler.
+
+        The handler itself can fail (no DB, no Mediastack key) but that's
+        a 5xx, not a 401. We assert ``status_code != 401`` to prove the
+        bypass works without coupling to whatever the handler does next.
+        """
+        resp = client.post("/api/v1/cleanup")
+        assert resp.status_code != 401, (
+            f"Expected OIDC bypass in local env, got 401: {resp.text}"
+        )
+
+    def test_oidc_dependency_rejects_missing_token(
+        self, production_client: TestClient
+    ) -> None:
+        """ENV=production + no Authorization header → 401."""
+        resp = production_client.post("/api/v1/cleanup")
+        assert resp.status_code == 401
+        assert "OIDC" in resp.json()["detail"] or "token" in resp.json()["detail"]
+
+    def test_oidc_dependency_rejects_invalid_token(
+        self, production_client: TestClient
+    ) -> None:
+        """ENV=production + malformed token → 401 (signature won't verify)."""
+        resp = production_client.post(
+            "/api/v1/cleanup",
+            headers={"Authorization": "Bearer this.is.not.a.real.jwt"},
+        )
+        assert resp.status_code == 401
+
+    def test_oidc_dependency_rejects_wrong_signer(
+        self, production_client: TestClient
+    ) -> None:
+        """A correctly-signed token from the wrong service account → 401.
+
+        We patch ``id_token.verify_oauth2_token`` to return claims that
+        verify cryptographically but carry the wrong ``email`` claim.
+        This proves the signer-allowlist check works independently of
+        the cryptographic check.
+        """
+        with patch(
+            "app.deps.oidc.id_token.verify_oauth2_token",
+            return_value={
+                "email": "attacker@evil.iam.gserviceaccount.com",
+                "email_verified": True,
+                "aud": "https://aifeelnews-web-813770885946.europe-west1.run.app",
+            },
+        ):
+            resp = production_client.post(
+                "/api/v1/cleanup",
+                headers={"Authorization": "Bearer fake.but.cryptographically.valid"},
+            )
+        assert resp.status_code == 401
+        assert "signer" in resp.json()["detail"].lower()
+
+
+# -----------------------------------------------------------------------------
+# CORS
+# -----------------------------------------------------------------------------
+
+
+class TestCorsPolicy:
+    """Verify that the CORS middleware refuses unknown origins."""
+
+    def test_cors_accepts_known_origin(self, client: TestClient) -> None:
+        """Firebase Hosting origin is in the allowlist."""
+        resp = client.options(
+            "/api/v1/sentiment/info",
+            headers={
+                "Origin": "https://aifeelnews-front.web.app",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.status_code == 200
+        assert (
+            resp.headers.get("access-control-allow-origin")
+            == "https://aifeelnews-front.web.app"
+        )
+
+    def test_cors_rejects_unknown_origin(self, client: TestClient) -> None:
+        """A preflight from evil.com must NOT receive Allow-Origin echo."""
+        resp = client.options(
+            "/api/v1/sentiment/info",
+            headers={
+                "Origin": "https://evil.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        # Starlette's CORSMiddleware returns 400 for preflights it rejects
+        # and crucially never sets `access-control-allow-origin`. Browsers
+        # then refuse the cross-origin request.
+        assert resp.headers.get("access-control-allow-origin") is None
+
+
+# -----------------------------------------------------------------------------
+# Rate limiting (slowapi)
+# -----------------------------------------------------------------------------
+
+
+class TestRateLimiting:
+    """``slowapi`` returns 429 when the per-IP budget is blown."""
+
+    def test_rate_limit_returns_429(self, client: TestClient) -> None:
+        """Hit the sentiment info endpoint past its 60/minute budget.
+
+        slowapi captures the limit string at decoration time, so we
+        cannot lower the budget at runtime to make the test snappier
+        — we just send 80 requests and assert at least one 429 surfaces.
+        80 > 60 ensures the bucket is exhausted regardless of the small
+        clock drift between requests.
+
+        The limiter's in-memory storage is reset before and after so
+        ordering with other tests is irrelevant.
+        """
+        from app.main import app as live_app
+
+        live_app.state.limiter.reset()
+
+        try:
+            saw_429 = False
+            for _ in range(80):
+                resp = client.get("/api/v1/sentiment/info")
+                if resp.status_code == 429:
+                    saw_429 = True
+                    break
+            assert saw_429, (
+                "Expected a 429 within 80 requests at 60/minute budget; "
+                "limiter may not be wired correctly."
+            )
+        finally:
+            live_app.state.limiter.reset()

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -442,3 +442,72 @@ class TestCrawlWorkerRollbackHygiene:
         assert calls == ["commit", "rollback", "commit"], (
             f"expected commit→rollback→commit, got {calls}"
         )
+
+
+# -----------------------------------------------------------------------------
+# Error semantics — generic 503 detail, no internal leak
+# -----------------------------------------------------------------------------
+
+
+class TestErrorDetailDoesNotLeakInternals:
+    """The threat model (§1.I2) says 5xx responses must not leak the
+    underlying exception text — connection strings, DB schema, stack
+    frames. ``/health`` and ``/ready`` are the easiest surfaces to
+    assert this on because both run a ``SELECT 1`` and surface a 503
+    on failure.
+    """
+
+    def test_health_503_returns_generic_detail_when_db_unreachable(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sqlalchemy
+
+        secret_token = "INTERNAL_DB_HOST_aifeelnews-prod:europe-west1"
+
+        class _BoomSession:
+            def execute(self, *_a: Any, **_kw: Any) -> Any:
+                raise sqlalchemy.exc.OperationalError(
+                    f"connection failed: {secret_token}", None, None
+                )
+
+            def close(self) -> None:
+                pass
+
+        # /health and /ready import SessionLocal lazily inside the handler,
+        # so patching at the module attribute is what the handler actually
+        # resolves.
+        import app.database as database_mod
+
+        monkeypatch.setattr(database_mod, "SessionLocal", _BoomSession)
+
+        response = client.get("/health")
+
+        assert response.status_code == 503
+        assert response.json() == {"detail": "Service temporarily unavailable"}
+        assert secret_token not in response.text
+
+    def test_ready_503_returns_generic_detail_when_db_unreachable(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sqlalchemy
+
+        secret_token = "INTERNAL_DB_HOST_aifeelnews-prod:europe-west1"
+
+        class _BoomSession:
+            def execute(self, *_a: Any, **_kw: Any) -> Any:
+                raise sqlalchemy.exc.OperationalError(
+                    f"connection failed: {secret_token}", None, None
+                )
+
+            def close(self) -> None:
+                pass
+
+        import app.database as database_mod
+
+        monkeypatch.setattr(database_mod, "SessionLocal", _BoomSession)
+
+        response = client.get("/ready")
+
+        assert response.status_code == 503
+        assert response.json() == {"detail": "Service temporarily unavailable"}
+        assert secret_token not in response.text

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -267,3 +267,178 @@ class TestRateLimiting:
             )
         finally:
             live_app.state.limiter.reset()
+
+
+# -----------------------------------------------------------------------------
+# DB constraint → HTTP status translation
+# -----------------------------------------------------------------------------
+
+
+class TestBookmarkConflictHandling:
+    """The ``trg_prevent_duplicate_bookmark`` PostgreSQL trigger raises
+    ``IntegrityError`` on a duplicate ``(user_id, article_id)`` pair. The
+    create-bookmark route must translate that into HTTP 409, not 500.
+
+    The test runs against SQLite (which has no trigger), so we patch
+    ``db.commit`` directly to raise ``IntegrityError``. That is the same
+    exception class the route catches in production, so the test proves
+    the catch + rollback + 409 path is wired correctly.
+    """
+
+    def test_create_bookmark_returns_409_on_integrity_error(
+        self, client: TestClient
+    ) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        from app.deps.auth import get_current_user
+        from app.main import app as live_app
+        from app.models.user import User
+        from app.routers.bookmarks import get_db as bookmarks_get_db
+
+        # Stub out the auth dep so the request reaches the handler.
+        fake_user = User(id=1, firebase_uid="test-uid", email="t@x", hashed_password="")
+
+        class _StubDb:
+            """Just enough Session surface to satisfy the route under test.
+
+            ``commit`` raises IntegrityError once to simulate the trigger
+            firing. ``rollback`` is recorded so the test can assert the
+            handler called it before raising 409.
+            """
+
+            def __init__(self) -> None:
+                self.rolled_back = False
+
+            def add(self, _obj: Any) -> None:  # pragma: no cover — trivial
+                pass
+
+            def commit(self) -> None:
+                raise IntegrityError("stmt", {}, Exception("duplicate"))
+
+            def rollback(self) -> None:
+                self.rolled_back = True
+
+            def refresh(self, _obj: Any) -> None:  # pragma: no cover — unreachable
+                pass
+
+            def close(self) -> None:  # pragma: no cover — never called by client
+                pass
+
+        stub_db = _StubDb()
+
+        def _override_get_db() -> Iterator[_StubDb]:
+            yield stub_db
+
+        def _override_get_current_user() -> User:
+            return fake_user
+
+        live_app.dependency_overrides[bookmarks_get_db] = _override_get_db
+        live_app.dependency_overrides[get_current_user] = _override_get_current_user
+        try:
+            resp = client.post("/bookmarks/", json={"article_id": 42})
+        finally:
+            live_app.dependency_overrides.pop(bookmarks_get_db, None)
+            live_app.dependency_overrides.pop(get_current_user, None)
+
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"].lower()
+        assert stub_db.rolled_back, (
+            "create_bookmark must call db.rollback() before raising 409 — "
+            "leaving the session in PendingRollbackError state breaks "
+            "subsequent requests on the same connection."
+        )
+
+
+# -----------------------------------------------------------------------------
+# Crawl-worker rollback hygiene
+# -----------------------------------------------------------------------------
+
+
+class TestCrawlWorkerRollbackHygiene:
+    """Change B in the security PR: the crawl_worker exception handlers
+    call ``db.rollback()`` BEFORE mutating ``crawl_job`` and re-committing.
+
+    Without that rollback, a failed earlier commit leaves the session in
+    ``PendingRollbackError`` and the second commit propagates, the job
+    stays in its prior status, and the worker retries the poisoned job
+    forever.
+
+    The full ``crawl_article`` function has a wide mock surface (requests,
+    robots, sentiment, NLP) that we don't want to recreate here. Instead
+    we test the contract directly: after a network failure, the handler
+    must record FAILED + ``NETWORK_ERROR`` and must have called rollback.
+    """
+
+    def test_network_error_handler_rolls_back_then_records_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import requests
+
+        from app.jobs import crawl_worker
+        from app.models.crawl_job import CrawlStatus
+
+        # Make robots check return "allowed" without doing network IO.
+        monkeypatch.setattr(
+            crawl_worker,
+            "check_robots_compliance",
+            lambda _url: {"allowed": True, "reason": "ok"},
+        )
+        # Skip the rate-limit delay path.
+        monkeypatch.setattr(crawl_worker, "respect_crawl_delay", lambda *_a: True)
+
+        # Make the actual fetch raise RequestException so we land in the
+        # handler under test.
+        def _raise_network(*_a: Any, **_kw: Any) -> Any:
+            raise requests.RequestException("simulated DNS failure")
+
+        monkeypatch.setattr(crawl_worker.requests, "get", _raise_network)
+
+        # Stub crawl_job + article. ``article`` is read once at the top
+        # of the function for url + domain.
+        class _Article:
+            url = "https://example.com/post"
+
+        class _CrawlJob:
+            article = _Article()
+            status: Any = CrawlStatus.PENDING
+            error_code: Any = None
+            error_message: Any = None
+            updated_at: Any = None
+            robots_allowed: Any = None
+            http_status: Any = None
+            bytes_downloaded: Any = None
+            fetched_at: Any = None
+
+        crawl_job = _CrawlJob()
+
+        # Stub Session: record the call sequence so we can assert order.
+        calls: list[str] = []
+
+        class _StubSession:
+            def commit(self) -> None:
+                calls.append("commit")
+
+            def rollback(self) -> None:
+                calls.append("rollback")
+
+            # Methods the success path would touch but the failing path
+            # below should never reach.
+            def add(self, *_a: Any) -> None:  # pragma: no cover
+                pass
+
+            def query(self, *_a: Any) -> Any:  # pragma: no cover
+                raise AssertionError("query() unexpected on network-error path")
+
+        result = crawl_worker.crawl_article(crawl_job, _StubSession())  # type: ignore[arg-type]
+
+        assert result is False
+        assert crawl_job.status == CrawlStatus.FAILED
+        assert crawl_job.error_code == "NETWORK_ERROR"
+        assert "Network error" in crawl_job.error_message
+
+        # The exact sequence we want: status-update commit (line ~140)
+        # succeeded, then network error fired, then handler rolled back
+        # before re-committing the failure record.
+        assert calls == ["commit", "rollback", "commit"], (
+            f"expected commit→rollback→commit, got {calls}"
+        )


### PR DESCRIPTION
## Summary

Closes the Cybersecurity and Relational Databases module submissions. Seven atomic commits, all on top of `main`.

| # | Commit | Concern |
|---|---|---|
| 1 | `feat(security): OIDC verification on Scheduler endpoints + slowapi rate limiting` | Cloud Scheduler endpoints now require Google-signed OIDC tokens; per-IP rate limits applied to scheduler/sentiment/analytics. |
| 2 | `chore(security): add gitleaks pre-commit + pip-audit CI workflow` | Secret-leak scanner pre-commit + CI; PyPI-CVE gate per PR + weekly cron. |
| 3 | `test(security): add auth + rate-limit + CORS test suite` | Tests for the new and existing security primitives. |
| 4 | `fix(db): enable PITR + tune SQLAlchemy connection pool + 409 on duplicate bookmark + crawler rollback hygiene` | DB durability + correctness wins; bookmark-duplicate trigger now translates to clean HTTP 409; crawl-worker rollback bug closed. |
| 5 | `chore(ci): add Dependabot config for weekly pip + npm + actions updates` | Codifies the existing Dependabot setup. |
| 6 | `docs(security): add THREAT_MODEL.md and SECURITY_MEASURES.md, sync README, document transactions` | STRIDE threat model per component; controls catalogued by layer; ACID/transactions section in DATABASE.md. |
| 7 | `fix(observability): align logging + error semantics with documented behavior` | Audit-driven: 503s no longer leak exception text; `exc_info=True` on error logs; structured JSON in job entry-points; auth-failure cause logging. |

## What this PR addresses

### Cybersecurity submission deliverables
- Threat model: \`docs/THREAT_MODEL.md\` (STRIDE per component, 6 components, trust-boundary diagram, consolidated known gaps with engineering tradeoffs).
- Security measures: \`docs/SECURITY_MEASURES.md\` (38 measures across 8 layers, each with code citations + threat-anchor links).

### Relational Databases submission deliverables
- ACID/transactions section added to \`docs/DATABASE.md\` documenting per-component commit policy, constraint enforcement, and session aborted-state handling.
- Connection-pool tuning (\`pool_pre_ping\`, \`pool_recycle\`).
- PITR enabled on Cloud SQL (cost: ~\$0.15/month additional at current data volume).

### Closes real defects
- **Crawl-worker infinite-retry bug**: exception handlers now \`db.rollback()\` before re-committing the failure record, so a constraint violation no longer poisons the session and traps the worker.
- **HTTP 500 on duplicate bookmark** → now HTTP 409 with a clean detail.
- **503 responses leaking internal exception text** → now generic \"Service temporarily unavailable\".
- **Background jobs bypassing structured JSON logs** via \`logging.basicConfig()\` → now use \`setup_logging()\`.
- **Silent VADER fallback** when GCP NL fails → now logs WARNING with stack trace.
- **Auth-failure cause swallowed** → now logged for forensics; client still sees only generic 401.

### New tests (12 → 37 total)
- \`TestFirebaseAuthGate\`, \`TestSchedulerOidcGate\`, \`TestCorsPolicy\`, \`TestRateLimiting\`, \`TestBookmarkConflictHandling\`, \`TestCrawlWorkerRollbackHygiene\`, \`TestErrorDetailDoesNotLeakInternals\`.

## Sanity checks (local, pre-push)

- \`ruff check app/ tests/\` → clean
- \`mypy app/\` → 64 files, clean
- \`pytest tests/ -v\` → **37 passed**
- All YAML files parse
- \`terraform fmt -check -diff\` + \`terraform validate\` → clean

## Test plan

- [ ] CI \`test\` job passes
- [ ] Production deploy succeeds end-to-end (build + migrations as \`aifeelnews\` user + Cloud Run revision health-check)
- [ ] New revision spec shows \`DATABASE_URL\` as \`secretKeyRef\` (no literal value)
- [ ] Smoke: \`/health\`, \`/api/v1/articles/?limit=1\`, \`/api/v1/db-analytics/sentiment/breakdown\`
- [ ] OIDC-protected \`/api/v1/cleanup\` returns 401 unauthenticated