### PR TITLE
fix: /sources/ N+1 timeout + frontend init resilience

### DIFF
--- a/app/schemas/source.py
+++ b/app/schemas/source.py
@@ -1,10 +1,6 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
-
-if TYPE_CHECKING:
-    from app.schemas.article import ArticleRead
 
 
 class SourceBase(BaseModel):
@@ -33,10 +29,20 @@ class SourceCreate(SourceBase):
 
 
 class SourceRead(SourceBase):
+    """Lean source representation used by ``GET /sources/``.
+
+    The relationship to articles is intentionally NOT included here. Returning
+    every article on every source produces an N+1 explosion via Pydantic's
+    ``from_attributes`` serialization (each Source's ``articles`` lazy-loads,
+    and every Article then loads its own eager-load chain), which timed out
+    the route at the 300s Cloud Run boundary in production. If a future
+    endpoint needs the nested-articles shape, define a separate
+    ``SourceWithArticlesRead`` and use ``selectinload`` to keep it bounded.
+    """
+
     id: int
     created_at: datetime = Field(..., description="When source was added")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    articles: Optional[List["ArticleRead"]] = None  # forward ref
 
     model_config = {
         "from_attributes": True,
@@ -49,8 +55,3 @@ class SourceRead(SourceBase):
             }
         },
     }
-
-
-from app.schemas.article import ArticleRead  # noqa: F401, E402, F811
-
-SourceRead.model_rebuild()

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -128,7 +128,11 @@ The duplicate-bookmark trigger is a defence-in-depth measure: a `UNIQUE` constra
 
 ## 4. Optimization Examples
 
-### 4.1 N+1 Query Fix on `GET /articles/`
+### 4.1 N+1 Query Fixes
+
+Two distinct N+1 patterns have shipped fixes. They look similar in a profiler — too many queries per request — but originate at different layers and call for different remedies.
+
+#### `GET /articles/` — choose the right eager-load strategy
 
 Lazy-loading `Article.source`, `Article.sentiment_analyses`, `Article.article_entities`, and `Article.article_categories` triggers a separate round-trip per article. With 40 articles in the feed and 4 lazy relationships, a naive implementation makes ~160 extra queries per response.
 
