### PR TITLE
fix: Cloud Run OOM + Firebase Admin SDK init + categories dropdown

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,7 +166,7 @@ jobs:
           --allow-unauthenticated
           --service-account=cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com
           --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:aifeelnews-db
-          --memory=512Mi
+          --memory=1Gi
           --cpu=1
           --min-instances=0
           --max-instances=10

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Ingests articles from Mediastack, crawls original content (respecting robots.txt
 
 ### Prerequisites
 
-- Python 3.13+
-- Node.js 18+ (frontend)
-- Docker + Docker Compose (optional — for full-stack setup)
+- Docker + Docker Compose (recommended — supported full-stack path)
+- Python 3.13+ (only if running the backend on the host instead of in Compose)
+- Node.js 18+ (frontend dev server)
 
 ### Two run modes
 
@@ -134,8 +134,8 @@ This is the recommended path for local development and demos — no Mediastack k
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ENV` | No | `local` (default) / `development` / `production` |
-| `LOCAL_DATABASE_URL` | No | Default: `sqlite:///./dev.db` |
-| `DATABASE_URL` | Docker only | PostgreSQL URL for docker-compose (`postgresql://postgres:pass@db:5432/aifeelnews`) |
+| `LOCAL_DATABASE_URL` | When running backend on host | PostgreSQL URL pointing at a host-side instance (`postgresql://user:pass@localhost:5432/aifeelnews`). SQLite is not a supported substitute — the migration chain uses Postgres-only DDL. |
+| `DATABASE_URL` | Docker | PostgreSQL URL for docker-compose (`postgresql://postgres:pass@db:5432/aifeelnews`); committed default in `.env.example` works as-is. |
 | `MEDIASTACK_API_KEY` | Production-equivalent mode only | Paid tier required — the free tier is HTTP-only and the project enforces HTTPS. Demo mode skips ingestion and uses the bundled seed instead. |
 | `SENTIMENT_PROVIDER` | No | `VADER` (default in `.env.example`, free, no credentials) or `GCP_NL` (production-equivalent, needs a GCP service account JSON with the Cloud Natural Language API enabled) |
 

--- a/app/services/firebase_admin.py
+++ b/app/services/firebase_admin.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Any, Dict
 
@@ -12,9 +13,19 @@ def get_firebase_app() -> Any:
     if _app:
         return _app
 
-    service_account_path = os.getenv("FIREBASE_SERVICE_ACCOUNT_JSON")
-    if service_account_path:
-        cred = credentials.Certificate(service_account_path)
+    # FIREBASE_SERVICE_ACCOUNT_JSON can be either a path to a JSON file
+    # (typical local dev: GOOGLE_APPLICATION_CREDENTIALS-style) or the JSON
+    # contents themselves (Cloud Run with Secret Manager secretKeyRef, which
+    # mounts the secret value directly into the env var). credentials.Certificate
+    # only accepts a file path, so detect the JSON case and write it to a temp
+    # file or pass the parsed dict.
+    raw = os.getenv("FIREBASE_SERVICE_ACCOUNT_JSON")
+    if raw:
+        stripped = raw.lstrip()
+        if stripped.startswith("{"):
+            cred = credentials.Certificate(json.loads(raw))
+        else:
+            cred = credentials.Certificate(raw)
         _app = firebase_admin.initialize_app(cred)
     else:
         _app = firebase_admin.initialize_app()

--- a/docs/CICD_PIPELINE.md
+++ b/docs/CICD_PIPELINE.md
@@ -102,9 +102,9 @@ flowchart TB
 | **Linting** | `ruff check app/` + `mypy app/` |
 | **Tests** | `pytest tests/ -v` with `ENV=test` |
 | **Registry** | Artifact Registry (`europe-west1-docker.pkg.dev/aifeelnews-prod/aifeelnews/`) |
-| **Migrations** | 3-step in CI (before deploy, not in startup.sh): (1) start Cloud SQL Auth Proxy v2.14.1 on `127.0.0.1:5432`, (2) `gcloud secrets versions access latest --secret=aifeelnews-db-password`, (3) `alembic upgrade head` as the `aifeelnews` user |
+| **Migrations** | 3-step in CI (before deploy, not in startup.sh): (1) start Cloud SQL Auth Proxy v2.14.1 on `127.0.0.1:5432`, (2) `gcloud secrets versions access latest --secret=db-password` (postgres superuser, needed for DDL ownership), (3) `alembic upgrade head` as `postgres`. The runtime app on Cloud Run continues to connect as the least-privileged `aifeelnews` user via `secretKeyRef`. |
 | **Deploy target** | Cloud Run `aifeelnews-web` in `europe-west1` |
-| **Deploy config** | 512Mi, 1 vCPU, min-instances=0, max=10, concurrency=80, timeout=300s |
+| **Deploy config** | 1Gi, 1 vCPU, min-instances=0, max=10, concurrency=80, timeout=300s |
 | **Env vars** | `BIGQUERY_ENABLE_BIGQUERY=true`, `ENV=production`, `APP_VERSION=$GITHUB_SHA`, `SENTIMENT_PROVIDER=GCP_NL`, `GCP_PROJECT_ID` |
 | **Secrets** | All mounted from Secret Manager via `secrets:` block: `MEDIASTACK_API_KEY`, `GCP_NLP_KEY_JSON`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `DATABASE_URL` (full Unix-socket conn string ref `aifeelnews-database-url`). Migration password (`aifeelnews-db-password`) pulled in-job via `gcloud`, never written to GitHub. |
 | **Service account** | `cloudrun-sa@aifeelnews-prod.iam.gserviceaccount.com` (least-privilege) |

--- a/docs/COST_AND_SCALABILITY.md
+++ b/docs/COST_AND_SCALABILITY.md
@@ -4,7 +4,7 @@
 
 | Service | Tier / Config | Monthly Estimate | Free Tier Coverage |
 |---------|--------------|-----------------|-------------------|
-| Cloud Run (web) | 512Mi, 1 vCPU, min=0, max=10 | ~$0-5 | 2M requests/month free; scale-to-zero eliminates idle cost |
+| Cloud Run (web) | 1Gi, 1 vCPU, min=0, max=10 | ~$0-5 | 2M requests/month free; scale-to-zero eliminates idle cost |
 | Cloud SQL (PostgreSQL 14) | db-f1-micro, 10GB, ZONAL, daily backup | ~$7-9 | N/A (always-on instance) |
 | Cloud Scheduler | 2 jobs (every 8h + daily 2AM) | $0 | 3 free jobs/month |
 | Secret Manager | 6 secrets, low-frequency access | ~$0 | 6 active secret versions free |
@@ -70,7 +70,7 @@ The architecture is designed for the current scale of a student project, but eac
 
 | Component | Current Config | Medium Scale (100x) | Large Scale (10,000x) |
 |-----------|---------------|--------------------|-----------------------|
-| **Cloud Run** | 0-1 instances, 512Mi | Auto-scales to max=10 (already configured) | Increase max-instances, set min=1 to avoid cold starts, increase memory |
+| **Cloud Run** | 0-1 instances, 1Gi | Auto-scales to max=10 (already configured) | Increase max-instances, set min=1 to avoid cold starts, further increase memory |
 | **Cloud SQL** | db-f1-micro, 50 connections | Upgrade to db-n1-standard-1, add read replicas | Migrate to Cloud Spanner for horizontal scaling, or add PgBouncer for connection pooling |
 | **BigQuery** | Append-only streaming | Partitioning + clustering already configured, handles petabytes natively | No changes needed — BigQuery auto-scales storage and compute |
 | **Ingestion** | Synchronous worker, Cloud Scheduler | Add Pub/Sub queue for parallel crawl workers | Cloud Dataflow / Pub/Sub fan-out pipeline |

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -38,15 +38,18 @@
   let skip: number = 0;
   const limit: number = 20;
 
-  // Static mediastack categories. (Backend doesn't expose a categories endpoint
-  // yet; we keep this client-side for now and TODO a `/categories` route.)
+  // Mediastack categories that the ingestion job actually fetches. The
+  // production config (MEDIASTACK_FETCH_CATEGORIES in app/config/ingestion.py)
+  // explicitly excludes ``sports`` and ``entertainment`` via the leading-``-``
+  // syntax, so listing them here would offer the user dropdown options that
+  // can never have results. Backend doesn't expose a categories endpoint yet
+  // — TODO a /categories route so this can be data-driven instead of hand-kept
+  // in sync.
   const CATEGORY_OPTIONS: string[] = [
     "general",
     "business",
-    "entertainment",
     "health",
     "science",
-    "sports",
     "technology",
   ];
 


### PR DESCRIPTION
## Summary

Three production bugs found while debugging an "All sources empty" report on the live site after the PR #83 deploy. None caused by PR #83 itself — all latent issues that surfaced under load + a closer look at logs.

### Three commits

1. **`fix(auth): handle FIREBASE_SERVICE_ACCOUNT_JSON as either path or JSON contents`** — the Firebase Admin SDK was being initialised with `credentials.Certificate(env_var_value)`, which only accepts a file path. Cloud Run's `secretKeyRef` mounts the JSON *contents* into the env var, so the OS tried to open a multi-line JSON string as a filename and every authenticated request 401'd. Detected via Cloud Logging: `[Errno 2] No such file or directory: '{\n  "type": "service_account", ...'`. Auth has been broken in production since `FIREBASE_SERVICE_ACCOUNT_JSON` was first wired through Secret Manager.

2. **`fix(deploy): bump Cloud Run memory 512Mi → 1Gi to stop OOM kills`** — Cloud Run was killing containers at 512 MiB during `/articles/` requests that eager-load source + sentiment_analyses + article_entities (joined to entity) + article_categories. Idle baseline ~250 MiB plus per-request ORM hydration of ~500 SQLAlchemy objects per page tipped concurrent requests over the cap. Symptom: intermittent 503s on `/sources/` and other endpoints, surfaced in the UI as empty dropdowns and silent auth failures.

3. **`fix(ui): drop sports + entertainment from category filter dropdown`** — `MEDIASTACK_FETCH_CATEGORIES` excludes those two via leading-`-` syntax, so listing them gave users options that could never have results.

### Why I didn't catch any of this earlier

- The auth bug only affected production because Cloud Run is the only environment using `secretKeyRef` for the Firebase secret. Local + CI use file paths.
- The OOM is racy — single-user manual testing rarely hits it. Page-load concurrency tips the balance.

### Test plan

- [x] `pytest tests/` — 54 passed
- [x] `ruff check app/` — clean
- [x] `mypy app/` — clean
- [x] `npm run build` (frontend) — clean
- [ ] After merge to main: live `/sources/` returns 200 (not 503)
- [ ] Live login flow completes without 401 on `/bookmarks/`
- [ ] Analytics tab visible after login
- [ ] Category dropdown shows only general/business/health/science/technology

### Doc updates included

- `docs/CICD_PIPELINE.md` — Deploy config row 512Mi → 1Gi; Migrations row reflects the postgres-superuser switch from PR #82
- `docs/COST_AND_SCALABILITY.md` — both 512Mi mentions updated to 1Gi