### PR TITLE
chore: sync main into develop (CVE fixes + frontend type-check CI)

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -1,0 +1,38 @@
+# Type-checks the Svelte frontend. `vite build` transpiles with esbuild,
+# which strips TypeScript types WITHOUT checking them, so a type error
+# never fails the build/preview job. This workflow runs the project's
+# `npm run check` (svelte-check + tsc) to close that gap — notably so
+# Dependabot bumps of typescript / @types/* are verified against real
+# type-checking before merge.
+name: Frontend Type Check
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: svelte-check + tsc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Type-check (svelte-check + tsc)
+        run: npm run check
+        working-directory: frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ h11==0.16.0
 idna==3.10
 iniconfig==2.1.0
 limits==5.8.0
-Mako==1.3.11
+Mako==1.3.12
 MarkupSafe==3.0.2
 mypy==1.15.0
 mypy_extensions==1.1.0
@@ -47,7 +47,7 @@ types-requests==2.32.0.20241016
 starlette==0.49.1
 typing-inspection==0.4.2
 typing_extensions==4.13.2
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.34.2
 vaderSentiment==3.3.2
 wrapt==2.1.2


### PR DESCRIPTION
## Why

`develop` had diverged from `main` (17 behind) after the Dependabot backlog cleanup and #100 landed on `main`. This back-merge realigns `develop` so it carries:

- The urllib3 / Mako CVE patches (`requirements.txt`).
- The new `Frontend Type Check` workflow (`.github/workflows/frontend-check.yml`).

## Net diff

Only `frontend-check.yml` is added — the rest of `main`'s commits were already content-equivalent on `develop` (the Dependabot bumps and the Scheduler OIDC fix shipped to both branches under different SHAs), so Git merged them with no textual change. `requirements.txt` auto-merged to the patched urllib3 2.7.0 / Mako 1.3.12 pins.

## Follow-up

Unblocks Dependabot PR #78 (typescript 6.0.3) — once `develop` has the type-check job, #78 can be re-run against it to verify TypeScript 6.0 type-checks cleanly before merge.