### PR TITLE
fix(ci): run alembic migrations as postgres superuser, not aifeelnews user

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,13 +118,18 @@ jobs:
           sleep 1
         done
 
-    - name: Fetch DB password from Secret Manager
+    # The runtime app uses the least-privileged ``aifeelnews`` user (table
+    # DML only). Migrations need to CREATE INDEX, which requires ownership;
+    # so we fetch the postgres superuser password here and use it for the
+    # alembic step only. The runtime DATABASE_URL on Cloud Run still points
+    # at ``aifeelnews`` via secretKeyRef — see the ``secrets:`` block below.
+    - name: Fetch postgres superuser password from Secret Manager
       id: dbpass
       run: |
         PASSWORD=$(gcloud secrets versions access latest \
-          --secret=aifeelnews-db-password --project=${{ env.PROJECT_ID }})
+          --secret=db-password --project=${{ env.PROJECT_ID }})
         if [ -z "$PASSWORD" ]; then
-          echo "::error::aifeelnews-db-password secret is empty"
+          echo "::error::db-password secret is empty"
           exit 1
         fi
         echo "::add-mask::$PASSWORD"
@@ -136,7 +141,7 @@ jobs:
         alembic upgrade head
       env:
         ENV: production
-        DATABASE_URL: postgresql://aifeelnews:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
+        DATABASE_URL: postgresql://postgres:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
 
     - name: Deploy to Cloud Run
       id: deploy


### PR DESCRIPTION
## Summary

Hotfix for the production deploy failure on commit `f88c6be` (PR #80's merge to main): migration `f2a3b4c5d6` (article filter indexes) failed with:

```
psycopg2.errors.InsufficientPrivilege: must be owner of table articles
[SQL: CREATE INDEX ix_articles_sentiment_label ON articles (sentiment_label)]
```

## Root cause

Path B (PR #60) moved the runtime app to the least-privileged `aifeelnews` user with table DML only — no DDL, no ownership. That works for the request path. It also broke migrations: `alembic upgrade head` in deploy.yml was running as the same `aifeelnews` user, so any migration that creates an index, alters a table, or otherwise requires ownership now fails.

PR #80 was the first migration to touch the production schema after Path B landed, which is why this is the first time we have hit it.

## Fix

Fetch the postgres superuser password (already exists in Secret Manager as `db-password`, separate from `aifeelnews-db-password` and rotated 2026-05-03 as part of Path B) and use it only for the migration step. The runtime app's DATABASE_URL on Cloud Run is unchanged — still points at `aifeelnews` via `secretKeyRef` in the deploy step's `secrets:` block — so the runtime privilege boundary stays intact.

`github-actions-sa` already has project-level `secretmanager.secretAccessor` (verified via `gcloud projects get-iam-policy aifeelnews-prod`), so no IAM change is needed.

## Test plan

- [ ] CI test job passes
- [ ] After merge to main: migration step authenticates as `postgres` and runs `f2a3b4c5d6` cleanly
- [ ] Cloud Run revision deploys
- [ ] Verify-deployment step confirms the new revision serves 100% traffic
- [ ] `curl '.../articles/?sentiment_label=positive&limit=3'` returns filtered set
- [ ] Cloud SQL: confirm the three new indexes exist (`\d+ articles` in psql shows `ix_articles_sentiment_label`, `ix_articles_category`, `ix_articles_source_id`)