### PR TITLE
release: /sources/ N+1 fix + frontend init resilience → main

### DIFF
--- a/app/schemas/source.py
+++ b/app/schemas/source.py
@@ -1,10 +1,6 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
-
-if TYPE_CHECKING:
-    from app.schemas.article import ArticleRead
 
 
 class SourceBase(BaseModel):
@@ -33,10 +29,20 @@ class SourceCreate(SourceBase):
 
 
 class SourceRead(SourceBase):
+    """Lean source representation used by ``GET /sources/``.
+
+    The relationship to articles is intentionally NOT included here. Returning
+    every article on every source produces an N+1 explosion via Pydantic's
+    ``from_attributes`` serialization (each Source's ``articles`` lazy-loads,
+    and every Article then loads its own eager-load chain), which timed out
+    the route at the 300s Cloud Run boundary in production. If a future
+    endpoint needs the nested-articles shape, define a separate
+    ``SourceWithArticlesRead`` and use ``selectinload`` to keep it bounded.
+    """
+
     id: int
     created_at: datetime = Field(..., description="When source was added")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    articles: Optional[List["ArticleRead"]] = None  # forward ref
 
     model_config = {
         "from_attributes": True,
@@ -49,8 +55,3 @@ class SourceRead(SourceBase):
             }
         },
     }
-
-
-from app.schemas.article import ArticleRead  # noqa: F401, E402, F811
-
-SourceRead.model_rebuild()

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -128,7 +128,11 @@ The duplicate-bookmark trigger is a defence-in-depth measure: a `UNIQUE` constra
 
 ## 4. Optimization Examples
 
-### 4.1 N+1 Query Fix on `GET /articles/`
+### 4.1 N+1 Query Fixes
+
+Two distinct N+1 patterns have shipped fixes. They look similar in a profiler — too many queries per request — but originate at different layers and call for different remedies.
+
+#### `GET /articles/` — choose the right eager-load strategy
 
 Lazy-loading `Article.source`, `Article.sentiment_analyses`, `Article.article_entities`, and `Article.article_categories` triggers a separate round-trip per article. With 40 articles in the feed and 4 lazy relationships, a naive implementation makes ~160 extra queries per response.
 
@@ -148,6 +152,14 @@ db.query(ArticleModel)
 ```
 
 `joinedload` is right for 1:1 / low-cardinality relationships; `subqueryload` is right for high-cardinality ones (entities, categories) to avoid Cartesian explosion.
+
+#### `GET /sources/` — don't declare unbounded relationships in the response schema
+
+`SourceRead` originally declared `articles: Optional[List[ArticleRead]] = None` with `from_attributes=True`. Pydantic v2 accesses SQLAlchemy relationship attributes during response serialisation even when the field default is `None` — so every `/sources/` call lazy-loaded `Source.articles`, and each Article then fanned out into its own lazy chain (`bookmarks`, `crawl_jobs`, `content`, `sentiment_analyses`, `article_entities`, `article_categories`). Tolerable when sources held ~50 articles each; at production scale (22 sources × ~1,300 articles each) the route 504'd at the 300s Cloud Run timeout.
+
+The fix removes the `articles` field from `SourceRead` ([app/schemas/source.py](../app/schemas/source.py)). The SQLAlchemy relationship stays on the model — only the response schema changes. No consumer was reading the nested array. If a future endpoint genuinely needs the nested shape, define a separate `SourceWithArticlesRead` and load it via `selectinload` so the relationship is bounded.
+
+The contrast matters: the first fix is about *strategy choice once a relationship is being accessed*; the second is about *not declaring an unbounded relationship in the response shape in the first place*. The first lives in the route, the second lives in the schema.
 
 ### 4.2 Bookmark Foreign-Key Indexes
 

--- a/docs/submissions/SUBMISSION_RELATIONAL_DB.md
+++ b/docs/submissions/SUBMISSION_RELATIONAL_DB.md
@@ -176,7 +176,7 @@ SQLAlchemy 2.0 ORM with typed `Mapped[]` declarations under [app/models/](https:
 - `(expires_at)` on `article_contents` so the TTL cleanup job's `WHERE expires_at < now()` doesn't scan every row
 - Bookmark FK indexes on `(user_id)` and `(article_id)` — Postgres does not auto-index FKs
 
-The N+1 query fix on `GET /articles/` is documented with before/after in [DATABASE.md § 4.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#41-n1-query-fix-on-get-articles): the original implementation issued one query per article for `source`, `sentiment_analyses`, `article_entities`, `article_categories`; now a single query with `joinedload` + `subqueryload`.
+Two N+1 fixes are documented in [DATABASE.md § 4.1](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#41-n1-query-fixes): one on `GET /articles/` (eager-load strategy chosen per relationship — `joinedload` for 1:1, `subqueryload` for high-cardinality M2Ms), and one on `GET /sources/` (an unbounded relationship was being declared in the Pydantic response schema and lazy-loading the entire articles table; the fix was to drop the field from `SourceRead`).
 
 Substring search on `articles.title` uses `ILIKE '%term%'`, which a B-tree cannot accelerate. The pg_trgm GIN upgrade path is documented in [DATABASE.md § 4.4](https://github.com/cardox6/aifeelnews/blob/submission-2026-05-04/docs/DATABASE.md#44-article-filter-indexes).
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -130,7 +130,10 @@
   }
 
   onMount(async () => {
-    await Promise.all([loadArticles(), loadSources()]);
+    // ``allSettled`` so a slow/failing /sources/ request can't block the
+    // articles fetch or prevent ``initialised`` from flipping. Both load
+    // functions already swallow their own errors; this is belt-and-suspenders.
+    await Promise.allSettled([loadArticles(), loadSources()]);
     initialised = true;
   });
 


### PR DESCRIPTION
## Summary

Promotes PR #86 to main. Triggers a fresh production deploy that should restore `/sources/` (currently 504-ing at 300s) and let the frontend filter dropdowns respond immediately instead of after a 5-minute hang.

## What this deploy will do

1. Migration step runs as the postgres superuser — no new migrations, so this is a no-op.
2. Cloud Run revision rolls out with:
   - **`SourceRead`** no longer carries the `articles: Optional[List[ArticleRead]]` field. `GET /sources/` no longer lazy-loads 28k+ Article rows during Pydantic serialisation.
   - **Frontend `onMount`** uses `Promise.allSettled` so a slow request can't gate the `initialised` flag. Defence-in-depth.
3. Verify-deployment step hits `/health` + `/metrics` + `/articles/?skip=0&limit=1` and confirms the new revision serves 100% traffic.

## Post-deploy verification

- [ ] `curl https://aifeelnews-web-813770885946.europe-west1.run.app/sources/` returns 200 in <1s (was 504 after 300s)
- [ ] Live site sources dropdown populates immediately after page load
- [ ] Filter clicks work immediately, not after 5 minutes
- [ ] Cloud Run logs: no fresh `request failed` / `malformed response` / OOM warnings from the new revision

## After the deploy is verified

Tag + freeze the submission state:

\`\`\`bash
git checkout main
git pull
git tag -a submission-rel-db-2026-05-04 -m "Submitted state: Relational Databases (SE_05)"
git tag -a submission-cybersec-2026-05-04 -m "Submitted state: Cybersecurity (SE_09)"
git push origin --tags
git branch submission-2026-05-04 main
git push -u origin submission-2026-05-04
\`\`\`

Then export both `docs/submissions/*.md` to PDF and upload to Fuxam.