### PR TITLE
feat: filter/search/paginate + bookmarks UI + local-setup fixes + submission packages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,22 @@
-# Example .env for local development. Copy to .env and fill secrets. Do NOT commit .env.
-# Local DB uses SQLite by default for quick setup. For Postgres set a proper URL.
+# Example .env for local development. Copy to .env. Do NOT commit .env.
+# These defaults work as-is with `docker-compose up`. To use a host-side
+# Postgres, set LOCAL_DATABASE_URL to a postgresql:// URL pointing at it.
 ENV=local
-LOCAL_DATABASE_URL=sqlite:///./dev.db
-# If you have Postgres locally, use: postgresql://user:pass@localhost:5432/aifeelnews_dev
-DATABASE_URL=
 
-# Mediastack API key (required to fetch real articles).
+# Postgres credentials used by docker-compose (the `db` service reads them
+# from the env_file and `web` connects via DATABASE_URL on the docker network).
+POSTGRES_DB=aifeelnews
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=devpassword
+DATABASE_URL=postgresql://postgres:devpassword@db:5432/aifeelnews
+
+# Host-side Postgres URL (used when running uvicorn directly, not via Compose).
+# Leave commented unless running bare-metal — Compose uses DATABASE_URL above.
+# LOCAL_DATABASE_URL=postgresql://postgres:devpassword@localhost:5433/aifeelnews
+
+# Mediastack API key (required to fetch real articles via the scheduler).
 # Free tier: 100 requests/month at https://mediastack.com
-# Leave blank for local testing without ingestion.
+# Leave blank for the seed-data + worker demo path.
 MEDIASTACK_API_KEY=
 MEDIASTACK_BASE_URL=https://api.mediastack.com/v1/news
 MEDIASTACK_FETCH_LIMIT=25
@@ -22,7 +31,7 @@ PLACEHOLDER_IMAGE=https://picsum.photos/id/366/200/300
 # Sentiment analysis provider
 # VADER = free local fallback (no credentials needed, good for local dev)
 # GCP_NL = Google Cloud Natural Language API (production, requires GCP credentials below)
-SENTIMENT_PROVIDER=GCP_NL
+SENTIMENT_PROVIDER=VADER
 
 # Google Cloud Natural Language API (optional, for production sentiment analysis)
 # GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account-key.json

--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,11 @@ DATABASE_URL=postgresql://postgres:devpassword@db:5432/aifeelnews
 # Leave commented unless running bare-metal — Compose uses DATABASE_URL above.
 # LOCAL_DATABASE_URL=postgresql://postgres:devpassword@localhost:5433/aifeelnews
 
-# Mediastack API key (required to fetch real articles via the scheduler).
-# Free tier: 100 requests/month at https://mediastack.com
-# Leave blank for the seed-data + worker demo path.
+# Mediastack API key — only needed for production-equivalent mode (live
+# ingestion via the scheduler). The project enforces HTTPS, which the
+# Mediastack free tier does not allow, so a paid key is required to
+# actually fetch articles. Demo mode (the default) skips ingestion
+# entirely and uses the bundled seed dataset — leave this blank.
 MEDIASTACK_API_KEY=
 MEDIASTACK_BASE_URL=https://api.mediastack.com/v1/news
 MEDIASTACK_FETCH_LIMIT=25
@@ -29,8 +31,12 @@ MEDIASTACK_TIMEOUT=10
 PLACEHOLDER_IMAGE=https://picsum.photos/id/366/200/300
 
 # Sentiment analysis provider
-# VADER = free local fallback (no credentials needed, good for local dev)
-# GCP_NL = Google Cloud Natural Language API (production, requires GCP credentials below)
+# VADER  = free local analyzer; produces sentiment label + score only
+#          (no entities, no NLP categories — Top Entities and GCP NL
+#          Categories charts on the Analytics dashboard stay empty).
+# GCP_NL = Google Cloud Natural Language API; produces sentiment +
+#          entities + categories. Requires a GCP service account JSON
+#          with the Cloud Natural Language API enabled (see below).
 SENTIMENT_PROVIDER=VADER
 
 # Google Cloud Natural Language API (optional, for production sentiment analysis)

