### PR TITLE
chore(security): patch urllib3/mako CVEs + add frontend type-check CI

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -1,0 +1,38 @@
+# Type-checks the Svelte frontend. `vite build` transpiles with esbuild,
+# which strips TypeScript types WITHOUT checking them, so a type error
+# never fails the build/preview job. This workflow runs the project's
+# `npm run check` (svelte-check + tsc) to close that gap — notably so
+# Dependabot bumps of typescript / @types/* are verified against real
+# type-checking before merge.
+name: Frontend Type Check
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: svelte-check + tsc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Type-check (svelte-check + tsc)
+        run: npm run check
+        working-directory: frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ h11==0.16.0
 idna==3.10
 iniconfig==2.1.0
 limits==5.8.0
-Mako==1.3.11
+Mako==1.3.12
 MarkupSafe==3.0.2
 mypy==1.15.0
 mypy_extensions==1.1.0
@@ -47,7 +47,7 @@ types-requests==2.32.0.20241016
 starlette==0.49.1
 typing-inspection==0.4.2
 typing_extensions==4.13.2
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.34.2
 vaderSentiment==3.3.2
 wrapt==2.1.2


### PR DESCRIPTION
## Why

While clearing the Dependabot PR backlog, `pip-audit --strict` was failing on `main` against newly disclosed advisories in pinned dependencies. That failure surfaced on every Dependabot PR's security scan even when the PR itself was unrelated (e.g. npm-only bumps).

## Changes

**1. Patch base-branch CVEs in `requirements.txt`**
| Package | From | To | Advisories |
|---|---|---|---|
| urllib3 | 2.6.3 | 2.7.0 | CVE-2026-44431, CVE-2026-44432 |
| Mako | 1.3.11 | 1.3.12 | CVE-2026-44307 |

**2. New `Frontend Type Check` workflow** (`.github/workflows/frontend-check.yml`)

Runs the project's existing `npm run check` (`svelte-check` + `tsc`). `vite build` transpiles with esbuild, which **strips TypeScript types without checking them** — so a type error never fails the `build_and_preview` job. Crucially, `build_and_preview` also explicitly skips Dependabot (`github.actor != 'dependabot[bot]'`), so `typescript` / `@types/*` bumps currently merge with **zero** type verification. This workflow has no such exclusion and closes that gap.

Verified locally: `npm run check` passes clean on current `main` (0 errors, 0 warnings).