### PR TITLE
release: deploy.yml hotfix → main (re-run failed deploy with postgres superuser)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,13 +118,18 @@ jobs:
           sleep 1
         done
 
-    - name: Fetch DB password from Secret Manager
+    # The runtime app uses the least-privileged ``aifeelnews`` user (table
+    # DML only). Migrations need to CREATE INDEX, which requires ownership;
+    # so we fetch the postgres superuser password here and use it for the
+    # alembic step only. The runtime DATABASE_URL on Cloud Run still points
+    # at ``aifeelnews`` via secretKeyRef — see the ``secrets:`` block below.
+    - name: Fetch postgres superuser password from Secret Manager
       id: dbpass
       run: |
         PASSWORD=$(gcloud secrets versions access latest \
-          --secret=aifeelnews-db-password --project=${{ env.PROJECT_ID }})
+          --secret=db-password --project=${{ env.PROJECT_ID }})
         if [ -z "$PASSWORD" ]; then
-          echo "::error::aifeelnews-db-password secret is empty"
+          echo "::error::db-password secret is empty"
           exit 1
         fi
         echo "::add-mask::$PASSWORD"
@@ -136,7 +141,7 @@ jobs:
         alembic upgrade head
       env:
         ENV: production
-        DATABASE_URL: postgresql://aifeelnews:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
+        DATABASE_URL: postgresql://postgres:${{ steps.dbpass.outputs.password }}@127.0.0.1:5432/aifeelnews
 
     - name: Deploy to Cloud Run
       id: deploy


### PR DESCRIPTION
## Summary

Promotes PR #82 (the deploy.yml hotfix) to main, which triggers a fresh production deploy. This time `alembic upgrade head` runs as the postgres superuser, so migration `f2a3b4c5d6` (article filter indexes) can `CREATE INDEX` on the existing tables.

The previous deploy (commit `f88c6be`) failed at the migration step. Cloud Run was never updated, so the existing revision is still serving 100% traffic — the site is healthy, just without the new filter indexes.

## What this deploy will do

1. Build + push the Docker image (same image content as `f88c6be` plus the deploy.yml change)
2. Run alembic as `postgres` superuser via the Cloud SQL Auth Proxy
3. Apply migration `f2a3b4c5d6` — creates `ix_articles_sentiment_label`, `ix_articles_category`, `ix_articles_source_id`. Sub-second on a 30k-row table.
4. Deploy the new Cloud Run revision (still runs as `aifeelnews` user — runtime privilege boundary unchanged)
5. Verify-deployment step confirms the new revision serves 100% traffic
6. Auto-rollback to previous healthy revision if verification fails

## Post-deploy

After merge + green deploy:
- Tag `submission-rel-db-2026-05-04` and `submission-cybersec-2026-05-04` on main
- Create branch `submission-2026-05-04` pointing at main
- Push tags + branch so all submission PDF links resolve
- Export both `docs/submissions/*.md` to PDF, upload to Fuxam

## Test plan

- [ ] CI test job passes on this PR
- [ ] After merge: deploy workflow's "Run database migrations" step succeeds (was the failure point on `f88c6be`)
- [ ] New Cloud Run revision deploys
- [ ] `curl '.../articles/?sentiment_label=positive&limit=3'` returns filtered set
- [ ] No new auto-issue created (the `failure()` step would file one if anything broke)