--- a/README.md
+++ b/README.md
@@ -32,15 +32,37 @@ Ingests articles from Mediastack, crawls original content (respecting robots.txt
 - Node.js 18+ (frontend)
 - Docker + Docker Compose (optional — for full-stack setup)
 
+### Two run modes
+
+The project has two distinct local-run modes:
+
+| Mode | Sentiment | Articles | Credentials needed |
+|---|---|---|---|
+| **Demo** (default in `.env.example`) | VADER | Bundled seed dataset (50 articles) | None |
+| **Production-equivalent** | GCP NL (entities + categories) | Live Mediastack ingestion | GCP service account JSON + paid Mediastack key |
+
+Demo mode is fully self-contained — no API keys, no GCP project. The bundled seed has sentiment pre-populated, so filters and the sentiment-trends chart on the Analytics dashboard work out of the box. The Top Entities and GCP NL Categories charts will be empty in demo mode because VADER does not produce entity or category data, and the seed dataset does not include rows in `article_entities` or `article_categories`. Running the worker with `--queue-crawl-jobs` (see below) populates `article_contents` and `sentiment_analyses` from the live article URLs.
+
+Production-equivalent mode requires real credentials: a GCP service account JSON with the Cloud Natural Language API enabled, and a paid Mediastack key — the free tier is HTTP-only and the project enforces HTTPS in [`app/config/ingestion.py:7`](app/config/ingestion.py#L7), so a free key will not authenticate. Both are project secrets and not shipped with the repo.
+
 ### Recommended: Docker Compose
 
-The supported local path. The Alembic migration chain uses Postgres-only DDL (views, PL/pgSQL functions, triggers), so a Postgres-backed setup is the path that mirrors production. Compose brings up the database, web, worker, and scheduler in one shot.
+Compose brings up Postgres, the FastAPI service, the worker, and the scheduler in one shot. The Alembic migration chain uses Postgres-only DDL (views, PL/pgSQL functions, triggers), so a Postgres-backed setup is the path that mirrors production.
 
 ```bash
-cp .env.example .env                        # committed defaults are sufficient
+cp .env.example .env                        # committed defaults run demo mode
 docker-compose up --build                   # first build ~2-3 min; subsequent boots are seconds
 docker-compose exec web python -m app.seeds.seed_db   # bundled 50-article snapshot
 ```
+
+To exercise the **full ingestion pipeline** (robots.txt check, body extraction, sentiment + entity analysis on real article URLs), pass `--queue-crawl-jobs`:
+
+```bash
+docker-compose exec web python -m app.seeds.seed_db --queue-crawl-jobs
+docker-compose logs -f worker      # watch the worker drain the queue
+```
+
+The seed URLs are real public URLs (BBC, The Guardian, Reuters, etc., sampled from production). Some will not crawl successfully — they may have been moved or removed (`status=FAILED`), be denied by `robots.txt` (`status=FORBIDDEN_BY_ROBOTS`), or hit the per-host rate limit (`status=RATE_LIMITED`, retried later). That is the intended behavior of the worker; failures are surfaced in `crawl_jobs.status` and visible at `GET /metrics`.
 
 Frontend runs separately (the SPA is a Vite + Svelte 5 app, not part of Compose):
 
@@ -97,12 +119,13 @@ alembic history                   # View migration history
 **Loading sample data.** A static seed dataset of 50 articles across 10 sources (sampled from production with PII removed) is bundled at `app/seeds/seed_data.json`. Load it after running migrations:
 
 ```bash
-python -m app.seeds.seed_db          # idempotent: safe to re-run, skips existing URLs
-python -m app.seeds.seed_db --reset  # wipe seed rows then reinsert
-python -m app.seeds.seed_db --dry-run # show what would be inserted, no commits
+python -m app.seeds.seed_db                       # idempotent: safe to re-run, skips existing URLs
+python -m app.seeds.seed_db --reset               # wipe seed rows then reinsert
+python -m app.seeds.seed_db --dry-run             # show what would be inserted, no commits
+python -m app.seeds.seed_db --queue-crawl-jobs    # also enqueue PENDING crawl_jobs for the worker
 ```
 
-This is the recommended path for local development and demos — no Mediastack key required. For "production-shape" data, configure `MEDIASTACK_API_KEY` and run `python -m app.jobs.run_ingestion` instead.
+This is the recommended path for local development and demos — no Mediastack key required. The seed URLs are real, so `--queue-crawl-jobs` lets the worker exercise the full pipeline against live article pages (a mix of SUCCESS / RATE_LIMITED / FAILED / FORBIDDEN_BY_ROBOTS terminal states is expected behaviour, not a fault). For "production-shape" data, configure `MEDIASTACK_API_KEY` and run `python -m app.jobs.run_ingestion` instead — see the "Two run modes" section above for what that path requires.
 
 ### Environment Variables
 
@@ -113,8 +136,8 @@ This is the recommended path for local development and demos — no Mediastack k
 | `ENV` | No | `local` (default) / `development` / `production` |
 | `LOCAL_DATABASE_URL` | No | Default: `sqlite:///./dev.db` |
 | `DATABASE_URL` | Docker only | PostgreSQL URL for docker-compose (`postgresql://postgres:pass@db:5432/aifeelnews`) |
-| `MEDIASTACK_API_KEY` | For ingestion | Free tier at [mediastack.com](https://mediastack.com) (100 req/month) |
-| `SENTIMENT_PROVIDER` | No | `VADER` (free, local) or `GCP_NL` (default, needs GCP credentials) |
+| `MEDIASTACK_API_KEY` | Production-equivalent mode only | Paid tier required — the free tier is HTTP-only and the project enforces HTTPS. Demo mode skips ingestion and uses the bundled seed instead. |
+| `SENTIMENT_PROVIDER` | No | `VADER` (default in `.env.example`, free, no credentials) or `GCP_NL` (production-equivalent, needs a GCP service account JSON with the Cloud Natural Language API enabled) |
 
 **Frontend** (`frontend/.env` — copy from `frontend/.env.example`):
 

--- a/README.md
+++ b/README.md
@@ -32,76 +32,62 @@ Ingests articles from Mediastack, crawls original content (respecting robots.txt
 - Node.js 18+ (frontend)
 - Docker + Docker Compose (optional — for full-stack setup)
 
-### Option A: Minimal Setup (SQLite + VADER)
+### Recommended: Docker Compose
 
-No external services needed. Uses SQLite for the database and VADER for local sentiment analysis.
+The supported local path. The Alembic migration chain uses Postgres-only DDL (views, PL/pgSQL functions, triggers), so a Postgres-backed setup is the path that mirrors production. Compose brings up the database, web, worker, and scheduler in one shot.
 
 ```bash
-# Install dependencies
-pip install -r requirements.txt
-
-# Configure environment
-cp .env.example .env
-# Defaults: SQLite database, GCP_NL sentiment (change to VADER for free local analysis)
-# Edit .env → SENTIMENT_PROVIDER=VADER
-
-# Create database tables
-alembic upgrade head
-
-# Start backend API
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+cp .env.example .env                        # committed defaults are sufficient
+docker-compose up --build                   # first build ~2-3 min; subsequent boots are seconds
+docker-compose exec web python -m app.seeds.seed_db   # bundled 50-article snapshot
 ```
 
+Frontend runs separately (the SPA is a Vite + Svelte 5 app, not part of Compose):
+
 ```bash
-# Frontend (separate terminal)
 cd frontend
-cp .env.example .env              # defaults point to localhost:8000
+cp .env.example .env
+echo "VITE_API_BASE_URL=http://localhost:8080" >> .env.local
 npm install && npm run dev
 ```
 
-API docs: http://localhost:8000/docs (Swagger UI). To ingest real articles, add a `MEDIASTACK_API_KEY` to `.env` ([free tier](https://mediastack.com)), then run:
-```bash
-python -m app.jobs.run_ingestion
-```
+Backend services:
 
-### Option B: Full Stack (Docker Compose)
-
-Runs PostgreSQL 14, the API server, background worker, and scheduler in containers.
-
-```bash
-cp .env.example .env
-# Set in .env:
-#   POSTGRES_PASSWORD=<your-password>
-#   DATABASE_URL=postgresql://postgres:<your-password>@db:5432/aifeelnews
-docker-compose up --build
-```
-
-This starts four services:
 | Service | Port | Description |
 |---------|------|-------------|
 | **db** | 5433 | PostgreSQL 14 with persistent volume |
 | **web** | 8080 | FastAPI API (migrations run automatically on startup) |
-| **worker** | — | Background crawling + NLP analysis |
-| **scheduler** | — | Periodic ingestion (every hour) |
+| **worker** | — | Background crawling + NLP analysis on articles in the `crawl_jobs` queue |
+| **scheduler** | — | Hourly Mediastack ingestion (only active when `MEDIASTACK_API_KEY` is set) |
 
-Frontend runs separately:
+API docs are at `http://localhost:8080/docs` (Swagger UI).
+
+### Bare-metal alternative
+
+If you'd rather not use Docker, install PostgreSQL 14 on the host and point `LOCAL_DATABASE_URL` at it:
+
 ```bash
-cd frontend
+pip install -r requirements.txt
 cp .env.example .env
-# Edit .env → VITE_API_BASE_URL=http://localhost:8080
-npm install && npm run dev
+# Edit .env: LOCAL_DATABASE_URL=postgresql://<user>:<pass>@localhost:5432/aifeelnews
+
+alembic upgrade head
+python -m app.seeds.seed_db
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
+
+SQLite is **not** a supported substitute for Postgres at the migration layer — the test suite uses SQLite via `Base.metadata.create_all` (which sidesteps migrations), but `alembic upgrade head` against SQLite will fail on the views/functions/triggers DDL.
 
 ### Database Setup
 
 | Environment | Database | Configuration |
 |-------------|----------|---------------|
-| **Local dev** | SQLite (default) | `LOCAL_DATABASE_URL=sqlite:///./dev.db` — no install needed |
-| **Docker Compose** | PostgreSQL 14 | Auto-provisioned, port 5433, set `DATABASE_URL` in `.env` |
+| **Docker Compose** | PostgreSQL 14 | Auto-provisioned, port 5433, defaults in `.env.example` |
 | **Standalone Postgres** | PostgreSQL 14 | Set `LOCAL_DATABASE_URL=postgresql://user:pass@localhost:5432/aifeelnews_dev` |
+| **Tests** | SQLite (in-memory) | Created on the fly via `Base.metadata.create_all` — bypasses migrations |
 | **Production** | Cloud SQL | Managed via Terraform — see [Multi-Environment Strategy](docs/MULTI_ENVIRONMENT_STRATEGY.md) |
 
-Schema migrations are managed by Alembic (8 migration files):
+Schema migrations are managed by Alembic (10 migration files; see [docs/DATABASE.md § 2](docs/DATABASE.md#2-migrations) for the inventory):
 ```bash
 alembic upgrade head              # Apply all pending migrations
 alembic downgrade -1              # Rollback last migration
@@ -146,7 +132,7 @@ This is the recommended path for local development and demos — no Mediastack k
 | `GET /ready` | Readiness probe (DB-aware) |
 | `GET /version` | Build SHA + timestamp |
 | `GET /metrics` | Lightweight observability metrics |
-| `GET /articles/`, `GET /articles/{id}`, `GET /articles/latest` | Articles with sentiment data |
+| `GET /articles/`, `GET /articles/{id}`, `GET /articles/latest` | Articles with sentiment data; list routes accept `skip`, `limit`, `sentiment_label`, `category`, `source_id`, `search` |
 | `GET /sources/`, `POST /sources/` | News sources |
 | `GET/POST/DELETE /bookmarks/...` | User bookmarks (auth required) |
 | `GET /api/v1/sentiment/info` | Active sentiment provider |

--- a/alembic/versions/f2a3b4c5d6e7_add_article_filter_indexes.py
+++ b/alembic/versions/f2a3b4c5d6e7_add_article_filter_indexes.py
@@ -1,0 +1,31 @@
+"""add article filter indexes
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-05-03 09:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Filter columns on /articles/ — supports the sentiment/category/source
+    # filters and FK-join performance for source_id lookups.
+    op.create_index("ix_articles_sentiment_label", "articles", ["sentiment_label"])
+    op.create_index("ix_articles_category", "articles", ["category"])
+    op.create_index("ix_articles_source_id", "articles", ["source_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_articles_source_id", table_name="articles")
+    op.drop_index("ix_articles_category", table_name="articles")
+    op.drop_index("ix_articles_sentiment_label", table_name="articles")

--- a/app/models/article.py
+++ b/app/models/article.py
@@ -20,7 +20,9 @@ class Article(Base):
     __tablename__ = "articles"
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
-    source_id: Mapped[int] = mapped_column(ForeignKey("sources.id", ondelete="CASCADE"))
+    source_id: Mapped[int] = mapped_column(
+        ForeignKey("sources.id", ondelete="CASCADE"), index=True
+    )
     title: Mapped[str] = mapped_column(String(255))
     description: Mapped[Optional[str]] = mapped_column(String(1000), default=None)
     url: Mapped[str] = mapped_column(String(1000), unique=True)
@@ -28,8 +30,12 @@ class Article(Base):
     published_at: Mapped[datetime] = mapped_column(index=True)
     language: Mapped[Optional[str]] = mapped_column(String(2), default=None)
     country: Mapped[Optional[str]] = mapped_column(String(2), default=None)
-    category: Mapped[Optional[str]] = mapped_column(String(50), default=None)
-    sentiment_label: Mapped[Optional[str]] = mapped_column(String(20), default=None)
+    category: Mapped[Optional[str]] = mapped_column(
+        String(50), default=None, index=True
+    )
+    sentiment_label: Mapped[Optional[str]] = mapped_column(
+        String(20), default=None, index=True
+    )
     sentiment_score: Mapped[Optional[float]] = mapped_column(default=None)
 
     source: Mapped["Source"] = relationship(back_populates="articles")

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload, subqueryload
 
 from app.database import get_db
@@ -11,44 +11,84 @@ from app.schemas.article import ArticleRead
 router = APIRouter(tags=["Articles"])
 
 
-@router.get("/", response_model=List[ArticleRead])
-def get_articles(db: Session = Depends(get_db), limit: int = 20) -> List[ArticleRead]:
-    articles = (
-        db.query(ArticleModel)
-        .options(
-            joinedload(ArticleModel.source),
-            joinedload(ArticleModel.sentiment_analyses),
-            subqueryload(ArticleModel.article_entities).joinedload(
-                ArticleEntity.entity
-            ),
-            subqueryload(ArticleModel.article_categories),
+def _query_articles(
+    db: Session,
+    skip: int,
+    limit: int,
+    sentiment_label: str | None,
+    category: str | None,
+    source_id: int | None,
+    search: str | None,
+) -> list[ArticleModel]:
+    """Build the article-list query with optional filters and pagination.
+
+    The filter columns (sentiment_label, category, source_id) are indexed in
+    migration ``f2a3b4c5d6e7`` so filter+order is index-supported. Substring
+    search on title is unindexed; production-grade search would use pg_trgm
+    GIN.
+    """
+    query = db.query(ArticleModel).options(
+        joinedload(ArticleModel.source),
+        joinedload(ArticleModel.sentiment_analyses),
+        subqueryload(ArticleModel.article_entities).joinedload(ArticleEntity.entity),
+        subqueryload(ArticleModel.article_categories),
+    )
+    if sentiment_label is not None:
+        query = query.filter(ArticleModel.sentiment_label == sentiment_label)
+    if category is not None:
+        query = query.filter(ArticleModel.category == category)
+    if source_id is not None:
+        query = query.filter(ArticleModel.source_id == source_id)
+    if search is not None:
+        query = query.filter(ArticleModel.title.ilike(f"%{search}%"))
+    return list(
+        query.order_by(
+            ArticleModel.published_at.desc(),
+            ArticleModel.id.desc(),
         )
-        .order_by(ArticleModel.published_at.desc())
+        .offset(skip)
         .limit(limit)
         .all()
     )
-    return articles  # type: ignore[return-value,no-any-return]
+
+
+@router.get("/", response_model=List[ArticleRead])
+def get_articles(
+    db: Session = Depends(get_db),
+    skip: int = Query(0, ge=0, description="Pagination offset (zero-based)"),
+    limit: int = Query(20, ge=1, le=100, description="Page size; capped at 100"),
+    sentiment_label: str | None = Query(
+        None,
+        pattern="^(positive|negative|neutral)$",
+        description="Filter by sentiment label",
+    ),
+    category: str | None = Query(None, max_length=50),
+    source_id: int | None = Query(None, ge=1),
+    search: str | None = Query(
+        None,
+        min_length=2,
+        max_length=200,
+        description="Case-insensitive substring match against article title",
+    ),
+) -> List[ArticleRead]:
+    return _query_articles(  # type: ignore[return-value]
+        db, skip, limit, sentiment_label, category, source_id, search
+    )
 
 
 @router.get("/latest", response_model=List[ArticleRead])
 def get_latest_articles(
-    db: Session = Depends(get_db), limit: int = 40
+    db: Session = Depends(get_db),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(40, ge=1, le=100),
+    sentiment_label: str | None = Query(None, pattern="^(positive|negative|neutral)$"),
+    category: str | None = Query(None, max_length=50),
+    source_id: int | None = Query(None, ge=1),
+    search: str | None = Query(None, min_length=2, max_length=200),
 ) -> List[ArticleRead]:
-    articles = (
-        db.query(ArticleModel)
-        .options(
-            joinedload(ArticleModel.source),
-            joinedload(ArticleModel.sentiment_analyses),
-            subqueryload(ArticleModel.article_entities).joinedload(
-                ArticleEntity.entity
-            ),
-            subqueryload(ArticleModel.article_categories),
-        )
-        .order_by(ArticleModel.published_at.desc())
-        .limit(limit)
-        .all()
+    return _query_articles(  # type: ignore[return-value]
+        db, skip, limit, sentiment_label, category, source_id, search
     )
-    return articles  # type: ignore[return-value,no-any-return]
 
 
 @router.get("/{article_id}", response_model=ArticleRead)

--- a/app/seeds/seed_db.py
+++ b/app/seeds/seed_db.py
@@ -38,6 +38,7 @@ from typing import Any, Optional
 from sqlalchemy.orm import Session
 
 from app.models.article import Article
+from app.models.crawl_job import CrawlJob, CrawlStatus
 from app.models.source import Source
 
 DEFAULT_SEED_PATH = Path(__file__).resolve().parent / "seed_data.json"
@@ -103,6 +104,7 @@ def seed_database(
     *,
     reset: bool = False,
     dry_run: bool = False,
+    queue_crawl_jobs: bool = False,
 ) -> dict[str, int]:
     """Seed the database from ``seed_data.json``.
 
@@ -113,10 +115,17 @@ def seed_database(
             "sources_skipped": int,
             "articles_inserted": int,
             "articles_skipped": int,
+            "crawl_jobs_inserted": int,
         }
 
     On ``dry_run=True``, no INSERT/DELETE is committed; counts reflect what
     *would* have been inserted.
+
+    When ``queue_crawl_jobs=True``, a PENDING ``crawl_jobs`` row is created
+    for every seeded article that does not already have one. The worker
+    container then exercises the full pipeline (robots.txt check, body
+    extraction, sentiment + entity analysis on success). Useful for
+    end-to-end demos; off by default to keep the seed step fast.
     """
     path = json_path or DEFAULT_SEED_PATH
     data = _load_seed(path)
@@ -191,6 +200,21 @@ def seed_database(
         seen_urls_in_batch.add(url)
         articles_inserted += 1
 
+    crawl_jobs_inserted = 0
+    if queue_crawl_jobs:
+        # Need article IDs, so flush before querying.
+        db.flush()
+        seed_urls = [a["url"] for a in data["articles"]]
+        articles_to_queue = (
+            db.query(Article)
+            .filter(Article.url.in_(seed_urls))
+            .filter(~Article.id.in_(db.query(CrawlJob.article_id).distinct()))  # type: ignore[arg-type]
+            .all()
+        )
+        for article in articles_to_queue:
+            db.add(CrawlJob(article_id=article.id, status=CrawlStatus.PENDING))
+            crawl_jobs_inserted += 1
+
     if dry_run:
         db.rollback()
     else:
@@ -201,6 +225,7 @@ def seed_database(
         "sources_skipped": sources_skipped,
         "articles_inserted": articles_inserted,
         "articles_skipped": articles_skipped,
+        "crawl_jobs_inserted": crawl_jobs_inserted,
     }
 
 
@@ -231,6 +256,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to seed JSON (defaults to app/seeds/seed_data.json).",
     )
+    parser.add_argument(
+        "--queue-crawl-jobs",
+        action="store_true",
+        help=(
+            "Also enqueue PENDING crawl_jobs rows for each seeded article so "
+            "the worker container exercises the full ingestion pipeline "
+            "(robots.txt, body extraction, sentiment + entity analysis). "
+            "Skipped articles already have a job; URLs that 404, are blocked "
+            "by robots.txt, or rate-limit will land in non-SUCCESS terminal "
+            "states — that is correct behaviour, not failure."
+        ),
+    )
     return parser
 
 
@@ -247,6 +284,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             json_path=args.json_path,
             reset=args.reset,
             dry_run=args.dry_run,
+            queue_crawl_jobs=args.queue_crawl_jobs,
         )
     except Exception as exc:
         db.rollback()
@@ -261,6 +299,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         f"{summary['articles_inserted']} new articles. "
         f"{summary['articles_skipped']} articles already present (skipped)."
     )
+    if args.queue_crawl_jobs:
+        print(
+            f"{prefix}Enqueued {summary['crawl_jobs_inserted']} new crawl jobs "
+            f"(worker will pick them up; tail logs with "
+            f"`docker-compose logs -f worker`)."
+        )
     return 0
 
 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -35,5 +35,8 @@ USER worker
 HEALTHCHECK --interval=60s --timeout=30s --start-period=10s --retries=3 \
     CMD python -c "from app.database import SessionLocal; db = SessionLocal(); db.execute('SELECT 1'); db.close()" || exit 1
 
-# Run background worker jobs
-CMD ["python", "app/jobs/run_crawl_worker.py", "--max-jobs", "10"]
+# Run background worker jobs. ``-m`` runs as a module so the ``app``
+# package on /app is importable. Running the file by path puts the
+# script's own directory on sys.path, not /app, which breaks
+# ``from app.jobs.crawl_worker import ...``.
+CMD ["python", "-m", "app.jobs.run_crawl_worker", "--max-jobs", "10"]

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -28,7 +28,13 @@ docker-compose up --build
 #    something to render. Run this in a second terminal once `web` is up.
 docker-compose exec web python -m app.seeds.seed_db
 
-# 4. (Optional) run the test suite inside the web container.
+# 4. (Optional) Exercise the full ingestion pipeline. Adds PENDING crawl
+#    jobs for every seeded article; the worker picks them up and crawls
+#    the live article URLs (robots.txt-respecting, rate-limited).
+docker-compose exec web python -m app.seeds.seed_db --queue-crawl-jobs
+docker-compose logs -f worker
+
+# 5. (Optional) run the test suite inside the web container.
 docker-compose exec web pytest -v
 ```
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -8,41 +8,50 @@ This doc covers the operational concerns: setup, migrations, schema objects, opt
 
 ## 1. Local Setup
 
-**Prereqs:** Python 3.13, PostgreSQL 14, Docker (optional).
+The supported local path is **Docker Compose**. The migration chain uses PostgreSQL-only DDL (`CREATE OR REPLACE VIEW`, PL/pgSQL functions, `::numeric` casts), so a bare-SQLite path can't run `alembic upgrade head` end-to-end — SQLite is used by the test suite only, via `Base.metadata.create_all`.
+
+### Quick start (Docker)
+
+**Prereqs:** Docker Desktop / Docker Engine + Compose.
 
 ```bash
-# 1. Install Python deps
-pip install -r requirements.txt
+# 1. Copy the example env file. The committed defaults are sufficient for
+#    local Compose; Mediastack/Firebase keys are only needed for live
+#    ingestion and bookmark/auth flows respectively.
+cp .env.example .env
 
-# 2. Configure env
-cat > .env <<'EOF'
-ENV=local
-LOCAL_DATABASE_URL=postgresql://aifeelnews:devpass@localhost:5432/aifeelnews
-ARTICLE_CONTENT_TTL_HOURS=168
-EOF
+# 2. Bring up the full stack (Postgres 14, FastAPI web, worker, scheduler).
+#    First boot builds the images (~2-3 min); subsequent boots are seconds.
+docker-compose up --build
 
-# 3. Start PostgreSQL (or use docker-compose)
-docker run -d --name aifeelnews-pg \
-  -e POSTGRES_USER=aifeelnews -e POSTGRES_PASSWORD=devpass \
-  -e POSTGRES_DB=aifeelnews -p 5432:5432 postgres:14
+# 3. Seed the database with the bundled 50-article snapshot so the UI has
+#    something to render. Run this in a second terminal once `web` is up.
+docker-compose exec web python -m app.seeds.seed_db
 
-# 4. Run migrations
-alembic upgrade head
-
-# 5. Seed with one ingestion run
-python -m app.jobs.run_ingestion
-
-# 6. Start the API
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+# 4. (Optional) run the test suite inside the web container.
+docker-compose exec web pytest -v
 ```
 
-**Full stack via Docker:** `docker-compose up --build` — brings up PostgreSQL, the FastAPI web service, the worker, and the scheduler in one shot.
+The API is then served at `http://localhost:8080` (e.g. `GET /articles/?limit=5`). The frontend in `frontend/` is run separately with `npm run dev` — see [README.md § Development Setup](../README.md#development-setup).
+
+### What's running
+
+| Service | Image | Purpose |
+|---------|-------|---------|
+| `db` | `postgres:14` | Database; persists in a Docker volume |
+| `web` | `aifeelnews-web` | FastAPI app; runs migrations on start |
+| `worker` | `aifeelnews-worker` | Background crawler — fetches article body content for jobs in the `crawl_jobs` queue |
+| `scheduler` | `aifeelnews-scheduler` | Hourly Mediastack ingestion loop (when `MEDIASTACK_API_KEY` is set) |
+
+### Running without Docker
+
+The bare-metal path (Postgres on the host, `uvicorn` on the host) works the same way as inside the container — install dependencies, point `LOCAL_DATABASE_URL` at a Postgres 14 instance, run `alembic upgrade head`, then `python -m app.seeds.seed_db`. SQLite is **not** a supported substitute for Postgres at the migration layer.
 
 ---
 
 ## 2. Migrations
 
-Nine migrations, applied in order. Run `alembic upgrade head` to apply, `alembic downgrade -1` to roll back the most recent one.
+Ten migrations, applied in order. Run `alembic upgrade head` to apply, `alembic downgrade -1` to roll back the most recent one.
 
 | # | Revision | Summary |
 |---|----------|---------|
@@ -55,6 +64,7 @@ Nine migrations, applied in order. Run `alembic upgrade head` to apply, `alembic
 | 7 | `c7d8e9f0a1b2` | Add `entities`, `article_entities`, `article_categories` |
 | 8 | `d8e9f0a1b2c3` | Add `mention_count` to `article_entities` |
 | 9 | `e1f2a3b4c5d6` | Bookmark FK indexes + views, stored functions, triggers |
+| 10 | `f2a3b4c5d6e7` | Article filter indexes — `sentiment_label`, `category`, `source_id` |
 
 ---
 
@@ -156,9 +166,30 @@ The CRUD module [app/crud/analytics.py](../app/crud/analytics.py) uses the right
 **GROUPING SETS — multi-dimensional aggregation in one pass:**
 - `sentiment_grouping_sets()` ([analytics.py:112-117](../app/crud/analytics.py#L112-L117)) — produces per-(category, label) counts plus per-category subtotals plus per-label subtotals plus a grand total in a single query, instead of running four separate `GROUP BY` queries and stitching the results.
 
-### 4.4 Index Inventory
+### 4.4 Article Filter Indexes
 
-Composite and performance indexes are listed in [ER_Diagram.md § Composite & Performance Indexes](ER_Diagram.md#composite--performance-indexes). Highlights: `entities (name, type)` UNIQUE for canonical deduplication, `article_entities (article_id, entity_id)` UNIQUE preventing duplicate mentions, and `article_contents (expires_at)` for the TTL cleanup job.
+The `/articles/` endpoint accepts `sentiment_label`, `category`, `source_id`, and `search` query parameters. Without indexes, every filtered request was a sequential scan over ~30k rows. Added in [migration f2a3b4c5d6e7](../alembic/versions/f2a3b4c5d6e7_add_article_filter_indexes.py):
+
+```sql
+CREATE INDEX ix_articles_sentiment_label ON articles (sentiment_label);
+CREATE INDEX ix_articles_category        ON articles (category);
+CREATE INDEX ix_articles_source_id       ON articles (source_id);
+```
+
+PostgreSQL's planner combines an index lookup on the filter column with the existing `(published_at, id)` order to serve the page directly from the index, instead of scanning then sorting. The `source_id` index also covers the FK join used by the eager-load on `Article.source` ([app/routers/articles.py:30-35](../app/routers/articles.py#L30-L35)).
+
+**Search is intentionally unindexed.** The `search` parameter does `WHERE title ILIKE '%term%'`, which a B-tree cannot accelerate — the leading `%` defeats prefix matching. The production-grade upgrade path is PostgreSQL's `pg_trgm` extension with a GIN index:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX ix_articles_title_trgm ON articles USING gin (title gin_trgm_ops);
+```
+
+This is deferred because the SQLite test fixture used by the pytest suite cannot exercise `pg_trgm` — it would require a Postgres CI service (tracked in PLAN.md as Phase E). At ~30k articles a sequential scan on `title` returns in tens of milliseconds, so the upgrade is a forward-looking optimization, not a current bottleneck.
+
+### 4.5 Index Inventory
+
+Composite and performance indexes are listed in [ER_Diagram.md § Composite & Performance Indexes](ER_Diagram.md#composite--performance-indexes). Highlights: `entities (name, type)` UNIQUE for canonical deduplication, `article_entities (article_id, entity_id)` UNIQUE preventing duplicate mentions, `article_contents (expires_at)` for the TTL cleanup job, and the article filter indexes documented above.
 
 ---
 

--- a/docs/ER_Diagram.md
+++ b/docs/ER_Diagram.md
@@ -159,6 +159,9 @@ Categories are **per-article NLP output**, not a shared vocabulary. Each article
 | `article_entities` | `ix_article_entities_article_entity` | (article_id, entity_id) | UNIQUE | Prevent duplicate mentions |
 | `sentiment_analyses` | `ix_sentiment_analyses_provider_article` | (provider, article_id) | COMPOSITE | Multi-provider lookups |
 | `articles` | `ix_articles_published_at` | (published_at) | B-TREE | Timeline/feed ordering |
+| `articles` | `ix_articles_sentiment_label` | (sentiment_label) | B-TREE | Filter feed by sentiment |
+| `articles` | `ix_articles_category` | (category) | B-TREE | Filter feed by category |
+| `articles` | `ix_articles_source_id` | (source_id) | B-TREE | Filter feed by source + FK join cover |
 | `article_contents` | `ix_article_contents_expires_at` | (expires_at) | B-TREE | TTL cleanup job efficiency |
 | `crawl_jobs` | `ix_crawl_jobs_status` | (status) | B-TREE | Job queue filtering |
 

--- a/docs/PERSONAS_AND_USE_CASES.md
+++ b/docs/PERSONAS_AND_USE_CASES.md
@@ -78,11 +78,11 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 
 | ID | Use Case | Backend | UI | Endpoint | Notes |
 |----|----------|---------|----|----------|-------|
-| UC-13 | View sentiment trends over time | ✅ | 🔲 | `GET /api/v1/analytics/trends?days=30` | Analytics dashboard page deferred |
-| UC-14 | Compare sources by sentiment | ✅ | 🔲 | `GET /api/v1/analytics/sources?days=30` | |
-| UC-15 | View top entities by mention count | ✅ | 🔲 | `GET /api/v1/analytics/entities/top` | |
+| UC-13 | View sentiment trends over time | ✅ | ✅ | `GET /api/v1/analytics/trends?days=30` | Analytics dashboard, "Sentiment Trends" chart |
+| UC-14 | Compare sources by sentiment | ✅ | ✅ | `GET /api/v1/analytics/sources?days=30` | Analytics dashboard, "Source Comparison" chart |
+| UC-15 | View top entities by mention count | ✅ | ✅ | `GET /api/v1/analytics/entities/top` | Analytics dashboard, "Top Entities" chart |
 | UC-16 | View entity sentiment distribution | ✅ | 🔲 | `GET /api/v1/analytics/entities/sentiment` | |
-| UC-17 | View NLP category breakdown | ✅ | 🔲 | `GET /api/v1/analytics/categories/nlp` | |
+| UC-17 | View NLP category breakdown | ✅ | ✅ | `GET /api/v1/analytics/categories/nlp` | Analytics dashboard, "GCP NL Categories" chart |
 | UC-18 | Browse entity directory | ✅ | 🔲 | `GET /api/v1/entities/?entity_type=...` | |
 | UC-19 | View entity detail | ✅ | 🔲 | `GET /api/v1/entities/{id}` | |
 
@@ -102,9 +102,9 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 |---------|-----------|------|------|--------|-----------|
 | P1 Casual Reader | 7 / 7 | 6 / 7 | 1 (UC-02) | 0 | 0 |
 | P2 Registered Reader | 4 / 5 | 4 / 5 | 0 | 0 | 1 (UC-09) |
-| P3 News Analyst | 7 / 7 | 0 / 7 | 7 | 0 | 0 |
+| P3 News Analyst | 7 / 7 | 4 / 7 | 3 (UC-16, UC-18, UC-19) | 0 | 0 |
 | P4 System Administrator | 3 / 3 | n/a | n/a | 3 | 0 |
-| **Totals** | **21 / 22** | **10 / 14 user-facing** | **8** | **3** | **1** |
+| **Totals** | **21 / 22** | **14 / 19 user-facing** | **5** | **3** | **1** |
 
 User-facing UC count excludes P4 (scheduler-driven, no UI by design).
 
@@ -116,8 +116,8 @@ User-facing UC count excludes P4 (scheduler-driven, no UI by design).
 |----|--------|------|
 | UC-02 | UI 🔲 | Article detail page — Svelte route showing full content, entities, sentiment scores. Backend ready. |
 | UC-09 | Backend + UI 🔲 | Email/Password sign-in via Firebase Auth. Deferred because it touches the working Google flow. |
-| UC-13–17 | UI 🔲 | Analytics dashboard with charts (trends, sources, entities, categories). Backend already returns chart-ready JSON. |
-| UC-18–19 | UI 🔲 | Entity directory + detail pages. Backend ready. |
+| UC-16 | UI 🔲 | Entity sentiment-distribution chart. Backend ready; not yet on the dashboard. |
+| UC-18, UC-19 | UI 🔲 | Entity directory list + detail page. Backend ready. |
 
 ---
 

--- a/docs/PERSONAS_AND_USE_CASES.md
+++ b/docs/PERSONAS_AND_USE_CASES.md
@@ -46,70 +46,84 @@
 
 ## Use Cases
 
-Each use case maps to a backend endpoint and indicates implementation status:
-- ✅ Backend implemented
-- ⚠️ Partial (backend exists, frontend not wired or missing params)
+Each use case has two status columns — backend (the API/data layer) and UI (what the SPA actually exposes to a user) — because the two can move at different speeds:
+
+- ✅ Implemented
 - 🔲 Not yet implemented
+- `n/a` Not user-facing (e.g. P4 admin scheduler triggers don't have a UI by design)
 
 ### Casual Reader (P1)
 
-| ID | Use Case | Status | Endpoint | Notes |
-|----|----------|--------|----------|-------|
-| UC-01 | Browse latest articles | ✅ | `GET /articles/latest?limit=40` | |
-| UC-02 | View article detail with sentiment + entities | ✅ | `GET /articles/{id}` | Frontend detail page needed (Phase G) |
-| UC-03 | Filter articles by sentiment label | 🔲 | `GET /articles/?sentiment_label=...` | Query param not yet on endpoint |
-| UC-04 | Filter articles by category | 🔲 | `GET /articles/?category=...` | Query param not yet on endpoint |
-| UC-05 | Filter articles by source | 🔲 | `GET /articles/?source_id=...` | Query param not yet on endpoint |
-| UC-06 | Paginate article feed | 🔲 | `GET /articles/?offset=...&limit=...` | Only `limit` exists today |
-| UC-07 | Search articles by keyword | 🔲 | `GET /articles/?search=...` | No search param on endpoint |
+| ID | Use Case | Backend | UI | Endpoint | Notes |
+|----|----------|---------|----|----------|-------|
+| UC-01 | Browse latest articles | ✅ | ✅ | `GET /articles/latest?limit=40` | |
+| UC-02 | View article detail with sentiment + entities | ✅ | 🔲 | `GET /articles/{id}` | Detail page deferred — feed cards already show sentiment badge |
+| UC-03 | Filter articles by sentiment label | ✅ | ✅ | `GET /articles/?sentiment_label=...` | |
+| UC-04 | Filter articles by category | ✅ | ✅ | `GET /articles/?category=...` | UI uses static mediastack enum; categories endpoint deferred |
+| UC-05 | Filter articles by source | ✅ | ✅ | `GET /articles/?source_id=...` | UI populates dropdown from `GET /sources/` |
+| UC-06 | Paginate article feed | ✅ | ✅ | `GET /articles/?skip=...&limit=...` | |
+| UC-07 | Search articles by keyword | ✅ | ✅ | `GET /articles/?search=...` | ILIKE substring on title; pg_trgm upgrade path documented in DATABASE.md |
 
 ### Registered Reader (P2)
 
-| ID | Use Case | Status | Endpoint | Notes |
-|----|----------|--------|----------|-------|
-| UC-08 | Sign in with Google | ✅ | Firebase Auth (Google provider) | |
-| UC-09 | Sign in with Email/Password | 🔲 | Firebase Auth (Email provider) | Phase D |
-| UC-10 | Bookmark an article | ✅ | `POST /bookmarks/` | Frontend shows "coming soon" alert |
-| UC-11 | View bookmarks list | ✅ | `GET /bookmarks/` | Frontend page needed (Phase G) |
-| UC-12 | Remove a bookmark | ✅ | `DELETE /bookmarks/{id}` | |
+| ID | Use Case | Backend | UI | Endpoint | Notes |
+|----|----------|---------|----|----------|-------|
+| UC-08 | Sign in with Google | ✅ | ✅ | Firebase Auth (Google provider) | |
+| UC-09 | Sign in with Email/Password | 🔲 | 🔲 | Firebase Auth (Email provider) | Phase D — risk of regressing working Google sign-in, deferred |
+| UC-10 | Bookmark an article | ✅ | ✅ | `POST /bookmarks/` | Optimistic UI; 409 treated as silent success |
+| UC-11 | View bookmarks list | ✅ | ✅ | `GET /bookmarks/` | Dedicated `/bookmarks` view in SPA |
+| UC-12 | Remove a bookmark | ✅ | ✅ | `DELETE /bookmarks/{id}` | Optimistic remove with revert-on-error |
 
 ### News Analyst (P3)
 
-| ID | Use Case | Status | Endpoint | Notes |
-|----|----------|--------|----------|-------|
-| UC-13 | View sentiment trends over time | ✅ | `GET /api/v1/analytics/trends?days=30` | |
-| UC-14 | Compare sources by sentiment | ✅ | `GET /api/v1/analytics/sources?days=30` | |
-| UC-15 | View top entities by mention count | ✅ | `GET /api/v1/analytics/entities/top` | |
-| UC-16 | View entity sentiment distribution | ✅ | `GET /api/v1/analytics/entities/sentiment` | |
-| UC-17 | View NLP category breakdown | ✅ | `GET /api/v1/analytics/categories/nlp` | |
-| UC-18 | Browse entity directory | ✅ | `GET /api/v1/entities/?entity_type=...` | |
-| UC-19 | View entity detail | ✅ | `GET /api/v1/entities/{id}` | |
+| ID | Use Case | Backend | UI | Endpoint | Notes |
+|----|----------|---------|----|----------|-------|
+| UC-13 | View sentiment trends over time | ✅ | 🔲 | `GET /api/v1/analytics/trends?days=30` | Analytics dashboard page deferred |
+| UC-14 | Compare sources by sentiment | ✅ | 🔲 | `GET /api/v1/analytics/sources?days=30` | |
+| UC-15 | View top entities by mention count | ✅ | 🔲 | `GET /api/v1/analytics/entities/top` | |
+| UC-16 | View entity sentiment distribution | ✅ | 🔲 | `GET /api/v1/analytics/entities/sentiment` | |
+| UC-17 | View NLP category breakdown | ✅ | 🔲 | `GET /api/v1/analytics/categories/nlp` | |
+| UC-18 | Browse entity directory | ✅ | 🔲 | `GET /api/v1/entities/?entity_type=...` | |
+| UC-19 | View entity detail | ✅ | 🔲 | `GET /api/v1/entities/{id}` | |
 
 ### System Administrator (P4)
 
-| ID | Use Case | Status | Endpoint | Notes |
-|----|----------|--------|----------|-------|
-| UC-20 | Trigger manual ingestion | ✅ | `POST /api/v1/trigger-ingestion` | Needs OIDC auth (Phase D) |
-| UC-21 | View pipeline health metrics | ✅ | `GET /api/v1/analytics/pipeline?days=7` | |
-| UC-22 | Run TTL content cleanup | ✅ | `POST /api/v1/cleanup` | Needs OIDC auth (Phase D) |
+| ID | Use Case | Backend | UI | Endpoint | Notes |
+|----|----------|---------|----|----------|-------|
+| UC-20 | Trigger manual ingestion | ✅ | n/a | `POST /api/v1/trigger-ingestion` | Cloud Scheduler-driven, OIDC-verified |
+| UC-21 | View pipeline health metrics | ✅ | n/a | `GET /api/v1/analytics/pipeline?days=7` | Available to operators via API + GCP console |
+| UC-22 | Run TTL content cleanup | ✅ | n/a | `POST /api/v1/cleanup` | Cloud Scheduler-driven, OIDC-verified |
 
 ---
 
 ## Use Case Summary
 
-| Status | Count | Notes |
-|--------|-------|-------|
-| ✅ Implemented | 14 | Backend fully functional |
-| ⚠️ Partial | 0 | — |
-| 🔲 Planned | 8 | Filtering, pagination, search, Email auth, frontend wiring |
+| Persona | Backend ✅ | UI ✅ | UI 🔲 | UI n/a | Backend 🔲 |
+|---------|-----------|------|------|--------|-----------|
+| P1 Casual Reader | 7 / 7 | 6 / 7 | 1 (UC-02) | 0 | 0 |
+| P2 Registered Reader | 4 / 5 | 4 / 5 | 0 | 0 | 1 (UC-09) |
+| P3 News Analyst | 7 / 7 | 0 / 7 | 7 | 0 | 0 |
+| P4 System Administrator | 3 / 3 | n/a | n/a | 3 | 0 |
+| **Totals** | **21 / 22** | **10 / 14 user-facing** | **8** | **3** | **1** |
 
-**Total: 22 use cases across 4 personas**
+User-facing UC count excludes P4 (scheduler-driven, no UI by design).
+
+---
+
+## Roadmap for not-yet-implemented use cases
+
+| ID | Status | Plan |
+|----|--------|------|
+| UC-02 | UI 🔲 | Article detail page — Svelte route showing full content, entities, sentiment scores. Backend ready. |
+| UC-09 | Backend + UI 🔲 | Email/Password sign-in via Firebase Auth. Deferred because it touches the working Google flow. |
+| UC-13–17 | UI 🔲 | Analytics dashboard with charts (trends, sources, entities, categories). Backend already returns chart-ready JSON. |
+| UC-18–19 | UI 🔲 | Entity directory + detail pages. Backend ready. |
 
 ---
 
 ## Traceability Matrix
 
-A traceability matrix connects requirements (use cases) to implementation (tables, phases, endpoints). It ensures every table in the schema serves at least one real user need, and every planned feature traces back to a persona.
+A traceability matrix connects requirements (use cases) to implementation (tables, endpoints). It ensures every table in the schema serves at least one real user need, and every planned feature traces back to a persona.
 
 ### Tables → Use Cases (DB-centric view)
 
@@ -125,12 +139,3 @@ A traceability matrix connects requirements (use cases) to implementation (table
 | `article_entities` | UC-15–16, UC-18 | M2M with payload — salience/mention_count power entity analytics |
 | `article_categories` | UC-04, UC-17 | NLP classification enables category filtering and heatmaps |
 | `crawl_jobs` | UC-21 | Pipeline health metrics for System Admin |
-
-### Phases → Use Cases (implementation view)
-
-| Phase | Use Cases Addressed | What It Delivers |
-|-------|---------------------|------------------|
-| **B** (DB Excellence) | UC-03–07 | Filtering, pagination, search — requires new query params + indexes |
-| **D** (Auth + Security) | UC-09, UC-20, UC-22 | Email/Password sign-in, OIDC on admin endpoints |
-| **F** (BigQuery) | UC-13–17 | Richer analytics queries powering dashboard charts |
-| **G** (Frontend) | UC-02, UC-06–07, UC-10–11 | Article detail page, pagination/search UI, bookmarks page |

--- a/docs/submissions/SUBMISSION_CYBERSECURITY.md
+++ b/docs/submissions/SUBMISSION_CYBERSECURITY.md
@@ -1,0 +1,293 @@
+# Cybersecurity Submission — aiFeelNews
+
+**Module:** SE_09 — Cybersecurity
+**Author:** Matias Cardone
+**Submission date:** 2026-05-04
+
+---
+
+## How to view this submission's exact state
+
+This document corresponds to git tag `submission-cybersec-2026-05-04` and branch `submission-2026-05-04` on the project repository. The live URL `https://aifeelnews-front.web.app/` reflects the same state at submission time but may evolve as the project continues toward the Capstone assessment in 2-3 weeks.
+
+**File links in this document point to the frozen `submission-2026-05-04` branch**, not to `main`. That way the source they reference doesn't drift if the project keeps moving after submission.
+
+| Pointer | Where |
+|---|---|
+| Repository | https://github.com/cardox6/aifeelnews/tree/submission-2026-05-04 |
+| Tag | `submission-cybersec-2026-05-04` |
+| Live frontend | https://aifeelnews-front.web.app/ |
+| Live API | https://aifeelnews-web-813770885946.europe-west1.run.app |
+| Threat model | [docs/THREAT_MODEL.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/THREAT_MODEL.md) |
+| Security measures | [docs/SECURITY_MEASURES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md) |
+
+---
+
+## 1. Project identity
+
+aiFeelNews is a news sentiment analysis platform deployed on Google Cloud (Cloud Run + Cloud SQL + Firebase Auth + Firebase Hosting). It ingests articles from Mediastack, crawls original content respecting robots.txt, runs sentiment analysis via Google Cloud Natural Language API, and serves a Svelte SPA backed by a FastAPI service. Auth uses Firebase ID tokens verified server-side; the Cloud Scheduler integration uses OIDC.
+
+The repository is **public** at https://github.com/cardox6/aifeelnews — no invitation needed.
+
+**Team contribution:** solo project. All commits on the `submission-2026-05-04` branch are mine.
+
+---
+
+## 2. Documentation pointers
+
+The two primary security artifacts:
+
+- [docs/THREAT_MODEL.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/THREAT_MODEL.md) — STRIDE applied per component (6 components: Cloud Run web service, Cloud SQL, Firebase Auth, Cloud Scheduler → API, CI/CD, external ingestion). Trust-boundary diagram. Consolidated known-gaps list with engineering tradeoffs.
+- [docs/SECURITY_MEASURES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md) — 38 implemented controls catalogued by 8 layers (Identity & Access, Secrets, Transport & Network, Application, Data Protection, Container & Runtime, CI/CD & Supply Chain, Monitoring & Detection). Every measure is line-anchored to source.
+
+The README's [§ Security section](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/README.md#security) gives a one-screen summary of the same material.
+
+---
+
+## 3. Threat model — sample inline
+
+The full STRIDE-per-component analysis is in [THREAT_MODEL.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/THREAT_MODEL.md). Two excerpts to illustrate the level of analysis the document carries:
+
+### Trust boundaries (ASCII diagram from the doc)
+
+```
+     ┌────────────────────────────────────────────────────────────────┐
+     │                    Public internet (untrusted)                 │
+     │                                                                │
+     │   Browser ──HTTPS──► Firebase Hosting (SPA)                    │
+     │   Browser ──HTTPS──► Cloud Run web (FastAPI)                   │
+     │   Mediastack/news sites ──HTTPS──► Cloud Run worker            │
+     └───────────────┬─────────────────────────────┬──────────────────┘
+                     │                             │
+              [TLS terminus]                  [TLS terminus]
+                     │                             │
+     ┌───────────────▼─────────────────────────────▼──────────────────┐
+     │            GCP project boundary (aifeelnews-prod)              │
+     │                                                                │
+     │   Cloud Run ───Unix socket───► Cloud SQL Auth Proxy            │
+     │              ───Secret Manager──► (mediastack key, db url, …)  │
+     │              ───OIDC───► Cloud Scheduler                       │
+     │   Firebase Auth ──ID token──► Cloud Run (verified server-side) │
+     └────────────────────────────────────────────────────────────────┘
+```
+
+### Component 1 — Cloud Run web service (sample STRIDE)
+
+| Threat | Concretely | Mitigation |
+|---|---|---|
+| **S**poofing | Forged Firebase ID tokens, impersonation of Cloud Scheduler | Server-side verification of every Firebase token via `firebase_admin.auth.verify_id_token` ([app/deps/auth.py:13-43](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/deps/auth.py#L13-L43)); OIDC verification of Scheduler audience claim ([app/deps/oidc.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/deps/oidc.py)) gated on `ENV=production` |
+| **T**ampering | Modified articles, bookmark IDs in URLs | Pydantic-validated request models reject malformed input with 422; ORM-level FK + ownership checks on bookmark delete |
+| **R**epudiation | "I didn't bookmark that" | Append-only `bookmarks` table with `created_at`; structured JSON logs in production retain user_id + action + timestamp |
+| **I**nformation disclosure | Leaking other users' bookmarks; verbose error stack traces | Bookmark routes scope to `current_user.id` server-side; production responses use generic 503 strings (full traceback in Cloud Logging only) |
+| **D**enial of service | Unauthenticated request floods | slowapi rate limiting on hot endpoints ([app/main.py:71-95](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/main.py#L71-L95)); Cloud Run autoscale ceiling at 10 instances |
+| **E**levation of privilege | Reaching admin scheduler endpoints as a regular user | OIDC + audience-claim verification on `/api/v1/trigger-ingestion` and `/api/v1/cleanup`; least-privilege Cloud Run service account |
+
+The same STRIDE table is filled out for the other 5 components (Cloud SQL, Firebase Auth, Cloud Scheduler → API, CI/CD, external ingestion) in the full document.
+
+---
+
+## 4. Security measures — table of contents (38 measures, 8 layers)
+
+Each entry below links into [SECURITY_MEASURES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md) where the measure is described with a code citation.
+
+### 1. Identity & Access (6)
+- [1.1 Firebase Auth (Google Sign-In)](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#11-firebase-auth-google-sign-in)
+- [1.2 Server-side Firebase ID token verification](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#12-server-side-firebase-id-token-verification)
+- [1.3 OIDC verification on Scheduler endpoints](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#13-oidc-verification-on-scheduler-endpoints)
+- [1.4 Least-privilege application DB user](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#14-least-privilege-application-db-user)
+- [1.5 Least-privilege Cloud Run service account](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#15-least-privilege-cloud-run-service-account)
+- [1.6 Firebase UID linkage on user records](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#16-firebase-uid-linkage-on-user-records)
+
+### 2. Secrets & Key Management (5)
+- 2.1 GCP Secret Manager (6 secrets)
+- 2.2 `DATABASE_URL` as `secretKeyRef`
+- 2.3 Cascading secret lookup
+- 2.4 GitHub Secrets, build/deploy time only
+- 2.5 No secrets in VCS
+
+### 3. Transport & Network (4)
+- 3.1 HTTPS-only on Cloud Run
+- 3.2 Cloud SQL `ssl_mode = ENCRYPTED_ONLY`
+- 3.3 CORS allowlist (no wildcard)
+- 3.4 Cloud SQL via Unix socket (not TCP)
+
+### 4. Application Layer (4)
+- 4.1 Pydantic input validation
+- 4.2 Parameterized SQL only
+- 4.3 slowapi rate limiting
+- 4.4 robots.txt + honest User-Agent
+
+### 5. Data Protection (4)
+- 5.1 Article content truncation (1024 chars) + 7-day TTL
+- 5.2 No full article bodies stored
+- 5.3 Minimal user PII
+- 5.4 Cloud SQL automated backups + PITR
+
+### 6. Container & Runtime (3)
+- 6.1 Non-root container users
+- 6.2 Distroless-leaning base images
+- 6.3 Cloud Run scale-to-zero
+
+### 7. CI/CD & Supply Chain (7)
+- 7.1 Dependabot
+- 7.2 pip-audit (CI)
+- 7.3 gitleaks (pre-commit + CI)
+- 7.4 Ruff
+- 7.5 mypy
+- 7.6 GCP_SA_KEY scoped to `production` GitHub environment
+- 7.7 SHA-pinned third-party actions
+
+### 8. Monitoring & Detection (4)
+- 8.1 Cloud Logging
+- 8.2 Cloud Monitoring dashboard
+- 8.3 Auto-issue on deploy failure
+- 8.4 Cloud Run revision identity check on deploy
+
+---
+
+## 5. Live demo readiness — proofs the assessor can verify
+
+Commands and the response codes returned by the live deployment.
+
+**Auth-protected endpoint returns 401 with no token:**
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  'https://aifeelnews-web-813770885946.europe-west1.run.app/bookmarks/'
+# Observed: 401
+```
+
+**OIDC-protected scheduler endpoint rejects unauthenticated POSTs.** The `-d ''` is needed because POST without a body returns 411 Length Required before the auth check runs:
+```bash
+curl -s -o /dev/null -X POST -d '' -w '%{http_code}\n' \
+  'https://aifeelnews-web-813770885946.europe-west1.run.app/api/v1/trigger-ingestion'
+# Observed: 401
+
+curl -s -o /dev/null -X POST -d '' -w '%{http_code}\n' \
+  'https://aifeelnews-web-813770885946.europe-west1.run.app/api/v1/cleanup'
+# Observed: 401
+```
+
+**Rate limit (30/minute on analytics endpoints):**
+```bash
+for i in $(seq 1 40); do
+  curl -s -o /dev/null -w '%{http_code} ' \
+    'https://aifeelnews-web-813770885946.europe-west1.run.app/api/v1/analytics/trends?days=7'
+done
+# Observed: 30x 200 then 10x 429 — limit configured at app/config/security.py:42
+```
+
+**CORS preflight rejects non-allowed origin** with a 400 and no `Access-Control-Allow-Origin` header in the response (the simple GET returns 200 because CORS is enforced by the browser via the missing response header, not by the server returning an error):
+```bash
+curl -s -i -X OPTIONS \
+  -H 'Origin: https://attacker.example.com' \
+  -H 'Access-Control-Request-Method: GET' \
+  'https://aifeelnews-web-813770885946.europe-west1.run.app/articles/' \
+  | grep -iE 'HTTP|access-control-allow-origin'
+# Observed: HTTP/1.1 400 Bad Request, no access-control-allow-origin header
+```
+
+**CI security scans:** open https://github.com/cardox6/aifeelnews/actions/workflows/security.yml — gitleaks + pip-audit run on every PR plus a weekly cron.
+
+---
+
+## 6. Auth demo — what's wired vs. what's documented
+
+The submission includes:
+
+- **Firebase Google Sign-In end-to-end**: SPA → Firebase Auth → ID token → Cloud Run server-side verification → user record auto-created/looked up by `firebase_uid`. Live and demonstrable on `https://aifeelnews-front.web.app/`.
+- **OIDC enforcement on Cloud Scheduler endpoints**: `/api/v1/trigger-ingestion` and `/api/v1/cleanup` reject any caller without a valid OIDC token whose audience matches the configured value. Documented in [app/deps/oidc.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/deps/oidc.py); test coverage in [tests/test_auth_security.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_auth_security.py).
+- **Email/Password auth (UC-09): not implemented**. Documented as 🔲 in PERSONAS_AND_USE_CASES.md. Adding it tonight risks regressing the working Google flow; deferred to the post-submission Capstone roadmap.
+
+---
+
+## 7. Where to find each module-description requirement
+
+Pointers into the codebase for the items the module description asks for. I'm leaving the level judgement to the assessor.
+
+### Authentication and authorization
+
+- Firebase Auth (Google Sign-In) on the SPA, server-side ID-token verification on the backend ([§ 1.1, 1.2 of SECURITY_MEASURES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#1-identity--access))
+- OIDC verification on Cloud Scheduler endpoints ([§ 1.3](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#13-oidc-verification-on-scheduler-endpoints))
+- Least-privilege application DB user and Cloud Run service account ([§ 1.4, 1.5](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#14-least-privilege-application-db-user))
+
+### Input validation and SQL safety
+
+- Pydantic validation on every route, query params included ([§ 4.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#41-pydantic-input-validation))
+- Parameterized SQL only ([§ 4.2](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#42-parameterized-sql-only))
+
+### Transport and network security
+
+- HTTPS-only on Cloud Run ([§ 3.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#31-https-only-on-cloud-run))
+- Cloud SQL `ssl_mode = ENCRYPTED_ONLY` ([§ 3.2](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#32-cloud-sql-ssl_mode--encrypted_only))
+- CORS allowlist with no wildcard ([§ 3.3](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#33-cors-allowlist-no-wildcard))
+- Cloud SQL via Unix socket, not TCP ([§ 3.4](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#34-cloud-sql-via-unix-socket-not-tcp))
+
+### Secrets management
+
+- Secret Manager for runtime secrets ([§ 2.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#21-gcp-secret-manager-6-secrets))
+- `DATABASE_URL` as `secretKeyRef` so the URL itself never appears in plaintext env on Cloud Run ([§ 2.2](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#22-database_url-as-secretkeyref))
+- Cascading secret lookup that prefers Secret Manager, falls through to env vars in dev ([§ 2.3](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#23-cascading-secret-lookup))
+- gitleaks pre-commit + CI to catch secrets before they land in VCS ([§ 7.3](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#73-gitleaks-secret-leak-scan))
+
+### Container security
+
+- Non-root container users in all three Dockerfiles ([§ 6.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#61-non-root-container-users))
+- Distroless-leaning base images ([§ 6.2](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#62-distroless-leaning-base-images))
+
+### Supply chain
+
+- Dependabot for Python + npm + GitHub Actions ([§ 7.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#71-dependabot))
+- pip-audit on every PR + weekly cron ([§ 7.2](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#72-pip-audit-cve-scan-on-pinned-deps))
+- SHA-pinned third-party GitHub Actions ([§ 7.7](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#77-sha-pinned-third-party-actions))
+
+### Data protection
+
+- Article content truncation (1024 chars) + 7-day TTL ([§ 5.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#51-article-content-truncation-1024-chars--7-day-ttl))
+- Minimal user PII stored ([§ 5.3](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#53-minimal-user-pii))
+- Cloud SQL automated backups + 7-day PITR ([§ 5.4](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#54-cloud-sql-automated-backups--pitr))
+
+### Monitoring and incident readiness
+
+- Structured JSON logs in production ([§ 8.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#81-cloud-logging))
+- Cloud Monitoring dashboard ([§ 8.2](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#82-cloud-monitoring-dashboard))
+- Auto-issue on deploy failure + revision-identity check on every deploy ([§ 8.3, 8.4](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md#83-auto-issue-on-deploy-failure))
+
+---
+
+## 8. Known gaps (from the threat model, not hidden)
+
+The threat model's [Known Gaps section](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/THREAT_MODEL.md#known-gaps-consolidated) acknowledges several items deferred with reasoned tradeoffs:
+
+- Email/password auth (UC-09) — not implemented; would risk regressing working Google flow
+- Web Application Firewall (Cloud Armor) — not provisioned; rate limiting at slowapi layer is the current control, with WAF being a future hardening step
+- Per-user authorization audit log — bookmark create/delete is logged at INFO level but not into a separate audit-log table
+- Container image scanning beyond pip-audit — Trivy/Snyk container scanning would catch base-image CVEs that pip-audit misses
+
+Each gap has a stated rationale; none are the result of oversight.
+
+---
+
+## 9. CI/CD security pipeline
+
+The security workflow at [.github/workflows/security.yml](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/.github/workflows/security.yml) runs on every PR and weekly on a cron:
+
+- **gitleaks** (commit-time + CI): blocks any commit containing a high-entropy secret
+- **pip-audit**: scans `requirements.txt` against the OSV vulnerability database
+- **CodeQL**: GitHub's static analysis for the FastAPI codebase
+
+The deploy workflow at [.github/workflows/deploy.yml](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/.github/workflows/deploy.yml) gates production deploys on:
+
+- All tests passing
+- A merge-policy enforcement step (only `develop` or `fix/*` can merge into `main`)
+- A post-deploy revision-identity check that confirms the just-deployed Cloud Run revision is actually the one serving 100% of traffic, with automatic rollback to the previous healthy revision if verification fails
+
+---
+
+## 10. Documentation index
+
+| Document | Purpose |
+|----------|---------|
+| [THREAT_MODEL.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/THREAT_MODEL.md) | STRIDE per component (6 components); trust-boundary diagram; consolidated known-gaps |
+| [SECURITY_MEASURES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/SECURITY_MEASURES.md) | 38 implemented controls catalogued by 8 layers, all line-anchored to source |
+| [README.md § Security](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/README.md#security) | One-screen summary of the same material |
+| [tests/test_auth_security.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_auth_security.py) | Auth, OIDC, CORS, rate-limit assertions executed on every PR |

--- a/docs/submissions/SUBMISSION_RELATIONAL_DB.md
+++ b/docs/submissions/SUBMISSION_RELATIONAL_DB.md
@@ -1,0 +1,223 @@
+# Relational Databases Submission — aiFeelNews
+
+**Module:** SE_05 — Relational Databases
+**Author:** Matias Cardone
+**Submission date:** 2026-05-04
+
+---
+
+## How to view this submission's exact state
+
+This document corresponds to git tag `submission-rel-db-2026-05-04` and branch `submission-2026-05-04` on the project repository. The live URL `https://aifeelnews-front.web.app/` reflects the same state at submission time but may evolve as the project continues toward the Capstone assessment in 2-3 weeks.
+
+**File links in this document point to the frozen `submission-2026-05-04` branch**, not to `main`. That way the source they reference doesn't drift if the project keeps moving after submission.
+
+| Pointer | Where |
+|---|---|
+| Repository | https://github.com/cardox6/aifeelnews/tree/submission-2026-05-04 |
+| Tag | `submission-rel-db-2026-05-04` |
+| Live frontend | https://aifeelnews-front.web.app/ |
+| Live API | https://aifeelnews-web-813770885946.europe-west1.run.app |
+| Module deliverables index | This document |
+
+---
+
+## 1. Project identity
+
+aiFeelNews is a news sentiment analysis platform: it ingests articles from Mediastack, crawls original content (respecting robots.txt), runs sentiment analysis via Google Cloud Natural Language API (with VADER as a local fallback), and presents articles with sentiment indicators in a Svelte SPA. The data layer is PostgreSQL 14 accessed through SQLAlchemy 2.0's typed `Mapped[]` ORM and managed with Alembic.
+
+The repository is **public** at https://github.com/cardox6/aifeelnews — no invitation needed.
+
+**Team contribution:** solo project. All commits on the `submission-2026-05-04` branch are mine.
+
+---
+
+## 2. Use cases
+
+22 use cases mapped to 4 personas, in [docs/PERSONAS_AND_USE_CASES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/PERSONAS_AND_USE_CASES.md).
+
+| Persona | Backend ✅ | UI ✅ | UI 🔲 | UI n/a | Backend 🔲 |
+|---------|-----------|------|------|--------|-----------|
+| P1 Casual Reader | 7 / 7 | 6 / 7 | 1 (UC-02) | 0 | 0 |
+| P2 Registered Reader | 4 / 5 | 4 / 5 | 0 | 0 | 1 (UC-09) |
+| P3 News Analyst | 7 / 7 | 4 / 7 | 3 (UC-16, UC-18, UC-19) | 0 | 0 |
+| P4 System Administrator | 3 / 3 | n/a | n/a | 3 | 0 |
+| **Totals** | **21 / 22** | **14 / 19 user-facing** | **5** | **3** | **1** |
+
+The two-column status (Backend / UI) reflects that backend implementation and frontend wiring move on different timelines. The Analytics tab on the live SPA exposes four charts (sentiment trends, source comparison, top entities, GCP NL categories) covering UC-13/14/15/17. Entity-sentiment distribution (UC-16) and the entity directory pages (UC-18/19) are backend-only for now.
+
+Each table in the schema serves at least one real use case; the [Tables → Use Cases traceability matrix](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/PERSONAS_AND_USE_CASES.md#tables--use-cases-db-centric-view) makes this explicit.
+
+---
+
+## 3. Repository layout and dev setup
+
+[README.md § Development Setup](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/README.md#development-setup) covers the supported local path. The short version:
+
+```bash
+git clone https://github.com/cardox6/aifeelnews.git
+cd aifeelnews
+git checkout submission-2026-05-04
+cp .env.example .env
+docker-compose up --build
+docker-compose exec web python -m app.seeds.seed_db
+```
+
+This brings up Postgres 14, the FastAPI service, the crawl worker, and the scheduler. The 50-article seed dataset lives at [`app/seeds/seed_data.json`](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/seeds/seed_data.json) — sampled from production with PII removed, idempotent loader, no Mediastack key required for the demo.
+
+The frontend (Svelte 5 + Vite) runs separately with `cd frontend && npm run dev`.
+
+---
+
+## 4. ER model
+
+The full ER diagram with all 10 tables, M2M relationships, cascade rules, and indexes is in [docs/ER_Diagram.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/ER_Diagram.md). The Mermaid source renders directly on GitHub.
+
+```mermaid
+erDiagram
+    sources ||--o{ articles : "has many"
+    articles ||--o{ bookmarks : "bookmarked by"
+    users ||--o{ bookmarks : "owns"
+    articles ||--o{ article_contents : "has body (TTL)"
+    articles ||--o{ sentiment_analyses : "scored by"
+    articles ||--o{ article_entities : "mentions"
+    entities ||--o{ article_entities : "mentioned in"
+    articles ||--o{ article_categories : "classified as"
+    articles ||--o{ crawl_jobs : "queued for crawl"
+```
+
+Two M2M relationships:
+
+- `bookmarks` joins `users` and `articles` with a unique `(user_id, article_id)` constraint enforced at three layers: SQLAlchemy ORM, the migration (`UniqueConstraint`), and a Postgres trigger ([prevent_duplicate_bookmarks](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/alembic/versions/e1f2a3b4c5d6_add_db_objects_views_functions_triggers.py)) so even direct SQL inserts cannot create duplicates.
+- `article_entities` joins `articles` and `entities` with payload columns (`salience`, `mention_count`, `analyzed_at`) — a true M2M-with-attributes that powers the entity-momentum analytics.
+
+---
+
+## 5. Schema non-triviality
+
+Beyond the M2M relationships above:
+
+- **10 tables**: `sources`, `articles`, `users`, `bookmarks`, `article_contents`, `sentiment_analyses`, `entities`, `article_entities`, `article_categories`, `crawl_jobs`. Inventory and column-by-column listing in [ER_Diagram.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/ER_Diagram.md).
+- **4 PostgreSQL views**: `v_article_summary`, `v_source_stats`, `v_daily_sentiment`, `v_trending_entities` — defined in [migration e1f2a3b4c5d6](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/alembic/versions/e1f2a3b4c5d6_add_db_objects_views_functions_triggers.py).
+- **2 stored functions** (PL/pgSQL): `fn_sentiment_distribution(days INT)` and `fn_source_performance(days INT)` — same migration.
+- **2 triggers**: `trg_update_source_timestamp` (auto-updates `sources.updated_at` on any related article insert) and `trg_prevent_duplicate_bookmarks` (raises before insert if the `(user_id, article_id)` pair already exists).
+- **Cascade deletes** on every child FK so removing an article reaps its content, sentiment, entities, and bookmarks atomically — see [ER_Diagram.md § Cascade Delete Strategy](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/ER_Diagram.md#cascade-delete-strategy).
+- **TTL data lifecycle** on `article_contents.expires_at` with an indexed cleanup job — original article body is truncated to 1024 chars and expires after 7 days, satisfying the data-minimization principle from the cybersecurity threat model.
+
+Full inventory of database objects: [DATABASE.md § 3](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#3-database-objects).
+
+---
+
+## 6. Data layer — proof it's a real, working database
+
+These three files are the entry points to inspect:
+
+- [app/routers/articles.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/routers/articles.py) — the article list endpoint with composable filters (sentiment, category, source, search) and pagination, served by a single shared `_query_articles` helper. Eager-loads via `joinedload` + `subqueryload` to fix the N+1 that originally hit on every `/articles/` request.
+- [app/crud/analytics.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/crud/analytics.py) — five non-trivial SQL patterns:
+  - `sentiment_rolling_average` — window function (`AVG() OVER (ORDER BY day ROWS BETWEEN N PRECEDING AND CURRENT ROW)`)
+  - `source_sentiment_ranked` — window function (`RANK() OVER (ORDER BY avg_sentiment DESC)`)
+  - `sentiment_grouping_sets` — `GROUPING SETS` for multi-dimensional aggregation in one pass
+  - `entity_momentum` — two CTEs + `FULL OUTER JOIN` for period-over-period growth
+  - `daily_category_sentiment_pivot` — `FILTER (WHERE ...)` clause for conditional aggregates
+- [app/routers/db_analytics.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/routers/db_analytics.py) — the live API surface that exposes those queries. Endpoints under `/api/v1/db-analytics/`.
+
+Live URLs the assessor can hit (against the production `submission-2026-05-04`-tagged deployment):
+
+```bash
+# Filter + paginate (P1 use cases UC-03 to UC-07)
+curl 'https://aifeelnews-web-813770885946.europe-west1.run.app/articles/?sentiment_label=positive&limit=3'
+curl 'https://aifeelnews-web-813770885946.europe-west1.run.app/articles/?search=news&limit=3'
+
+# Window function — 7-day rolling sentiment
+curl 'https://aifeelnews-web-813770885946.europe-west1.run.app/api/v1/db-analytics/sentiment/rolling?days=14'
+
+# Window function — sources ranked by sentiment
+curl 'https://aifeelnews-web-813770885946.europe-west1.run.app/api/v1/db-analytics/sources/ranked?days=30'
+
+# GROUPING SETS — sentiment x category breakdown with subtotals
+curl 'https://aifeelnews-web-813770885946.europe-west1.run.app/api/v1/db-analytics/sentiment/breakdown?days=30'
+```
+
+---
+
+## 7. Data — production volume and seeding
+
+Live counts pulled from `GET /metrics` on 2026-05-03 21:51 UTC:
+
+| Source | Volume | Where |
+|--------|--------|-------|
+| Production Postgres | 29,812 articles across 22 sources; 7,483 sentiment-analysed; 539 crawl jobs processed | Cloud SQL `aifeelnews-db` (live: [`/metrics`](https://aifeelnews-web-813770885946.europe-west1.run.app/metrics)) |
+| Seed dataset | 50 articles across 10 sources, sampled from production with PII removed | [app/seeds/seed_data.json](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/seeds/seed_data.json) |
+| Test fixture | Synthetic — 10 articles, 2 sources, deterministic | [tests/test_articles_filters.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_articles_filters.py) |
+
+**Generation methods:**
+- Production data is ingested every 8 hours by Cloud Scheduler hitting Mediastack (`infra/main.tf` — `ingestion_schedule = "0 */8 * * *"`), normalised, sentiment-scored, and persisted by [`app/jobs/run_ingestion.py`](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/jobs/run_ingestion.py). A daily cleanup job (2 AM UTC) trims expired article bodies.
+- The seed dataset was generated by [`app/seeds/_export_seed.py`](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/seeds/_export_seed.py) — a one-shot script that pulled a representative sample from prod with all user-identifiable fields stripped.
+- The test fixture is built inline in the test module so the assertions stay deterministic even as the schema evolves.
+
+Both seed and fixture flows are idempotent. `python -m app.seeds.seed_db` skips existing URLs; `--reset` truncates seed rows then reinserts.
+
+---
+
+## 8. Where to find each module-description requirement
+
+Pointers into the codebase for the items the module description asks for. I'm leaving the level judgement to the assessor.
+
+### Working data layer with use cases mapped
+
+SQLAlchemy 2.0 ORM with typed `Mapped[]` declarations under [app/models/](https://github.com/cardox6/aifeelnews/tree/submission-2026-05-04/app/models). FastAPI routers in [app/routers/](https://github.com/cardox6/aifeelnews/tree/submission-2026-05-04/app/routers). Alembic migrations under version control in [alembic/versions/](https://github.com/cardox6/aifeelnews/tree/submission-2026-05-04/alembic/versions). 22 use cases mapped to tables in [PERSONAS_AND_USE_CASES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/PERSONAS_AND_USE_CASES.md).
+
+### Indexes and query optimization
+
+- `(published_at)` for timeline ordering on every `/articles/` request — added in the initial migration
+- `(sentiment_label)`, `(category)`, `(source_id)` added in migration [`f2a3b4c5d6e7`](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/alembic/versions/f2a3b4c5d6e7_add_article_filter_indexes.py) so filter+order is index-supported instead of a sequential scan
+- `(article_id, entity_id)` UNIQUE on `article_entities` preventing duplicate mentions and accelerating M2M lookups
+- `(name, type)` UNIQUE on `entities` for canonical entity deduplication
+- `(expires_at)` on `article_contents` so the TTL cleanup job's `WHERE expires_at < now()` doesn't scan every row
+- Bookmark FK indexes on `(user_id)` and `(article_id)` — Postgres does not auto-index FKs
+
+The N+1 query fix on `GET /articles/` is documented with before/after in [DATABASE.md § 4.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#41-n1-query-fix-on-get-articles): the original implementation issued one query per article for `source`, `sentiment_analyses`, `article_entities`, `article_categories`; now a single query with `joinedload` + `subqueryload`.
+
+Substring search on `articles.title` uses `ILIKE '%term%'`, which a B-tree cannot accelerate. The pg_trgm GIN upgrade path is documented in [DATABASE.md § 4.4](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#44-article-filter-indexes).
+
+### Advanced SQL patterns
+
+[app/crud/analytics.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/app/crud/analytics.py) uses window functions (rolling averages, RANK), CTEs with FULL OUTER JOIN for period-over-period comparisons, GROUPING SETS for multi-dimensional aggregation, and FILTER clauses for conditional aggregates. Each is a single round-trip that returns chart-ready rows; none of them post-process in Python. See § 6 above for the function-by-function breakdown.
+
+### Database objects (views, functions, triggers)
+
+Defined in migration [e1f2a3b4c5d6](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/alembic/versions/e1f2a3b4c5d6_add_db_objects_views_functions_triggers.py): 4 views, 2 PL/pgSQL functions, 2 triggers. See § 5 of this document.
+
+### Transactions and ACID
+
+[DATABASE.md § 4A](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#4a-transactions-and-acid): SQLAlchemy session-per-request scoping, explicit atomicity policies per component (atomic for ingestion batches, per-article for crawl results), and rollback hygiene on the worker path.
+
+### Data lifecycle, backup and recovery
+
+- Lifecycle (TTL, retention, cascade rules, BigQuery export): [DATABASE.md § 5](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#5-data-lifecycle)
+- Cloud SQL automated backups + 7-day PITR: [DATABASE.md § 6](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#6-backup--recovery)
+
+---
+
+## 9. Test coverage
+
+51 tests passing as of submission. Categories:
+
+- [tests/test_articles_filters.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_articles_filters.py) — 11 tests covering filter, search, pagination, and Pydantic 422 boundary cases on `/articles/`.
+- [tests/test_auth_security.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_auth_security.py) — auth, OIDC, CORS, rate-limit assertions.
+- [tests/test_new_models.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_new_models.py) — model-level cascade and relationship checks.
+- [tests/test_seed_db.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_seed_db.py) — seed loader idempotence.
+- [tests/test_crawl_worker.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_crawl_worker.py), [tests/test_ingestion.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_ingestion.py), [tests/test_bigquery.py](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/tests/test_bigquery.py) — pipeline coverage.
+
+Run inside the Compose stack: `docker-compose exec web pytest -v`.
+
+---
+
+## 10. Documentation index
+
+| Document | Purpose |
+|----------|---------|
+| [DATABASE.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md) | Setup, migrations, schema objects, optimisation patterns, transactions, data lifecycle, backup/recovery, testing |
+| [ER_Diagram.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/ER_Diagram.md) | Mermaid ER, table-by-table column listing, cardinality, full index map |
+| [PERSONAS_AND_USE_CASES.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/PERSONAS_AND_USE_CASES.md) | Personas, 22 use cases with Backend/UI status, traceability matrix |
+| [README.md](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/README.md) | Project overview, dev setup, API endpoint inventory |

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,74 +1,157 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { userStore, loginWithGoogle, logout } from './lib/firebase';
+  import { onMount } from "svelte";
+  import { userStore, loginWithGoogle, logout } from "./lib/firebase";
   import {
-    fetchLatestArticles,
+    fetchArticles,
+    fetchSources,
     type ArticleDto,
     type ArticleEntityDto,
     type ArticleCategoryDto,
-  } from './lib/api';
-  import Dashboard from './lib/Dashboard.svelte';
+    type SourceDto,
+  } from "./lib/api";
+  import Dashboard from "./lib/Dashboard.svelte";
+  import FilterBar from "./lib/FilterBar.svelte";
+  import Pagination from "./lib/Pagination.svelte";
 
-  let currentPage: 'articles' | 'analytics' = 'articles';
+  let currentPage: "articles" | "analytics" = "articles";
   let articles: ArticleDto[] = [];
   let loading = true;
-  let error = '';
+  let error = "";
+
+  // Filter / pagination state.
+  let sentiment: string = "";
+  let category: string = "";
+  let sourceId: number | "" = "";
+  let search: string = "";
+  let skip: number = 0;
+  const limit: number = 20;
+
+  // Static mediastack categories. (Backend doesn't expose a categories endpoint
+  // yet; we keep this client-side for now and TODO a `/categories` route.)
+  const CATEGORY_OPTIONS: string[] = [
+    "general",
+    "business",
+    "entertainment",
+    "health",
+    "science",
+    "sports",
+    "technology",
+  ];
+
+  let sources: SourceDto[] = [];
+
+  // Track whether we've already done the initial mount-load. The reactive
+  // re-fetch block fires whenever filter/skip change, so we gate it until
+  // after onMount completes to avoid double-fetching on first render.
+  let initialised = false;
 
   async function loadArticles() {
     try {
       loading = true;
-      error = ''; // Clear previous errors
-      articles = await fetchLatestArticles(40);
+      error = "";
+      articles = await fetchArticles({
+        skip,
+        limit,
+        sentiment_label: sentiment || undefined,
+        category: category || undefined,
+        source_id: sourceId === "" ? undefined : sourceId,
+        search: search.trim().length >= 2 ? search.trim() : undefined,
+      });
     } catch (e) {
-      console.error('Failed to load articles:', e);
-      error = e instanceof Error ? e.message : 'Failed to load articles';
+      console.error("Failed to load articles:", e);
+      error = e instanceof Error ? e.message : "Failed to load articles";
     } finally {
       loading = false;
     }
   }
 
-  // Redirect to articles if user logs out while on analytics
-  $: if (!$userStore && currentPage === 'analytics') {
-    currentPage = 'articles';
+  async function loadSources() {
+    try {
+      sources = await fetchSources();
+    } catch (e) {
+      console.warn("Failed to load sources, continuing with empty list:", e);
+      sources = [];
+    }
   }
 
-  onMount(() => {
-    loadArticles();
+  // Re-fetch articles whenever a filter or pagination value changes.
+  // (Gated by `initialised` so we don't double-fetch on first render.)
+  $: if (initialised) {
+    void loadArticles();
+    // Reading these makes the block reactive to all of them.
+    void [sentiment, category, sourceId, search, skip];
+  }
+
+  // Redirect to articles if user logs out while on analytics
+  $: if (!$userStore && currentPage === "analytics") {
+    currentPage = "articles";
+  }
+
+  onMount(async () => {
+    await Promise.all([loadArticles(), loadSources()]);
+    initialised = true;
   });
 
   function handleRetry() {
     loadArticles();
   }
 
+  function handleFilterChange(
+    event: CustomEvent<{
+      sentiment: string;
+      category: string;
+      sourceId: number | "";
+      search: string;
+    }>
+  ) {
+    const next = event.detail;
+    sentiment = next.sentiment;
+    category = next.category;
+    sourceId = next.sourceId;
+    search = next.search;
+    // Filter changed → reset to first page.
+    skip = 0;
+  }
+
+  function handlePrevPage() {
+    skip = Math.max(0, skip - limit);
+  }
+
+  function handleNextPage() {
+    skip = skip + limit;
+  }
+
+  $: hasMore = articles.length === limit;
+
   // ── Sentiment helpers ──────────────────────────────────────────────
 
   function getSentimentColor(label?: string): string {
-    if (!label) return 'text-gray-500';
+    if (!label) return "text-gray-500";
     switch (label.toLowerCase()) {
-      case 'positive': return 'text-green-600';
-      case 'negative': return 'text-red-600';
-      case 'neutral':  return 'text-blue-600';
-      default:         return 'text-gray-500';
+      case "positive": return "text-green-600";
+      case "negative": return "text-red-600";
+      case "neutral":  return "text-blue-600";
+      default:         return "text-gray-500";
     }
   }
 
   function getSentimentBgColor(label?: string): string {
-    if (!label) return 'bg-gray-100';
+    if (!label) return "bg-gray-100";
     switch (label.toLowerCase()) {
-      case 'positive': return 'bg-green-100';
-      case 'negative': return 'bg-red-100';
-      case 'neutral':  return 'bg-blue-100';
-      default:         return 'bg-gray-100';
+      case "positive": return "bg-green-100";
+      case "negative": return "bg-red-100";
+      case "neutral":  return "bg-blue-100";
+      default:         return "bg-gray-100";
     }
   }
 
   function getSentimentBarColor(label?: string): string {
-    if (!label) return '#9ca3af';
+    if (!label) return "#9ca3af";
     switch (label.toLowerCase()) {
-      case 'positive': return '#16a34a';
-      case 'negative': return '#dc2626';
-      case 'neutral':  return '#2563eb';
-      default:         return '#9ca3af';
+      case "positive": return "#16a34a";
+      case "negative": return "#dc2626";
+      case "neutral":  return "#2563eb";
+      default:         return "#9ca3af";
     }
   }
 
@@ -77,14 +160,14 @@
   }
 
   function getSentimentExplanation(label?: string | null, score?: number | null): string {
-    if (!label || score === null || score === undefined) return '';
+    if (!label || score === null || score === undefined) return "";
     const abs = Math.abs(score);
-    const intensity = abs > 0.6 ? 'strongly' : abs > 0.25 ? 'moderately' : 'slightly';
+    const intensity = abs > 0.6 ? "strongly" : abs > 0.25 ? "moderately" : "slightly";
     switch (label.toLowerCase()) {
-      case 'positive': return `Overall tone is ${intensity} positive`;
-      case 'negative': return `Overall tone is ${intensity} negative`;
-      case 'neutral':  return 'Balanced, neutral tone';
-      default:         return '';
+      case "positive": return `Overall tone is ${intensity} positive`;
+      case "negative": return `Overall tone is ${intensity} negative`;
+      case "neutral":  return "Balanced, neutral tone";
+      default:         return "";
     }
   }
 
@@ -101,15 +184,15 @@
   }
 
   function formatCategoryName(taxonomyPath: string): string {
-    const parts = taxonomyPath.split('/').filter(Boolean);
+    const parts = taxonomyPath.split("/").filter(Boolean);
     return parts[parts.length - 1] || taxonomyPath;
   }
 
   function formatEntityType(type: string): string {
     const map: Record<string, string> = {
-      ORGANIZATION: 'Org', PERSON: 'Person', LOCATION: 'Place',
-      EVENT: 'Event', WORK_OF_ART: 'Work', CONSUMER_GOOD: 'Product',
-      OTHER: '', UNKNOWN: '',
+      ORGANIZATION: "Org", PERSON: "Person", LOCATION: "Place",
+      EVENT: "Event", WORK_OF_ART: "Work", CONSUMER_GOOD: "Product",
+      OTHER: "", UNKNOWN: "",
     };
     return map[type] ?? type.charAt(0) + type.slice(1).toLowerCase();
   }
@@ -118,21 +201,21 @@
 
   function getDomain(url: string): string {
     try {
-      return new URL(url).hostname.replace(/^www\./, '');
+      return new URL(url).hostname.replace(/^www\./, "");
     } catch {
-      return '';
+      return "";
     }
   }
 
   function getFaviconUrl(articleUrl: string, size = 20): string {
     const domain = getDomain(articleUrl);
-    if (!domain) return '';
+    if (!domain) return "";
     return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
   }
 
   function handleImageError(event: Event) {
     const img = event.target as HTMLImageElement;
-    img.style.display = 'none';
+    img.style.display = "none";
   }
 
   // ── General helpers ──────────────────────────────────────────────
@@ -143,7 +226,7 @@
 
   function handleBookmark(article: ArticleDto) {
     // TODO: Implement bookmark functionality when Firebase auth is working
-    console.log('Bookmarking article:', article.title);
+    console.log("Bookmarking article:", article.title);
     // For now, show a simple alert
     alert(`Bookmark feature coming soon!\n\nArticle: ${article.title}`);
   }
@@ -159,7 +242,7 @@
 
           <nav class="flex space-x-1">
             <button
-              on:click={() => currentPage = 'articles'}
+              on:click={() => currentPage = "articles"}
               class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors
                 {currentPage === 'articles' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}"
             >
@@ -167,7 +250,7 @@
             </button>
             {#if $userStore}
               <button
-                on:click={() => currentPage = 'analytics'}
+                on:click={() => currentPage = "analytics"}
                 class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors
                   {currentPage === 'analytics' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}"
               >
@@ -201,7 +284,17 @@
 
   <!-- Main Content -->
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    {#if currentPage === 'articles'}
+    {#if currentPage === "articles"}
+      <FilterBar
+        {sentiment}
+        {category}
+        {sourceId}
+        {search}
+        categories={CATEGORY_OPTIONS}
+        {sources}
+        on:change={handleFilterChange}
+      />
+
       {#if error}
         <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
           <div class="flex items-center justify-between">
@@ -227,164 +320,178 @@
           <p class="text-gray-600">Recent news with sentiment analysis</p>
         </div>
 
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {#each articles as article}
-            <div class="bg-white rounded-lg shadow-sm border overflow-hidden hover:shadow-md transition-shadow">
-              <!-- Article image / placeholder -->
-              <div class="card-image-wrapper">
-                <div class="card-image-placeholder">
-                  <svg class="card-image-placeholder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15l-5-5L5 21" />
-                    <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
-                  </svg>
-                </div>
-                {#if article.image_url}
-                  <img
-                    src={article.image_url}
-                    alt=""
-                    class="card-image"
-                    loading="lazy"
-                    decoding="async"
-                    referrerpolicy="no-referrer"
-                    on:error={handleImageError}
-                  />
-                {/if}
-              </div>
-
-              <div class="card-body">
-                <!-- Source (with favicon) -->
-                <div class="flex items-center justify-between mb-3">
-                  <span class="source-badge text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
-                    {#if getDomain(article.url)}
-                      <img
-                        src={getFaviconUrl(article.url)}
-                        alt=""
-                        class="source-favicon"
-                        loading="lazy"
-                        on:error={handleImageError}
-                      />
-                    {/if}
-                    {article.source?.name || `Source #${article.source?.id || 'Unknown'}`}
-                  </span>
-                  <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
-                </div>
-
-                <!-- Title -->
-                <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
-                  {article.title}
-                </h3>
-
-                <!-- Description -->
-                {#if article.description}
-                  <p class="text-gray-600 text-sm mb-3 line-clamp-3">
-                    {article.description}
-                  </p>
-                {/if}
-
-                <!-- Sentiment analysis -->
-                {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
-                  <div class="sentiment-section mb-3">
-                    <div class="flex items-center justify-between mb-2">
-                      <span class="text-xs font-semibold px-2 rounded {getSentimentBgColor(article.sentiment_label)} {getSentimentColor(article.sentiment_label)}">
-                        {article.sentiment_label.toUpperCase()}
-                      </span>
-                      <span
-                        class="text-xs text-gray-500"
-                        title="Sentiment score from -1.0 (very negative) to 1.0 (very positive)"
-                      >
-                        Score: {article.sentiment_score.toFixed(2)}
-                      </span>
-                    </div>
-
-                    <div class="sentiment-bar-track">
-                      <div
-                        class="sentiment-bar-fill"
-                        style="width: {sentimentScoreToPercent(article.sentiment_score)}%; background-color: {getSentimentBarColor(article.sentiment_label)};"
-                      ></div>
-                      <div class="sentiment-bar-midpoint"></div>
-                    </div>
-
-                    <p class="text-xs text-gray-400 mt-1 sentiment-explanation">
-                      {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
-                    </p>
+        {#if articles.length === 0}
+          <div class="text-center py-12">
+            <p class="text-gray-600">No articles match the current filters.</p>
+          </div>
+        {:else}
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {#each articles as article (article.id)}
+              <div class="bg-white rounded-lg shadow-sm border overflow-hidden hover:shadow-md transition-shadow">
+                <!-- Article image / placeholder -->
+                <div class="card-image-wrapper">
+                  <div class="card-image-placeholder">
+                    <svg class="card-image-placeholder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2z" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15l-5-5L5 21" />
+                      <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
+                    </svg>
                   </div>
-                {/if}
-
-                <!-- Content categories -->
-                {#if getTopCategories(article.article_categories).length > 0}
-                  <div class="flex items-center flex-wrap gap-1 mb-2">
-                    <span class="text-xs text-gray-400 mr-1">Topics:</span>
-                    {#each getTopCategories(article.article_categories) as cat}
-                      <span
-                        class="category-chip"
-                        title="Category: {cat.name} (confidence: {(cat.confidence * 100).toFixed(0)}%)"
-                      >
-                        {formatCategoryName(cat.name)}
-                      </span>
-                    {/each}
-                  </div>
-                {/if}
-
-                <!-- Key entities -->
-                {#if getTopEntities(article.article_entities).length > 0}
-                  <div class="flex items-center flex-wrap gap-1 mb-3">
-                    <span class="text-xs text-gray-400 mr-1">Entities:</span>
-                    {#each getTopEntities(article.article_entities) as ae}
-                      {#if ae.entity.wikipedia_url}
-                        <a
-                          href={ae.entity.wikipedia_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="entity-chip entity-chip-link"
-                          title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
-                        >
-                          {ae.entity.name}
-                          {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
-                        </a>
-                      {:else}
-                        <span
-                          class="entity-chip"
-                          title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
-                        >
-                          {ae.entity.name}
-                          {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
-                        </span>
-                      {/if}
-                    {/each}
-                  </div>
-                {/if}
-
-                <!-- Actions -->
-                <div class="flex items-center justify-between">
-                  <a
-                    href={article.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
-                  >
-                    Read Article →
-                  </a>
-
-                  {#if $userStore}
-                    <button
-                      on:click={() => handleBookmark(article)}
-                      class="text-gray-400 hover:text-gray-600"
-                      aria-label="Bookmark this article"
-                      title="Bookmark this article"
-                    >
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
-                      </svg>
-                    </button>
+                  {#if article.image_url}
+                    <img
+                      src={article.image_url}
+                      alt=""
+                      class="card-image"
+                      loading="lazy"
+                      decoding="async"
+                      referrerpolicy="no-referrer"
+                      on:error={handleImageError}
+                    />
                   {/if}
                 </div>
+
+                <div class="card-body">
+                  <!-- Source (with favicon) -->
+                  <div class="flex items-center justify-between mb-3">
+                    <span class="source-badge text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
+                      {#if getDomain(article.url)}
+                        <img
+                          src={getFaviconUrl(article.url)}
+                          alt=""
+                          class="source-favicon"
+                          loading="lazy"
+                          on:error={handleImageError}
+                        />
+                      {/if}
+                      {article.source?.name || `Source #${article.source?.id || "Unknown"}`}
+                    </span>
+                    <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
+                  </div>
+
+                  <!-- Title -->
+                  <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+                    {article.title}
+                  </h3>
+
+                  <!-- Description -->
+                  {#if article.description}
+                    <p class="text-gray-600 text-sm mb-3 line-clamp-3">
+                      {article.description}
+                    </p>
+                  {/if}
+
+                  <!-- Sentiment analysis -->
+                  {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
+                    <div class="sentiment-section mb-3">
+                      <div class="flex items-center justify-between mb-2">
+                        <span class="text-xs font-semibold px-2 rounded {getSentimentBgColor(article.sentiment_label)} {getSentimentColor(article.sentiment_label)}">
+                          {article.sentiment_label.toUpperCase()}
+                        </span>
+                        <span
+                          class="text-xs text-gray-500"
+                          title="Sentiment score from -1.0 (very negative) to 1.0 (very positive)"
+                        >
+                          Score: {article.sentiment_score.toFixed(2)}
+                        </span>
+                      </div>
+
+                      <div class="sentiment-bar-track">
+                        <div
+                          class="sentiment-bar-fill"
+                          style="width: {sentimentScoreToPercent(article.sentiment_score)}%; background-color: {getSentimentBarColor(article.sentiment_label)};"
+                        ></div>
+                        <div class="sentiment-bar-midpoint"></div>
+                      </div>
+
+                      <p class="text-xs text-gray-400 mt-1 sentiment-explanation">
+                        {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
+                      </p>
+                    </div>
+                  {/if}
+
+                  <!-- Content categories -->
+                  {#if getTopCategories(article.article_categories).length > 0}
+                    <div class="flex items-center flex-wrap gap-1 mb-2">
+                      <span class="text-xs text-gray-400 mr-1">Topics:</span>
+                      {#each getTopCategories(article.article_categories) as cat}
+                        <span
+                          class="category-chip"
+                          title="Category: {cat.name} (confidence: {(cat.confidence * 100).toFixed(0)}%)"
+                        >
+                          {formatCategoryName(cat.name)}
+                        </span>
+                      {/each}
+                    </div>
+                  {/if}
+
+                  <!-- Key entities -->
+                  {#if getTopEntities(article.article_entities).length > 0}
+                    <div class="flex items-center flex-wrap gap-1 mb-3">
+                      <span class="text-xs text-gray-400 mr-1">Entities:</span>
+                      {#each getTopEntities(article.article_entities) as ae}
+                        {#if ae.entity.wikipedia_url}
+                          <a
+                            href={ae.entity.wikipedia_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="entity-chip entity-chip-link"
+                            title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
+                          >
+                            {ae.entity.name}
+                            {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
+                          </a>
+                        {:else}
+                          <span
+                            class="entity-chip"
+                            title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
+                          >
+                            {ae.entity.name}
+                            {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
+                          </span>
+                        {/if}
+                      {/each}
+                    </div>
+                  {/if}
+
+                  <!-- Actions -->
+                  <div class="flex items-center justify-between">
+                    <a
+                      href={article.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      Read Article →
+                    </a>
+
+                    {#if $userStore}
+                      <button
+                        on:click={() => handleBookmark(article)}
+                        class="text-gray-400 hover:text-gray-600"
+                        aria-label="Bookmark this article"
+                        title="Bookmark this article"
+                      >
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+                        </svg>
+                      </button>
+                    {/if}
+                  </div>
+                </div>
               </div>
-            </div>
-          {/each}
-        </div>
+            {/each}
+          </div>
+        {/if}
+
+        <Pagination
+          current={skip}
+          pageSize={limit}
+          {hasMore}
+          on:prev={handlePrevPage}
+          on:next={handleNextPage}
+        />
       {/if}
-    {:else if currentPage === 'analytics' && $userStore}
+    {:else if currentPage === "analytics" && $userStore}
       <Dashboard />
     {:else}
       <div class="text-center py-12">

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,19 +1,31 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { userStore, loginWithGoogle, logout } from "./lib/firebase";
+  import {
+    userStore,
+    loginWithGoogle,
+    logout,
+    getIdToken,
+  } from "./lib/firebase";
   import {
     fetchArticles,
     fetchSources,
+    createBookmark,
+    deleteBookmark,
+    listBookmarks,
+    AuthExpiredError,
     type ArticleDto,
-    type ArticleEntityDto,
-    type ArticleCategoryDto,
     type SourceDto,
   } from "./lib/api";
+  import { bookmarkStore } from "./lib/bookmarkStore";
   import Dashboard from "./lib/Dashboard.svelte";
   import FilterBar from "./lib/FilterBar.svelte";
   import Pagination from "./lib/Pagination.svelte";
+  import ArticleCard from "./lib/ArticleCard.svelte";
+  import BookmarksView from "./lib/BookmarksView.svelte";
 
-  let currentPage: "articles" | "analytics" = "articles";
+  type Page = "articles" | "analytics" | "bookmarks";
+  let currentPage: Page = "articles";
+
   let articles: ArticleDto[] = [];
   let loading = true;
   let error = "";
@@ -74,6 +86,27 @@
     }
   }
 
+  async function hydrateBookmarks() {
+    if (!$userStore) {
+      bookmarkStore.reset();
+      return;
+    }
+    try {
+      const token = await getIdToken();
+      if (!token) return;
+      const bookmarks = await listBookmarks(token);
+      bookmarkStore.hydrate(bookmarks);
+    } catch (e) {
+      if (e instanceof AuthExpiredError) {
+        await logout();
+      } else {
+        console.warn("Failed to hydrate bookmarks:", e);
+      }
+    }
+  }
+
+  // ── Reactive triggers ───────────────────────────────────────────────
+
   // Re-fetch articles whenever a filter or pagination value changes.
   // (Gated by `initialised` so we don't double-fetch on first render.)
   $: if (initialised) {
@@ -82,9 +115,15 @@
     void [sentiment, category, sourceId, search, skip];
   }
 
-  // Redirect to articles if user logs out while on analytics
-  $: if (!$userStore && currentPage === "analytics") {
-    currentPage = "articles";
+  // React to auth-state changes: hydrate / reset the bookmark store, and
+  // bounce away from auth-only pages on sign-out.
+  $: if ($userStore) {
+    void hydrateBookmarks();
+  } else {
+    bookmarkStore.reset();
+    if (currentPage === "analytics" || currentPage === "bookmarks") {
+      currentPage = "articles";
+    }
   }
 
   onMount(async () => {
@@ -123,112 +162,75 @@
 
   $: hasMore = articles.length === limit;
 
-  // ── Sentiment helpers ──────────────────────────────────────────────
+  // ── Bookmark toggle from feed cards ────────────────────────────────
 
-  function getSentimentColor(label?: string): string {
-    if (!label) return "text-gray-500";
-    switch (label.toLowerCase()) {
-      case "positive": return "text-green-600";
-      case "negative": return "text-red-600";
-      case "neutral":  return "text-blue-600";
-      default:         return "text-gray-500";
+  async function handleBookmarkToggle(
+    event: CustomEvent<{ article: ArticleDto }>
+  ) {
+    const article = event.detail.article;
+
+    if (!$userStore) {
+      // Not signed in → kick off sign-in flow. No-op on the bookmark itself
+      // until the user finishes auth and clicks again.
+      try {
+        await loginWithGoogle();
+      } catch (e) {
+        console.warn("Sign-in cancelled or failed:", e);
+      }
+      return;
     }
-  }
 
-  function getSentimentBgColor(label?: string): string {
-    if (!label) return "bg-gray-100";
-    switch (label.toLowerCase()) {
-      case "positive": return "bg-green-100";
-      case "negative": return "bg-red-100";
-      case "neutral":  return "bg-blue-100";
-      default:         return "bg-gray-100";
+    const token = await getIdToken();
+    if (!token) {
+      console.warn("Could not retrieve auth token; aborting bookmark op.");
+      return;
     }
-  }
 
-  function getSentimentBarColor(label?: string): string {
-    if (!label) return "#9ca3af";
-    switch (label.toLowerCase()) {
-      case "positive": return "#16a34a";
-      case "negative": return "#dc2626";
-      case "neutral":  return "#2563eb";
-      default:         return "#9ca3af";
+    const wasBookmarked = bookmarkStore.has(article.id);
+
+    if (wasBookmarked) {
+      // Remove flow.
+      const bookmarkId = bookmarkStore.getBookmarkId(article.id);
+      if (bookmarkId === null) {
+        // Stale state — refetch and bail.
+        await hydrateBookmarks();
+        return;
+      }
+      // Optimistic remove.
+      bookmarkStore.remove(article.id);
+      try {
+        await deleteBookmark(bookmarkId, token);
+      } catch (e) {
+        // Revert
+        bookmarkStore.add(article.id, bookmarkId);
+        if (e instanceof AuthExpiredError) {
+          await logout();
+        } else {
+          console.error("Failed to remove bookmark:", e);
+        }
+      }
+    } else {
+      // Add flow. We don't yet have the bookmark.id, so optimistic-add
+      // without it; then patch in the real id once POST returns.
+      bookmarkStore.add(article.id);
+      try {
+        const created = await createBookmark(article.id, token);
+        if (created) {
+          bookmarkStore.add(article.id, created.id);
+        } else {
+          // 409 — already bookmarked server-side. Refetch to learn the id.
+          await hydrateBookmarks();
+        }
+      } catch (e) {
+        // Revert
+        bookmarkStore.remove(article.id);
+        if (e instanceof AuthExpiredError) {
+          await logout();
+        } else {
+          console.error("Failed to create bookmark:", e);
+        }
+      }
     }
-  }
-
-  function sentimentScoreToPercent(score: number): number {
-    return Math.round(((score + 1) / 2) * 100);
-  }
-
-  function getSentimentExplanation(label?: string | null, score?: number | null): string {
-    if (!label || score === null || score === undefined) return "";
-    const abs = Math.abs(score);
-    const intensity = abs > 0.6 ? "strongly" : abs > 0.25 ? "moderately" : "slightly";
-    switch (label.toLowerCase()) {
-      case "positive": return `Overall tone is ${intensity} positive`;
-      case "negative": return `Overall tone is ${intensity} negative`;
-      case "neutral":  return "Balanced, neutral tone";
-      default:         return "";
-    }
-  }
-
-  // ── Entity / category helpers ────────────────────────────────────
-
-  function getTopEntities(entities?: ArticleEntityDto[] | null, max = 3): ArticleEntityDto[] {
-    if (!entities || entities.length === 0) return [];
-    return [...entities].sort((a, b) => b.salience - a.salience).slice(0, max);
-  }
-
-  function getTopCategories(categories?: ArticleCategoryDto[] | null, max = 2): ArticleCategoryDto[] {
-    if (!categories || categories.length === 0) return [];
-    return [...categories].sort((a, b) => b.confidence - a.confidence).slice(0, max);
-  }
-
-  function formatCategoryName(taxonomyPath: string): string {
-    const parts = taxonomyPath.split("/").filter(Boolean);
-    return parts[parts.length - 1] || taxonomyPath;
-  }
-
-  function formatEntityType(type: string): string {
-    const map: Record<string, string> = {
-      ORGANIZATION: "Org", PERSON: "Person", LOCATION: "Place",
-      EVENT: "Event", WORK_OF_ART: "Work", CONSUMER_GOOD: "Product",
-      OTHER: "", UNKNOWN: "",
-    };
-    return map[type] ?? type.charAt(0) + type.slice(1).toLowerCase();
-  }
-
-  // ── Image / favicon helpers ─────────────────────────────────────
-
-  function getDomain(url: string): string {
-    try {
-      return new URL(url).hostname.replace(/^www\./, "");
-    } catch {
-      return "";
-    }
-  }
-
-  function getFaviconUrl(articleUrl: string, size = 20): string {
-    const domain = getDomain(articleUrl);
-    if (!domain) return "";
-    return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
-  }
-
-  function handleImageError(event: Event) {
-    const img = event.target as HTMLImageElement;
-    img.style.display = "none";
-  }
-
-  // ── General helpers ──────────────────────────────────────────────
-
-  function formatDate(dateStr: string): string {
-    return new Date(dateStr).toLocaleDateString();
-  }
-
-  function handleBookmark(article: ArticleDto) {
-    // TODO: Implement bookmark functionality when Firebase auth is working
-    console.log("Bookmarking article:", article.title);
-    // For now, show a simple alert
-    alert(`Bookmark feature coming soon!\n\nArticle: ${article.title}`);
   }
 </script>
 
@@ -240,19 +242,29 @@
         <div class="flex items-center space-x-6">
           <h1 class="text-2xl font-bold text-gray-900">aiFeelNews</h1>
 
-          <nav class="flex space-x-1">
+          <nav class="nav">
             <button
-              on:click={() => currentPage = "articles"}
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors
-                {currentPage === 'articles' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}"
+              on:click={() => (currentPage = "articles")}
+              class="nav-button"
+              class:nav-button-active={currentPage === "articles"}
+              aria-current={currentPage === "articles" ? "page" : undefined}
             >
               Articles
             </button>
             {#if $userStore}
               <button
-                on:click={() => currentPage = "analytics"}
-                class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors
-                  {currentPage === 'analytics' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}"
+                on:click={() => (currentPage = "bookmarks")}
+                class="nav-button"
+                class:nav-button-active={currentPage === "bookmarks"}
+                aria-current={currentPage === "bookmarks" ? "page" : undefined}
+              >
+                Bookmarks
+              </button>
+              <button
+                on:click={() => (currentPage = "analytics")}
+                class="nav-button"
+                class:nav-button-active={currentPage === "analytics"}
+                aria-current={currentPage === "analytics" ? "page" : undefined}
               >
                 Analytics
               </button>
@@ -316,169 +328,28 @@
         </div>
       {:else}
         <div class="mb-6">
-          <h2 class="text-xl font-semibold text-gray-900">Latest Articles ({articles.length})</h2>
+          <h2 class="text-xl font-semibold text-gray-900">
+            Latest Articles ({articles.length})
+          </h2>
           <p class="text-gray-600">Recent news with sentiment analysis</p>
         </div>
 
         {#if articles.length === 0}
           <div class="text-center py-12">
-            <p class="text-gray-600">No articles match the current filters.</p>
+            <p class="text-gray-600">
+              No articles match the current filters.
+            </p>
           </div>
         {:else}
           <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {#each articles as article (article.id)}
-              <div class="bg-white rounded-lg shadow-sm border overflow-hidden hover:shadow-md transition-shadow">
-                <!-- Article image / placeholder -->
-                <div class="card-image-wrapper">
-                  <div class="card-image-placeholder">
-                    <svg class="card-image-placeholder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2z" />
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15l-5-5L5 21" />
-                      <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
-                    </svg>
-                  </div>
-                  {#if article.image_url}
-                    <img
-                      src={article.image_url}
-                      alt=""
-                      class="card-image"
-                      loading="lazy"
-                      decoding="async"
-                      referrerpolicy="no-referrer"
-                      on:error={handleImageError}
-                    />
-                  {/if}
-                </div>
-
-                <div class="card-body">
-                  <!-- Source (with favicon) -->
-                  <div class="flex items-center justify-between mb-3">
-                    <span class="source-badge text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
-                      {#if getDomain(article.url)}
-                        <img
-                          src={getFaviconUrl(article.url)}
-                          alt=""
-                          class="source-favicon"
-                          loading="lazy"
-                          on:error={handleImageError}
-                        />
-                      {/if}
-                      {article.source?.name || `Source #${article.source?.id || "Unknown"}`}
-                    </span>
-                    <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
-                  </div>
-
-                  <!-- Title -->
-                  <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
-                    {article.title}
-                  </h3>
-
-                  <!-- Description -->
-                  {#if article.description}
-                    <p class="text-gray-600 text-sm mb-3 line-clamp-3">
-                      {article.description}
-                    </p>
-                  {/if}
-
-                  <!-- Sentiment analysis -->
-                  {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
-                    <div class="sentiment-section mb-3">
-                      <div class="flex items-center justify-between mb-2">
-                        <span class="text-xs font-semibold px-2 rounded {getSentimentBgColor(article.sentiment_label)} {getSentimentColor(article.sentiment_label)}">
-                          {article.sentiment_label.toUpperCase()}
-                        </span>
-                        <span
-                          class="text-xs text-gray-500"
-                          title="Sentiment score from -1.0 (very negative) to 1.0 (very positive)"
-                        >
-                          Score: {article.sentiment_score.toFixed(2)}
-                        </span>
-                      </div>
-
-                      <div class="sentiment-bar-track">
-                        <div
-                          class="sentiment-bar-fill"
-                          style="width: {sentimentScoreToPercent(article.sentiment_score)}%; background-color: {getSentimentBarColor(article.sentiment_label)};"
-                        ></div>
-                        <div class="sentiment-bar-midpoint"></div>
-                      </div>
-
-                      <p class="text-xs text-gray-400 mt-1 sentiment-explanation">
-                        {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
-                      </p>
-                    </div>
-                  {/if}
-
-                  <!-- Content categories -->
-                  {#if getTopCategories(article.article_categories).length > 0}
-                    <div class="flex items-center flex-wrap gap-1 mb-2">
-                      <span class="text-xs text-gray-400 mr-1">Topics:</span>
-                      {#each getTopCategories(article.article_categories) as cat}
-                        <span
-                          class="category-chip"
-                          title="Category: {cat.name} (confidence: {(cat.confidence * 100).toFixed(0)}%)"
-                        >
-                          {formatCategoryName(cat.name)}
-                        </span>
-                      {/each}
-                    </div>
-                  {/if}
-
-                  <!-- Key entities -->
-                  {#if getTopEntities(article.article_entities).length > 0}
-                    <div class="flex items-center flex-wrap gap-1 mb-3">
-                      <span class="text-xs text-gray-400 mr-1">Entities:</span>
-                      {#each getTopEntities(article.article_entities) as ae}
-                        {#if ae.entity.wikipedia_url}
-                          <a
-                            href={ae.entity.wikipedia_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="entity-chip entity-chip-link"
-                            title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
-                          >
-                            {ae.entity.name}
-                            {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
-                          </a>
-                        {:else}
-                          <span
-                            class="entity-chip"
-                            title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
-                          >
-                            {ae.entity.name}
-                            {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
-                          </span>
-                        {/if}
-                      {/each}
-                    </div>
-                  {/if}
-
-                  <!-- Actions -->
-                  <div class="flex items-center justify-between">
-                    <a
-                      href={article.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
-                    >
-                      Read Article →
-                    </a>
-
-                    {#if $userStore}
-                      <button
-                        on:click={() => handleBookmark(article)}
-                        class="text-gray-400 hover:text-gray-600"
-                        aria-label="Bookmark this article"
-                        title="Bookmark this article"
-                      >
-                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
-                        </svg>
-                      </button>
-                    {/if}
-                  </div>
-                </div>
-              </div>
+              <ArticleCard
+                {article}
+                showBookmarkButton={!!$userStore}
+                isBookmarked={$bookmarkStore.bookmarkedIds.has(article.id)}
+                actionVariant="toggle"
+                on:bookmark={handleBookmarkToggle}
+              />
             {/each}
           </div>
         {/if}
@@ -491,30 +362,14 @@
           on:next={handleNextPage}
         />
       {/if}
+    {:else if currentPage === "bookmarks" && $userStore}
+      <BookmarksView />
     {:else if currentPage === "analytics" && $userStore}
       <Dashboard />
     {:else}
       <div class="text-center py-12">
-        <p class="text-gray-600">Please log in to access analytics.</p>
+        <p class="text-gray-600">Please log in to access this page.</p>
       </div>
     {/if}
   </main>
 </div>
-
-<style>
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    line-clamp: 2; /* Standard property for compatibility */
-    overflow: hidden;
-  }
-
-  .line-clamp-3 {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    line-clamp: 3; /* Standard property for compatibility */
-    overflow: hidden;
-  }
-</style>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -257,6 +257,92 @@ body {
 
 .border-b-2 { border-bottom-width: 2px; }
 
+/* --- Filter bar --- */
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.filter-select,
+.search-input {
+  font-family: inherit;
+  font-size: 0.875rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.375rem;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  color: #111827;
+  line-height: 1.25rem;
+  min-height: 2.25rem;
+}
+
+.filter-select {
+  min-width: 9rem;
+  cursor: pointer;
+}
+
+.search-input {
+  flex: 1 1 14rem;
+  min-width: 12rem;
+}
+
+.filter-select:focus,
+.search-input:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: -1px;
+  border-color: #2563eb;
+}
+
+/* --- Pagination --- */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding: 1rem 0;
+}
+
+.pagination-button {
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  color: #1f2937;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.pagination-button:hover:not(:disabled) {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.pagination-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: #f9fafb;
+  color: #9ca3af;
+}
+
+.pagination-page {
+  font-size: 0.875rem;
+  color: #4b5563;
+  min-width: 4rem;
+  text-align: center;
+}
+
 @media (min-width: 768px) {
   .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -343,6 +343,55 @@ body {
   text-align: center;
 }
 
+/* --- Top nav --- */
+.nav {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.nav-button {
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  background-color: transparent;
+  color: #4b5563;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.nav-button:hover {
+  background-color: #f3f4f6;
+  color: #111827;
+}
+
+.nav-button-active,
+.nav-button-active:hover {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+
+/* --- Bookmark card remove button --- */
+.bookmark-card-remove {
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.375rem;
+  border: 1px solid #fecaca;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.bookmark-card-remove:hover {
+  background-color: #fecaca;
+  color: #7f1d1d;
+}
+
 @media (min-width: 768px) {
   .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }

--- a/frontend/src/lib/ArticleCard.svelte
+++ b/frontend/src/lib/ArticleCard.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import type {
+    ArticleDto,
+    ArticleEntityDto,
+    ArticleCategoryDto,
+  } from "./api";
+
+  export let article: ArticleDto;
+  /** Whether to render the bookmark/remove control (signed-in only). */
+  export let showBookmarkButton: boolean = false;
+  /** Whether the article is currently bookmarked (drives icon fill / toggle). */
+  export let isBookmarked: boolean = false;
+  /**
+   * Variant of the trailing action:
+   *  - 'toggle'  → bookmark icon, click toggles add/remove
+   *  - 'remove'  → explicit "✕ Remove" button (used by BookmarksView)
+   *  - 'none'    → no action button at all
+   */
+  export let actionVariant: "toggle" | "remove" | "none" = "toggle";
+
+  const dispatch = createEventDispatcher<{
+    bookmark: { article: ArticleDto };
+    remove: { article: ArticleDto };
+  }>();
+
+  // ── Sentiment helpers ──────────────────────────────────────────────
+
+  function getSentimentColor(label?: string | null): string {
+    if (!label) return "text-gray-500";
+    switch (label.toLowerCase()) {
+      case "positive": return "text-green-600";
+      case "negative": return "text-red-600";
+      case "neutral":  return "text-blue-600";
+      default:         return "text-gray-500";
+    }
+  }
+
+  function getSentimentBgColor(label?: string | null): string {
+    if (!label) return "bg-gray-100";
+    switch (label.toLowerCase()) {
+      case "positive": return "bg-green-100";
+      case "negative": return "bg-red-100";
+      case "neutral":  return "bg-blue-100";
+      default:         return "bg-gray-100";
+    }
+  }
+
+  function getSentimentBarColor(label?: string | null): string {
+    if (!label) return "#9ca3af";
+    switch (label.toLowerCase()) {
+      case "positive": return "#16a34a";
+      case "negative": return "#dc2626";
+      case "neutral":  return "#2563eb";
+      default:         return "#9ca3af";
+    }
+  }
+
+  function sentimentScoreToPercent(score: number): number {
+    return Math.round(((score + 1) / 2) * 100);
+  }
+
+  function getSentimentExplanation(
+    label?: string | null,
+    score?: number | null
+  ): string {
+    if (!label || score === null || score === undefined) return "";
+    const abs = Math.abs(score);
+    const intensity =
+      abs > 0.6 ? "strongly" : abs > 0.25 ? "moderately" : "slightly";
+    switch (label.toLowerCase()) {
+      case "positive": return `Overall tone is ${intensity} positive`;
+      case "negative": return `Overall tone is ${intensity} negative`;
+      case "neutral":  return "Balanced, neutral tone";
+      default:         return "";
+    }
+  }
+
+  // ── Entity / category helpers ────────────────────────────────────
+
+  function getTopEntities(
+    entities?: ArticleEntityDto[] | null,
+    max = 3
+  ): ArticleEntityDto[] {
+    if (!entities || entities.length === 0) return [];
+    return [...entities].sort((a, b) => b.salience - a.salience).slice(0, max);
+  }
+
+  function getTopCategories(
+    categories?: ArticleCategoryDto[] | null,
+    max = 2
+  ): ArticleCategoryDto[] {
+    if (!categories || categories.length === 0) return [];
+    return [...categories]
+      .sort((a, b) => b.confidence - a.confidence)
+      .slice(0, max);
+  }
+
+  function formatCategoryName(taxonomyPath: string): string {
+    const parts = taxonomyPath.split("/").filter(Boolean);
+    return parts[parts.length - 1] || taxonomyPath;
+  }
+
+  function formatEntityType(type: string): string {
+    const map: Record<string, string> = {
+      ORGANIZATION: "Org", PERSON: "Person", LOCATION: "Place",
+      EVENT: "Event", WORK_OF_ART: "Work", CONSUMER_GOOD: "Product",
+      OTHER: "", UNKNOWN: "",
+    };
+    return map[type] ?? type.charAt(0) + type.slice(1).toLowerCase();
+  }
+
+  // ── Image / favicon helpers ─────────────────────────────────────
+
+  function getDomain(url: string): string {
+    try {
+      return new URL(url).hostname.replace(/^www\./, "");
+    } catch {
+      return "";
+    }
+  }
+
+  function getFaviconUrl(articleUrl: string, size = 20): string {
+    const domain = getDomain(articleUrl);
+    if (!domain) return "";
+    return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
+  }
+
+  function handleImageError(event: Event) {
+    const img = event.target as HTMLImageElement;
+    img.style.display = "none";
+  }
+
+  function formatDate(dateStr: string): string {
+    return new Date(dateStr).toLocaleDateString();
+  }
+
+  function handleBookmarkClick() {
+    dispatch("bookmark", { article });
+  }
+
+  function handleRemoveClick() {
+    dispatch("remove", { article });
+  }
+</script>
+
+<div class="bg-white rounded-lg shadow-sm border overflow-hidden hover:shadow-md transition-shadow">
+  <!-- Article image / placeholder -->
+  <div class="card-image-wrapper">
+    <div class="card-image-placeholder">
+      <svg class="card-image-placeholder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2z" />
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15l-5-5L5 21" />
+        <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
+      </svg>
+    </div>
+    {#if article.image_url}
+      <img
+        src={article.image_url}
+        alt=""
+        class="card-image"
+        loading="lazy"
+        decoding="async"
+        referrerpolicy="no-referrer"
+        on:error={handleImageError}
+      />
+    {/if}
+  </div>
+
+  <div class="card-body">
+    <!-- Source (with favicon) -->
+    <div class="flex items-center justify-between mb-3">
+      <span class="source-badge text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
+        {#if getDomain(article.url)}
+          <img
+            src={getFaviconUrl(article.url)}
+            alt=""
+            class="source-favicon"
+            loading="lazy"
+            on:error={handleImageError}
+          />
+        {/if}
+        {article.source?.name || `Source #${article.source?.id || "Unknown"}`}
+      </span>
+      <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
+    </div>
+
+    <!-- Title -->
+    <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+      {article.title}
+    </h3>
+
+    <!-- Description -->
+    {#if article.description}
+      <p class="text-gray-600 text-sm mb-3 line-clamp-3">
+        {article.description}
+      </p>
+    {/if}
+
+    <!-- Sentiment analysis -->
+    {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
+      <div class="sentiment-section mb-3">
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-xs font-semibold px-2 rounded {getSentimentBgColor(article.sentiment_label)} {getSentimentColor(article.sentiment_label)}">
+            {article.sentiment_label.toUpperCase()}
+          </span>
+          <span
+            class="text-xs text-gray-500"
+            title="Sentiment score from -1.0 (very negative) to 1.0 (very positive)"
+          >
+            Score: {article.sentiment_score.toFixed(2)}
+          </span>
+        </div>
+
+        <div class="sentiment-bar-track">
+          <div
+            class="sentiment-bar-fill"
+            style="width: {sentimentScoreToPercent(article.sentiment_score)}%; background-color: {getSentimentBarColor(article.sentiment_label)};"
+          ></div>
+          <div class="sentiment-bar-midpoint"></div>
+        </div>
+
+        <p class="text-xs text-gray-400 mt-1 sentiment-explanation">
+          {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
+        </p>
+      </div>
+    {/if}
+
+    <!-- Content categories -->
+    {#if getTopCategories(article.article_categories).length > 0}
+      <div class="flex items-center flex-wrap gap-1 mb-2">
+        <span class="text-xs text-gray-400 mr-1">Topics:</span>
+        {#each getTopCategories(article.article_categories) as cat}
+          <span
+            class="category-chip"
+            title="Category: {cat.name} (confidence: {(cat.confidence * 100).toFixed(0)}%)"
+          >
+            {formatCategoryName(cat.name)}
+          </span>
+        {/each}
+      </div>
+    {/if}
+
+    <!-- Key entities -->
+    {#if getTopEntities(article.article_entities).length > 0}
+      <div class="flex items-center flex-wrap gap-1 mb-3">
+        <span class="text-xs text-gray-400 mr-1">Entities:</span>
+        {#each getTopEntities(article.article_entities) as ae}
+          {#if ae.entity.wikipedia_url}
+            <a
+              href={ae.entity.wikipedia_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="entity-chip entity-chip-link"
+              title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
+            >
+              {ae.entity.name}
+              {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
+            </a>
+          {:else}
+            <span
+              class="entity-chip"
+              title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
+            >
+              {ae.entity.name}
+              {#if formatEntityType(ae.entity.type)}<span class="entity-type">{formatEntityType(ae.entity.type)}</span>{/if}
+            </span>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+
+    <!-- Actions -->
+    <div class="flex items-center justify-between">
+      <a
+        href={article.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+      >
+        Read Article →
+      </a>
+
+      {#if showBookmarkButton && actionVariant === "toggle"}
+        <button
+          on:click={handleBookmarkClick}
+          class="text-gray-400 hover:text-gray-600"
+          aria-label={isBookmarked ? "Remove bookmark" : "Bookmark this article"}
+          aria-pressed={isBookmarked}
+          title={isBookmarked ? "Remove bookmark" : "Bookmark this article"}
+        >
+          <svg
+            class="w-5 h-5"
+            fill={isBookmarked ? "currentColor" : "none"}
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+          </svg>
+        </button>
+      {:else if actionVariant === "remove"}
+        <button
+          on:click={handleRemoveClick}
+          class="bookmark-card-remove"
+          aria-label="Remove bookmark"
+          title="Remove bookmark"
+          type="button"
+        >
+          ✕ Remove
+        </button>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    line-clamp: 3;
+    overflow: hidden;
+  }
+</style>

--- a/frontend/src/lib/BookmarksView.svelte
+++ b/frontend/src/lib/BookmarksView.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { userStore, getIdToken, loginWithGoogle } from "./firebase";
+  import {
+    listBookmarks,
+    deleteBookmark,
+    fetchArticleById,
+    AuthExpiredError,
+    type ArticleDto,
+    type BookmarkDto,
+  } from "./api";
+  import { bookmarkStore } from "./bookmarkStore";
+  import ArticleCard from "./ArticleCard.svelte";
+
+  type BookmarkedItem = {
+    bookmark: BookmarkDto;
+    article: ArticleDto;
+  };
+
+  let items: BookmarkedItem[] = [];
+  let loading = true;
+  let error = "";
+
+  async function loadBookmarks() {
+    loading = true;
+    error = "";
+
+    if (!$userStore) {
+      // Render empty state — sign-in prompt is in the template.
+      items = [];
+      loading = false;
+      return;
+    }
+
+    try {
+      const token = await getIdToken();
+      if (!token) {
+        items = [];
+        loading = false;
+        return;
+      }
+
+      const bookmarks = await listBookmarks(token);
+      bookmarkStore.hydrate(bookmarks);
+
+      // Hydrate each bookmark into a full article view. We fetch in parallel
+      // and gracefully drop any 404s (orphaned bookmark whose article was
+      // pruned by TTL cleanup).
+      const settled = await Promise.allSettled(
+        bookmarks.map((bm) => fetchArticleById(bm.article_id))
+      );
+
+      const next: BookmarkedItem[] = [];
+      bookmarks.forEach((bm, i) => {
+        const r = settled[i];
+        if (r.status === "fulfilled") {
+          next.push({ bookmark: bm, article: r.value });
+        } else {
+          console.warn(
+            `Could not load article ${bm.article_id} for bookmark ${bm.id}:`,
+            r.reason
+          );
+        }
+      });
+      items = next;
+    } catch (e) {
+      if (e instanceof AuthExpiredError) {
+        error = "Your session expired. Please sign in again.";
+      } else {
+        console.error("Failed to load bookmarks:", e);
+        error =
+          e instanceof Error ? e.message : "Failed to load bookmarks";
+      }
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleRemove(event: CustomEvent<{ article: ArticleDto }>) {
+    const articleId = event.detail.article.id;
+    const item = items.find((i) => i.article.id === articleId);
+    if (!item) return;
+
+    const token = await getIdToken();
+    if (!token) {
+      error = "You must be signed in to remove bookmarks.";
+      return;
+    }
+
+    // Optimistic removal: drop from local list + store, revert on error.
+    const previousItems = items;
+    items = items.filter((i) => i.article.id !== articleId);
+    bookmarkStore.remove(articleId);
+
+    try {
+      await deleteBookmark(item.bookmark.id, token);
+    } catch (e) {
+      if (e instanceof AuthExpiredError) {
+        error = "Your session expired. Please sign in again.";
+      } else {
+        console.error("Failed to delete bookmark:", e);
+        error =
+          e instanceof Error ? e.message : "Failed to delete bookmark";
+      }
+      // Revert
+      items = previousItems;
+      bookmarkStore.add(articleId, item.bookmark.id);
+    }
+  }
+
+  function handleRetry() {
+    loadBookmarks();
+  }
+
+  onMount(() => {
+    loadBookmarks();
+  });
+</script>
+
+<div class="mb-6">
+  <h2 class="text-xl font-semibold text-gray-900">Your Bookmarks</h2>
+  <p class="text-gray-600">Articles you've saved for later</p>
+</div>
+
+{#if !$userStore}
+  <div class="text-center py-12">
+    <p class="text-gray-600 mb-4">Please sign in to view your bookmarks.</p>
+    <button
+      on:click={loginWithGoogle}
+      class="bg-blue-600 text-white px-4 py-2 rounded-md text-sm hover:bg-blue-700"
+    >
+      Login with Google
+    </button>
+  </div>
+{:else if error}
+  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+    <div class="flex items-center justify-between">
+      <span>Couldn't load bookmarks. {error}</span>
+      <button
+        on:click={handleRetry}
+        class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
+      >
+        Retry
+      </button>
+    </div>
+  </div>
+{:else if loading}
+  <div class="text-center py-12">
+    <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+    <p class="mt-4 text-gray-600">Loading your bookmarks...</p>
+  </div>
+{:else if items.length === 0}
+  <div class="text-center py-12">
+    <p class="text-gray-600">
+      No bookmarks yet. Click the 🔖 icon on any article in the feed to save it here.
+    </p>
+  </div>
+{:else}
+  <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    {#each items as item (item.bookmark.id)}
+      <ArticleCard
+        article={item.article}
+        showBookmarkButton={true}
+        isBookmarked={true}
+        actionVariant="remove"
+        on:remove={handleRemove}
+      />
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/lib/FilterBar.svelte
+++ b/frontend/src/lib/FilterBar.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import type { SourceDto } from "./api";
+
+  export let sentiment: string = "";
+  export let category: string = "";
+  export let sourceId: number | "" = "";
+  export let search: string = "";
+  export let categories: string[] = [];
+  export let sources: SourceDto[] = [];
+
+  const dispatch = createEventDispatcher<{
+    change: {
+      sentiment: string;
+      category: string;
+      sourceId: number | "";
+      search: string;
+    };
+  }>();
+
+  // Debounce the search input so we don't fire one fetch per keystroke.
+  let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  function emitChange() {
+    dispatch("change", {
+      sentiment,
+      category,
+      sourceId,
+      search,
+    });
+  }
+
+  function handleSelectChange() {
+    // selects are non-debounced — change fires once per user pick.
+    emitChange();
+  }
+
+  function handleSearchInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    search = target.value;
+    if (searchDebounce !== null) clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(() => {
+      emitChange();
+      searchDebounce = null;
+    }, 300);
+  }
+
+  function handleSourceChange(event: Event) {
+    const target = event.target as HTMLSelectElement;
+    sourceId = target.value === "" ? "" : Number(target.value);
+    emitChange();
+  }
+</script>
+
+<div class="filter-bar">
+  <select
+    class="filter-select"
+    bind:value={sentiment}
+    on:change={handleSelectChange}
+    aria-label="Filter by sentiment"
+  >
+    <option value="">All sentiments</option>
+    <option value="positive">Positive</option>
+    <option value="negative">Negative</option>
+    <option value="neutral">Neutral</option>
+  </select>
+
+  <select
+    class="filter-select"
+    bind:value={category}
+    on:change={handleSelectChange}
+    aria-label="Filter by category"
+  >
+    <option value="">All categories</option>
+    {#each categories as cat}
+      <option value={cat}>{cat.charAt(0).toUpperCase() + cat.slice(1)}</option>
+    {/each}
+  </select>
+
+  <select
+    class="filter-select"
+    value={sourceId === "" ? "" : String(sourceId)}
+    on:change={handleSourceChange}
+    aria-label="Filter by source"
+  >
+    <option value="">All sources</option>
+    {#each sources as src}
+      <option value={String(src.id)}>{src.name}</option>
+    {/each}
+  </select>
+
+  <input
+    type="search"
+    class="search-input"
+    placeholder="Search titles..."
+    value={search}
+    on:input={handleSearchInput}
+    aria-label="Search article titles"
+  />
+</div>

--- a/frontend/src/lib/Pagination.svelte
+++ b/frontend/src/lib/Pagination.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let current: number = 0; // skip value (offset, zero-based)
+  export let pageSize: number = 20; // limit
+  export let hasMore: boolean = false;
+
+  const dispatch = createEventDispatcher<{ prev: void; next: void }>();
+
+  $: pageNumber = Math.floor(current / pageSize) + 1;
+  $: prevDisabled = current === 0;
+  $: nextDisabled = !hasMore;
+
+  function handlePrev() {
+    if (!prevDisabled) dispatch("prev");
+  }
+
+  function handleNext() {
+    if (!nextDisabled) dispatch("next");
+  }
+</script>
+
+<nav class="pagination" aria-label="Article feed pagination">
+  <button
+    class="pagination-button"
+    disabled={prevDisabled}
+    on:click={handlePrev}
+    aria-label="Previous page"
+    type="button"
+  >
+    ← Prev
+  </button>
+  <span class="pagination-page">Page {pageNumber}</span>
+  <button
+    class="pagination-button"
+    disabled={nextDisabled}
+    on:click={handleNext}
+    aria-label="Next page"
+    type="button"
+  >
+    Next →
+  </button>
+</nav>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -64,19 +64,66 @@ export type ArticleDto = {
   article_categories?: ArticleCategoryDto[] | null;
 };
 
-export async function fetchLatestArticles(limit = 40): Promise<ArticleDto[]> {
-  const url = `${API_BASE}/articles/latest?limit=${limit}`;
+export type ArticleFilterParams = {
+  skip?: number;
+  limit?: number;
+  sentiment_label?: string;
+  category?: string;
+  source_id?: number;
+  search?: string;
+};
+
+/**
+ * Fetch articles from the canonical filtered endpoint `/articles/`.
+ *
+ * Query params are serialised via URLSearchParams; empty / undefined values
+ * are skipped so the backend gets a clean URL. Order is server-stable
+ * (`published_at desc, id desc`).
+ */
+export async function fetchArticles(
+  params: ArticleFilterParams = {}
+): Promise<ArticleDto[]> {
+  const qs = new URLSearchParams();
+  if (params.skip !== undefined) qs.set("skip", String(params.skip));
+  if (params.limit !== undefined) qs.set("limit", String(params.limit));
+  if (params.sentiment_label) qs.set("sentiment_label", params.sentiment_label);
+  if (params.category) qs.set("category", params.category);
+  if (params.source_id !== undefined && params.source_id !== null) {
+    qs.set("source_id", String(params.source_id));
+  }
+  if (params.search) qs.set("search", params.search);
+
+  const queryString = qs.toString();
+  const url = queryString
+    ? `${API_BASE}/articles/?${queryString}`
+    : `${API_BASE}/articles/`;
 
   const res = await fetch(url);
 
   if (!res.ok) {
     const errorText = await res.text();
-    console.error('API Error:', errorText);
-    throw new Error(`Failed to fetch latest articles: ${res.status} ${errorText}`);
+    console.error("API Error:", errorText);
+    throw new Error(`Failed to fetch articles: ${res.status} ${errorText}`);
   }
 
-  const data = await res.json();
-  return data;
+  return await res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Sources
+// ---------------------------------------------------------------------------
+
+export type SourceDto = {
+  id: number;
+  name: string;
+};
+
+export async function fetchSources(): Promise<SourceDto[]> {
+  const res = await fetch(`${API_BASE}/sources/`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch sources: ${res.status}`);
+  }
+  return await res.json();
 }
 
 export async function fetchBookmarks(): Promise<any[]> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -109,6 +109,19 @@ export async function fetchArticles(
   return await res.json();
 }
 
+/**
+ * Fetch a single article by ID. Used by BookmarksView to hydrate bookmarked
+ * article details after listing the user's bookmarks.
+ */
+export async function fetchArticleById(id: number): Promise<ArticleDto> {
+  const res = await fetch(`${API_BASE}/articles/${id}`);
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Failed to fetch article ${id}: ${res.status} ${errorText}`);
+  }
+  return await res.json();
+}
+
 // ---------------------------------------------------------------------------
 // Sources
 // ---------------------------------------------------------------------------
@@ -126,16 +139,102 @@ export async function fetchSources(): Promise<SourceDto[]> {
   return await res.json();
 }
 
-export async function fetchBookmarks(): Promise<any[]> {
-  const token = await getIdToken();
-  if (!token) throw new Error("Not authenticated");
+// ---------------------------------------------------------------------------
+// Bookmarks
+// ---------------------------------------------------------------------------
 
-  const res = await fetch(`${API_BASE}/bookmarks`, {
-    headers: { Authorization: `Bearer ${token}` }
+export type BookmarkDto = {
+  id: number;
+  user_id: number;
+  article_id: number;
+  created_at?: string;
+};
+
+export class AuthExpiredError extends Error {
+  constructor(message = "Authentication expired") {
+    super(message);
+    this.name = "AuthExpiredError";
+  }
+}
+
+/**
+ * Create a bookmark for the given article.
+ *
+ * Treats 409 (already bookmarked) as silent success — the caller's optimistic
+ * UI was already correct. Throws ``AuthExpiredError`` on 401 so the caller
+ * can sign-out + re-prompt.
+ */
+export async function createBookmark(
+  articleId: number,
+  idToken: string
+): Promise<BookmarkDto | null> {
+  const res = await fetch(`${API_BASE}/bookmarks/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify({ article_id: articleId }),
   });
 
-  if (!res.ok) throw new Error("Failed to fetch bookmarks");
+  if (res.status === 409) {
+    return null; // already bookmarked — keep optimistic state
+  }
+  if (res.status === 401) {
+    throw new AuthExpiredError();
+  }
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Failed to create bookmark: ${res.status} ${errorText}`);
+  }
   return await res.json();
+}
+
+export async function listBookmarks(idToken: string): Promise<BookmarkDto[]> {
+  const res = await fetch(`${API_BASE}/bookmarks/`, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  if (res.status === 401) {
+    throw new AuthExpiredError();
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to list bookmarks: ${res.status}`);
+  }
+  return await res.json();
+}
+
+/**
+ * Delete a bookmark. 404 is treated as silent success — the bookmark is
+ * already gone, which is exactly what the caller wanted.
+ */
+export async function deleteBookmark(
+  bookmarkId: number,
+  idToken: string
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/bookmarks/${bookmarkId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+
+  if (res.status === 401) {
+    throw new AuthExpiredError();
+  }
+  if (res.status === 404) {
+    return; // already gone — silent success
+  }
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(
+      `Failed to delete bookmark ${bookmarkId}: ${res.status} ${errorText}`
+    );
+  }
+}
+
+/** @deprecated kept for backward compat — uses internal getIdToken. */
+export async function fetchBookmarks(): Promise<BookmarkDto[]> {
+  const token = await getIdToken();
+  if (!token) throw new Error("Not authenticated");
+  return await listBookmarks(token);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/bookmarkStore.ts
+++ b/frontend/src/lib/bookmarkStore.ts
@@ -1,0 +1,82 @@
+import { writable, get } from "svelte/store";
+import type { BookmarkDto } from "./api";
+
+/**
+ * Bookmark state for the signed-in user.
+ *
+ * Two parallel structures:
+ *   - `bookmarkedIds`: a Set of article IDs (drives icon fill on cards)
+ *   - `byArticleId`:   a map article_id → bookmark.id (needed for DELETE,
+ *     since the backend identifies bookmarks by their own primary key, not
+ *     by article id).
+ *
+ * The store is hydrated once on auth-state-change (from `listBookmarks`) and
+ * updated optimistically on add/remove from the article-card click handlers.
+ * On error the caller is expected to revert via the inverse mutation.
+ */
+
+type BookmarkState = {
+  bookmarkedIds: Set<number>;
+  byArticleId: Map<number, number>; // article_id -> bookmark.id
+};
+
+function createInitialState(): BookmarkState {
+  return {
+    bookmarkedIds: new Set<number>(),
+    byArticleId: new Map<number, number>(),
+  };
+}
+
+const internalStore = writable<BookmarkState>(createInitialState());
+
+export const bookmarkStore = {
+  subscribe: internalStore.subscribe,
+
+  /**
+   * Add an article to the bookmark set. If `bookmarkId` is known (post-create)
+   * pass it so future deletes can resolve. If unknown (optimistic-add before
+   * the POST returns) call again with the bookmarkId once the response lands.
+   */
+  add(articleId: number, bookmarkId?: number): void {
+    internalStore.update((state) => {
+      state.bookmarkedIds.add(articleId);
+      if (bookmarkId !== undefined) {
+        state.byArticleId.set(articleId, bookmarkId);
+      }
+      return { ...state };
+    });
+  },
+
+  remove(articleId: number): void {
+    internalStore.update((state) => {
+      state.bookmarkedIds.delete(articleId);
+      state.byArticleId.delete(articleId);
+      return { ...state };
+    });
+  },
+
+  has(articleId: number): boolean {
+    return get(internalStore).bookmarkedIds.has(articleId);
+  },
+
+  /**
+   * Resolve an article id to its server-side bookmark.id (for DELETE).
+   * Returns null if the mapping isn't known — the caller should refetch.
+   */
+  getBookmarkId(articleId: number): number | null {
+    return get(internalStore).byArticleId.get(articleId) ?? null;
+  },
+
+  hydrate(bookmarks: BookmarkDto[]): void {
+    const next = createInitialState();
+    for (const bm of bookmarks) {
+      next.bookmarkedIds.add(bm.article_id);
+      next.byArticleId.set(bm.article_id, bm.id);
+    }
+    internalStore.set(next);
+  },
+
+  reset(): void {
+    internalStore.set(createInitialState());
+  },
+};

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,25 @@
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
+from app import models  # noqa: F401 — register all ORM models on Base.metadata
 from app.database import Base
 
 
 @pytest.fixture(scope="function")
 def test_db():
-    """Create a fresh in-memory SQLite database for each test."""
-    # Use unique connection for each test to ensure proper isolation
+    """Create a fresh in-memory SQLite database for each test.
+
+    StaticPool keeps a single connection alive for every request, including
+    those FastAPI's TestClient runs in its threadpool — without it, each new
+    connection opens a separate ``:memory:`` database with no tables.
+    """
     engine = create_engine(
-        "sqlite:///:memory:", echo=False, connect_args={"check_same_thread": False}
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
 
     # Enable foreign key constraints in SQLite

--- a/tests/test_articles_filters.py
+++ b/tests/test_articles_filters.py
@@ -1,0 +1,182 @@
+"""Tests for the filter / search / pagination contract on /articles routes.
+
+These exercise the shared ``_query_articles`` helper through the public
+``/articles/`` endpoint via TestClient. ``/articles/latest`` reuses the same
+helper so a single smoke test covers it.
+
+The tests run against the in-memory SQLite ``test_db`` fixture from
+``tests/conftest.py``. Auth is irrelevant here because the article list
+routes are unauthenticated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.main import app
+from app.models.article import Article
+from app.models.source import Source
+
+
+@pytest.fixture
+def seeded_db(test_db: Session) -> Iterator[Session]:
+    """Seed the in-memory DB with two sources and ten varied articles.
+
+    Distribution:
+      - sentiment_label: 4 positive, 3 negative, 3 neutral
+      - category: 4 general, 3 business, 3 sports
+      - source_id: 5 from source 1, 5 from source 2
+      - one title contains "trump" so the substring search test has a hit
+    """
+    source1 = Source(id=1, name="bbc")
+    source2 = Source(id=2, name="cnn")
+    test_db.add_all([source1, source2])
+    test_db.flush()
+
+    base_time = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+    # (title, sentiment_label, category, source_id)
+    rows: list[tuple[str, str, str, int]] = [
+        ("Markets rally after Trump speech", "positive", "business", 1),
+        ("Olympic team announces new roster", "positive", "sports", 2),
+        ("Scientists discover quantum advance", "positive", "general", 1),
+        ("Local festival draws record crowd", "positive", "general", 2),
+        ("Layoffs hit major tech firm", "negative", "business", 1),
+        ("Storm causes widespread damage", "negative", "general", 2),
+        ("Team loses championship final", "negative", "sports", 1),
+        ("Central bank holds rates steady", "neutral", "business", 2),
+        ("New stadium opens to public", "neutral", "sports", 1),
+        ("City council debates new policy", "neutral", "general", 2),
+    ]
+
+    for idx, (title, sentiment, category, source_id) in enumerate(rows):
+        test_db.add(
+            Article(
+                source_id=source_id,
+                title=title,
+                url=f"https://example.com/articles/{idx}",
+                published_at=base_time - timedelta(hours=idx),
+                sentiment_label=sentiment,
+                category=category,
+            )
+        )
+    test_db.commit()
+
+    yield test_db
+
+
+@pytest.fixture
+def client(seeded_db: Session) -> Iterator[TestClient]:
+    """A TestClient with ``get_db`` overridden to yield the seeded session."""
+
+    def _override_get_db() -> Iterator[Session]:
+        yield seeded_db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+class TestArticleFilters:
+    """Filter / search / pagination + 422 boundary cases on /articles/."""
+
+    def test_articles_default(self, client: TestClient) -> None:
+        """No params: default page returns all 10 seeded rows."""
+        resp = client.get("/articles/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 10
+        # Stable order: newest first by published_at.
+        published = [a["published_at"] for a in data]
+        assert published == sorted(published, reverse=True)
+
+    def test_articles_filter_by_sentiment(self, client: TestClient) -> None:
+        """sentiment_label=positive returns exactly the 4 positive rows."""
+        resp = client.get("/articles/?sentiment_label=positive")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 4
+        assert all(a["sentiment_label"] == "positive" for a in data)
+
+    def test_articles_filter_by_category(self, client: TestClient) -> None:
+        """category=business returns exactly the 3 business rows."""
+        resp = client.get("/articles/?category=business")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+        assert all(a["category"] == "business" for a in data)
+
+    def test_articles_filter_by_source(self, client: TestClient) -> None:
+        """source_id=1 returns exactly the 5 rows from source 1."""
+        resp = client.get("/articles/?source_id=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 5
+        assert all(a["source"]["id"] == 1 for a in data)
+
+    def test_articles_search_substring(self, client: TestClient) -> None:
+        """Case-insensitive substring search on title; matches "trump"."""
+        resp = client.get("/articles/?search=trump")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert "Trump" in data[0]["title"]
+
+    def test_articles_pagination(self, client: TestClient) -> None:
+        """skip+limit yield disjoint id sets across consecutive pages."""
+        page1 = client.get("/articles/?skip=0&limit=5").json()
+        page2 = client.get("/articles/?skip=5&limit=5").json()
+
+        assert len(page1) == 5
+        assert len(page2) == 5
+
+        ids1 = {a["id"] for a in page1}
+        ids2 = {a["id"] for a in page2}
+        assert ids1.isdisjoint(ids2)
+        assert len(ids1 | ids2) == 10
+
+    def test_articles_filter_combination(self, client: TestClient) -> None:
+        """Filters AND together: positive + business = 1 row (Trump speech)."""
+        resp = client.get("/articles/?sentiment_label=positive&category=business")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["sentiment_label"] == "positive"
+        assert data[0]["category"] == "business"
+
+    def test_articles_invalid_sentiment_returns_422(self, client: TestClient) -> None:
+        """Values outside the regex enum (positive|negative|neutral) → 422."""
+        resp = client.get("/articles/?sentiment_label=ecstatic")
+        assert resp.status_code == 422
+        assert "detail" in resp.json()
+
+    def test_articles_invalid_skip_returns_422(self, client: TestClient) -> None:
+        """skip < 0 violates the ge=0 constraint → 422."""
+        resp = client.get("/articles/?skip=-1")
+        assert resp.status_code == 422
+        assert "detail" in resp.json()
+
+    def test_articles_search_too_short_returns_422(self, client: TestClient) -> None:
+        """search shorter than min_length=2 → 422."""
+        resp = client.get("/articles/?search=a")
+        assert resp.status_code == 422
+        assert "detail" in resp.json()
+
+
+def test_latest_accepts_same_query_params(client: TestClient) -> None:
+    """Smoke test: /articles/latest shares the helper, so the same filter
+    surface must work end-to-end. We assert filter semantics, not response
+    shape (already covered above)."""
+    resp = client.get("/articles/latest?sentiment_label=neutral&limit=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    assert all(a["sentiment_label"] == "neutral" for a in data)

--- a/tests/test_seed_db.py
+++ b/tests/test_seed_db.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from app.models.article import Article
+from app.models.crawl_job import CrawlJob, CrawlStatus
 from app.models.source import Source
 from app.seeds.seed_db import DEFAULT_SEED_PATH, seed_database
 
@@ -94,3 +95,32 @@ def test_seed_skips_duplicate_urls_within_batch(test_db, seed_payload):
     assert test_db.query(Article).count() == len(seed_payload["articles"])
     assert summary["articles_skipped"] >= 1
     assert summary["articles_inserted"] == len(seed_payload["articles"]) - 1
+
+
+def test_seed_queue_crawl_jobs_off_by_default(test_db, seed_payload):
+    """Without the flag, no crawl_jobs rows are created."""
+    summary = seed_database(test_db)
+    assert summary["crawl_jobs_inserted"] == 0
+    assert test_db.query(CrawlJob).count() == 0
+
+
+def test_seed_queue_crawl_jobs_enqueues_pending(test_db, seed_payload):
+    """With ``queue_crawl_jobs=True``, one PENDING job is enqueued per article."""
+    summary = seed_database(test_db, queue_crawl_jobs=True)
+    expected = len(seed_payload["articles"])
+    assert summary["crawl_jobs_inserted"] == expected
+    assert test_db.query(CrawlJob).count() == expected
+    # All freshly enqueued, none picked up yet.
+    assert (
+        test_db.query(CrawlJob).filter(CrawlJob.status == CrawlStatus.PENDING).count()
+        == expected
+    )
+
+
+def test_seed_queue_crawl_jobs_skips_articles_with_existing_jobs(test_db, seed_payload):
+    """Re-running with the flag does not duplicate jobs for already-queued articles."""
+    seed_database(test_db, queue_crawl_jobs=True)
+    second = seed_database(test_db, queue_crawl_jobs=True)
+    # Articles already had jobs from the first run — second run enqueues nothing.
+    assert second["crawl_jobs_inserted"] == 0
+    assert test_db.query(CrawlJob).count() == len(seed_payload["articles"])


### PR DESCRIPTION
## Summary

Closes the P1 article-discovery and P2 bookmark use cases end-to-end (backend → DB → UI), unbreaks the docker-compose worker, aligns the local-setup docs to what actually works, and adds the two module submission documents.

### What ships (9 commits, reviewable per-commit)

1. **Backend** — `/articles/` and `/articles/latest` accept `skip`, `limit`, `sentiment_label`, `category`, `source_id`, `search`. Pydantic-validated query params, stable `(published_at desc, id desc)` ordering, single shared `_query_articles` helper.
2. **DB indexes** — Alembic migration `f2a3b4c5d6e7` adds `ix_articles_sentiment_label`, `ix_articles_category`, `ix_articles_source_id` so filter+order is index-supported.
3. **Filter UI** — `FilterBar.svelte` (sentiment / category / source / debounced search) + `Pagination.svelte` (Prev/Next with edge disable) + reactive refetch on filter change.
4. **Bookmark UI** — `createBookmark` / `listBookmarks` / `deleteBookmark` wired with Firebase ID-token bearer auth, optimistic UI, 409-as-silent-success, `BookmarksView` page reachable from new nav toggle.
5. **Test fix** — conftest now uses `StaticPool` so the in-memory SQLite is shared across TestClient threads (8 previously-broken tests now pass).
6. **Local setup** — fixed worker Dockerfile (`python -m` so `app` package is importable), README + DATABASE.md + .env.example aligned to the actual `docker-compose up` flow. SQLite-via-migrations was never actually working; now documented honestly as test-only.
7. **Docs sync** — Backend/UI status columns on PERSONAS_AND_USE_CASES.md, index inventory in ER_Diagram.md.
8. **UC-13/14/15/17 UI ✅** — corrected the use-case table; the live Analytics tab already renders four Chart.js charts mapping to those use cases.
9. **Submission documents** — `docs/submissions/SUBMISSION_RELATIONAL_DB.md` (SE_05) and `docs/submissions/SUBMISSION_CYBERSECURITY.md` (SE_09). Both use `submission-2026-05-04` branch URLs (branch + tags get created post-merge).

## Test plan

- [x] `pytest tests/` — 51 passed (40 prior + 11 new in `test_articles_filters.py`)
- [x] `ruff check app/` — clean
- [x] `mypy app/` — clean
- [x] `npm run build` (frontend) — clean
- [x] `docker-compose up --build` — db healthy, web healthy, worker crawling, scheduler running. All 10 migrations apply. `seed_db` loads 50 articles. `/articles/?sentiment_label=positive&limit=3` returns expected filtered set.
- [x] Live URL smoke — all 5 cited curls in submission docs return expected status codes (200, 401, 401, 429-on-rate-limit, 400-on-CORS-preflight)
- [x] Every cited file path in both submission docs resolves (26/26)

## Post-merge sequence

1. Merge this PR into develop (squash or merge, your call — atomic commits are reviewable either way)
2. Open develop → main PR (will be empty other than this PR's content)
3. Merge main PR → CI runs migrations against Cloud SQL, deploys
4. Tag and freeze: `git tag -a submission-rel-db-2026-05-04 && git tag -a submission-cybersec-2026-05-04 && git push --tags && git branch submission-2026-05-04 main && git push -u origin submission-2026-05-04`
5. Export both `docs/submissions/*.md` to PDF, upload to Fuxam

## Known gaps (deliberate, documented in the relevant docs)

- UC-02 (article detail page UI), UC-09 (email/password auth), UC-16 (entity-sentiment chart), UC-18/19 (entity directory) — all 🔲 in PERSONAS_AND_USE_CASES.md with rationale
- ILIKE substring search is unindexed; pg_trgm GIN upgrade path documented in DATABASE.md § 4.4
- Rate limiting only on expensive/auth endpoints; Cloud Armor as future hardening tracked in THREAT_MODEL.md known-gaps