@@ -148,6 +152,14 @@ db.query(ArticleModel)
 ```
 
 `joinedload` is right for 1:1 / low-cardinality relationships; `subqueryload` is right for high-cardinality ones (entities, categories) to avoid Cartesian explosion.
+
+#### `GET /sources/` — don't declare unbounded relationships in the response schema
+
+`SourceRead` originally declared `articles: Optional[List[ArticleRead]] = None` with `from_attributes=True`. Pydantic v2 accesses SQLAlchemy relationship attributes during response serialisation even when the field default is `None` — so every `/sources/` call lazy-loaded `Source.articles`, and each Article then fanned out into its own lazy chain (`bookmarks`, `crawl_jobs`, `content`, `sentiment_analyses`, `article_entities`, `article_categories`). Tolerable when sources held ~50 articles each; at production scale (22 sources × ~1,300 articles each) the route 504'd at the 300s Cloud Run timeout.
+
+The fix removes the `articles` field from `SourceRead` ([app/schemas/source.py](../app/schemas/source.py)). The SQLAlchemy relationship stays on the model — only the response schema changes. No consumer was reading the nested array. If a future endpoint genuinely needs the nested shape, define a separate `SourceWithArticlesRead` and load it via `selectinload` so the relationship is bounded.
+
+The contrast matters: the first fix is about *strategy choice once a relationship is being accessed*; the second is about *not declaring an unbounded relationship in the response shape in the first place*. The first lives in the route, the second lives in the schema.
 
 ### 4.2 Bookmark Foreign-Key Indexes
 

--- a/docs/submissions/SUBMISSION_RELATIONAL_DB.md
+++ b/docs/submissions/SUBMISSION_RELATIONAL_DB.md
@@ -176,7 +176,7 @@ SQLAlchemy 2.0 ORM with typed `Mapped[]` declarations under [app/models/](https:
 - `(expires_at)` on `article_contents` so the TTL cleanup job's `WHERE expires_at < now()` doesn't scan every row
 - Bookmark FK indexes on `(user_id)` and `(article_id)` — Postgres does not auto-index FKs
 
-The N+1 query fix on `GET /articles/` is documented with before/after in [DATABASE.md § 4.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#41-n1-query-fix-on-get-articles): the original implementation issued one query per article for `source`, `sentiment_analyses`, `article_entities`, `article_categories`; now a single query with `joinedload` + `subqueryload`.
+Two N+1 fixes are documented in [DATABASE.md § 4.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#41-n1-query-fixes): one on `GET /articles/` (eager-load strategy chosen per relationship — `joinedload` for 1:1, `subqueryload` for high-cardinality M2Ms), and one on `GET /sources/` (an unbounded relationship was being declared in the Pydantic response schema and lazy-loading the entire articles table; the fix was to drop the field from `SourceRead`).
 
 Substring search on `articles.title` uses `ILIKE '%term%'`, which a B-tree cannot accelerate. The pg_trgm GIN upgrade path is documented in [DATABASE.md § 4.4](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#44-article-filter-indexes).
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -130,7 +130,10 @@
   }
 
   onMount(async () => {
-    await Promise.all([loadArticles(), loadSources()]);
+    // ``allSettled`` so a slow/failing /sources/ request can't block the
+    // articles fetch or prevent ``initialised`` from flipping. Both load
+    // functions already swallow their own errors; this is belt-and-suspenders.
+    await Promise.allSettled([loadArticles(), loadSources()]);
     initialised = true;
   });
 


### PR DESCRIPTION
## Summary

Fixes the production bug where `GET /sources/` was returning 504 (300s timeout) and the frontend's filter dropdowns appeared dead for ~5 minutes after page load.

## Root cause

`SourceRead` (the response schema for `GET /sources/`) declared `articles: Optional[List[ArticleRead]] = None` with `from_attributes=True`. Pydantic v2 with `from_attributes=True` accesses SQLAlchemy relationship attributes during serialisation even when the field default is `None` — confirmed by local curl which returned each source nested with its full article list.

This was tolerable when sources had ~5-50 articles each but is fatal at production scale: 22 sources × ~1300 articles each = 28,000+ Article rows lazy-loaded per call. Each Article then fans out to its own lazy `bookmarks`/`crawl_jobs`/`content`/`sentiment_analyses`/`article_entities`/`article_categories` relationships. The route hangs past Cloud Run's 300s timeout.

The bug has been latent since the field was added in commit `b148828` (Nov 2025). It only surfaced now because the dataset crossed the threshold where serialisation can't complete in 300s. There are **no changes to `/sources/`, the Source model, or `SourceRead` between revisions 00090 and 00091** — PR #85 didn't cause it, just exposed it once Firebase auth started working and users could actually browse the site.

## Why filters appeared broken too

`onMount` used `Promise.all([loadArticles(), loadSources()])`. Both load functions swallow their own errors, but `Promise.all` still has to wait for both promises to *resolve* before `initialised = true` flips. While `/sources/` was 504-ing for 300s, `initialised` stayed false, and the reactive block at line 115 (`$: if (initialised) { void loadArticles(); }`) ignored every filter change. The page rendered articles fine (loadArticles returned in 600ms) but clicking dropdowns appeared to do nothing.

Switching to `Promise.allSettled` removes this gating. The backend N+1 fix removes the actual hang; the frontend change is defence in depth.

## Audit — categories and search are not at risk

Confirmed by reading every Pydantic schema with `from_attributes=True`:

| Field | Risk? |
|---|---|
| `ArticleRead.article_entities` | No — `/articles/` uses `subqueryload` |
| `ArticleRead.article_categories` | No — same |
| `UserRead.bookmarks: List[int]` | Latent — but `UserRead` is not currently exposed by any route |

Categories filter uses a static client-side enum (no fetch). Search filter hits `/articles/?search=` (~600ms, ILIKE on 30k rows, debounced 300ms client-side). Neither has the same exposure.

## Test plan

- [x] `pytest tests/` — 54/54 passing
- [x] `ruff check app/` + `mypy app/` — clean
- [x] `npm run build` — clean
- [x] Local repro pre-fix: `curl http://127.0.0.1:8002/sources/` returned each source with nested `articles` array
- [x] Local repro post-fix: same curl returns sources with no `articles` key
- [ ] After merge to main: `curl https://aifeelnews-web-813770885946.europe-west1.run.app/sources/` returns 200 in <1s
- [ ] Live site sources dropdown populates immediately
- [ ] Filter clicks work immediately, not after 5 minutes