### PR TITLE
chore: sync main into develop (CodeQL fixes from #102)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+# Least-privilege GITHUB_TOKEN: this job only checks out the repo and
+# deploys via a Firebase service account, so read-only contents access
+# is all it needs. Without an explicit block the token gets the broad
+# default scope (CodeQL actions/missing-workflow-permissions).
+permissions:
+  contents: read
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/app/main.py
+++ b/app/main.py
@@ -245,10 +245,13 @@ def metrics() -> dict[str, Any]:
             "database": {"status": "connected"},
         }
     except Exception as e:
+        # Log the full exception server-side; return only a generic
+        # marker to the client so internal detail (DB errors, paths)
+        # is not exposed (CodeQL py/stack-trace-exposure).
         logger.error("Metrics collection failed: %s", e, exc_info=True)
         return {
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "error": str(e),
+            "error": "metrics collection failed",
         }
     finally:
         db.close()

--- a/app/routers/sentiment.py
+++ b/app/routers/sentiment.py
@@ -5,6 +5,7 @@ Rate limit: ``config.security.rate_limit_sentiment`` (default 60/minute)
 applied per-IP via slowapi.
 """
 
+import logging
 from typing import Dict, List, Union
 
 from fastapi import APIRouter, Request
@@ -15,6 +16,8 @@ from app.config import config
 
 # Import at module level to catch import errors early
 from app.utils.sentiment import get_sentiment_provider_info
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["sentiment"])
 
@@ -40,10 +43,13 @@ def get_provider_info(
     try:
         return get_sentiment_provider_info()
     except Exception as e:
-        # Return basic info if there's a function call issue
+        # Log the detail server-side; return a generic marker so internal
+        # exception text is not exposed to the client
+        # (CodeQL py/stack-trace-exposure).
+        logger.error("Sentiment provider info lookup failed: %s", e, exc_info=True)
         return {
             "provider": "ERROR",
-            "error": str(e),
+            "error": "provider info unavailable",
             "fallback_enabled": True,
             "supported_languages": ["en"],
         }


### PR DESCRIPTION
Back-merges PR #102 (CodeQL fixes: workflow permissions + stack-trace exposure) onto develop. Unblocks PR #103 (develop->main), which is currently BEHIND.