### PR TITLE
docs: promote CI/security doc sync to main

### DIFF
--- a/docs/CICD_PIPELINE.md
+++ b/docs/CICD_PIPELINE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-aiFeelNews uses **GitHub Actions** with 4 workflows that automate testing, building, and deploying both backend (Cloud Run) and frontend (Firebase Hosting) components. The pipeline enforces a **Simplified Git Flow** branching strategy with CI-gated merge policies, multi-endpoint smoke tests, automated rollback, and PR preview deploys.
+aiFeelNews uses **GitHub Actions** with 6 workflows that automate testing, building, deploying, and security-scanning both backend (Cloud Run) and frontend (Firebase Hosting) components. The pipeline enforces a **Simplified Git Flow** branching strategy with CI-gated merge policies, multi-endpoint smoke tests, automated rollback, and PR preview deploys. CodeQL SAST runs additionally via GitHub Advanced Security default setup (no in-repo workflow file).
 
 ## Branching Strategy
 
@@ -165,6 +165,26 @@ preview-cleanup (on PR close)
 |----------|-------|
 | **Trigger** | PR opened |
 | **Action** | Requests GitHub Copilot as reviewer via `github-script` |
+
+### 5. Security Scanning (`security.yml`)
+
+| Property | Value |
+|----------|-------|
+| **Trigger** | Push/PR to `main` or `develop`, weekly cron (Mon 06:00 UTC), manual dispatch |
+| **`pip-audit`** | Scans pinned `requirements.txt` for known CVEs; `--strict` fails CI on any advisory |
+| **`gitleaks`** | Full-history secret-leak scan; posts a summary comment on PRs |
+
+### 6. Frontend Type Check (`frontend-check.yml`)
+
+| Property | Value |
+|----------|-------|
+| **Trigger** | Push/PR to `main` or `develop`, manual dispatch |
+| **Action** | Runs `npm run check` (`svelte-check` + `tsc`) |
+| **Why** | `vite build` strips TypeScript types without checking them, so type errors never failed the build/preview job. Unlike `firebase-hosting-pull-request.yml`, this workflow has no Dependabot exclusion, so `typescript` / `@types/*` bumps are verified against real type-checking before merge. |
+
+### CodeQL SAST (GitHub default setup)
+
+CodeQL static analysis runs via **GitHub Advanced Security default setup** — configured in repo settings, not as an in-repo workflow file. It scans Python, JavaScript/TypeScript, and GitHub Actions on push/PR, surfacing findings as Code Scanning alerts.
 
 ## Secrets Inventory
 

--- a/docs/SECURITY_MEASURES.md
+++ b/docs/SECURITY_MEASURES.md
@@ -402,6 +402,31 @@ malicious steps.
 - **Config:** `.github/workflows/deploy.yml`
 - **Threats:** [5.T2](THREAT_MODEL.md#5-cicd-pipeline)
 
+### 7.8 CodeQL SAST
+
+Static analysis via GitHub Advanced Security default setup (configured
+in repo settings, not an in-repo workflow file). Scans Python,
+JavaScript/TypeScript, and GitHub Actions on push/PR; findings surface
+as Code Scanning alerts. Has caught stack-trace exposure
+(`py/stack-trace-exposure`) and missing workflow `permissions`
+(`actions/missing-workflow-permissions`).
+
+- **Config:** GitHub repo → Security → Code scanning (default setup)
+- **Threats:** [1.I1](THREAT_MODEL.md#1-cloud-run-web-service),
+  [5.T2](THREAT_MODEL.md#5-cicd-pipeline)
+
+### 7.9 Frontend type-check (CI)
+
+`npm run check` (`svelte-check` + `tsc`) runs on every push/PR via
+`frontend-check.yml`. `vite build` strips TypeScript types without
+checking them, so this is the only gate that fails CI on a frontend
+type error — and unlike the preview workflow it is not skipped for
+Dependabot, so `typescript` / `@types/*` bumps are verified.
+
+- **Config:** [.github/workflows/frontend-check.yml](../.github/workflows/frontend-check.yml)
+- **Threats:** code-quality side-effect on
+  [5.T2](THREAT_MODEL.md#5-cicd-pipeline)
+
 ---
 
 ## 8. Monitoring & Detection
@@ -457,7 +482,6 @@ See [THREAT_MODEL.md → Known gaps](THREAT_MODEL.md#known-gaps-consolidated)
 for the tradeoff on each:
 
 - No WAF / Cloud Armor.
-- No SAST in CI (CodeQL, Semgrep).
 - No SLSA attestation / SBOM.
 - Cloud SQL `cloudsql.iam_authentication` not enabled.
 - No formal pen-test history.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -134,9 +134,9 @@ scoped SA JSON stored in the `production` GitHub environment.
 | 5.E1 | Elevation of privilege | A PR's workflow run gains write access to `main`. | `permissions: contents: read` is the default for the workflow file; PR runs from forks have no secrets and no write tokens. The deploy job runs on push to `main`/`develop` only. | Pwn requests / branch-injection are hard to fully eliminate; reviewed at merge time. |
 
 Component 5 gaps: no SLSA attestation; no SBOM published with
-releases; no SAST tool (CodeQL/Semgrep) on the Python source — Ruff
-catches style and a small set of bug patterns but is not a security
-scanner.
+releases. SAST is covered by CodeQL (GitHub Advanced Security default
+setup), which scans Python, JavaScript/TypeScript, and Actions on
+push/PR; Ruff additionally catches style and a small bug-rule subset.
 
 ---
 
@@ -203,9 +203,6 @@ Things that are not mitigated, with the tradeoff for each.
   layer-7 DoS defence. Tradeoff: Cloud Armor pricing (~$5/policy/month
   + per-request cost) vs. current request volume; revisit if abuse
   appears.
-- **No SAST tool in CI** (CodeQL, Semgrep). Tradeoff: per-PR runtime
-  + queue cost vs. current code-review coverage and the small bug-rule
-  subset Ruff already enforces.
 - **No SLSA attestation / SBOM.** Builds are reproducible (pinned
   deps), but supply-chain provenance is not signed. Tradeoff: tooling
   + verifier complexity vs. a single-team ownership model.


### PR DESCRIPTION
Promotes #105 — CICD_PIPELINE.md, SECURITY_MEASURES.md, THREAT_MODEL.md synced with the current 6-workflow pipeline + CodeQL SAST. Docs-only.