### PR TITLE
fix(security): starlette 1.0.1 + fastapi 0.133.1 (Dependabot alert #47)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ charset-normalizer==3.4.7
 click==8.1.8
 coverage==7.8.0
 Deprecated==1.3.1
-fastapi==0.132.0
+fastapi==0.133.1
 firebase-admin==7.4.0
 google-cloud-bigquery==3.28.0
 google-cloud-language==2.20.0
@@ -44,7 +44,7 @@ SQLAlchemy==2.0.40
 types-beautifulsoup4==4.12.0.20241020
 types-python-dateutil==2.9.0.20241003
 types-requests==2.32.0.20241016
-starlette==0.49.1
+starlette==1.0.1
 typing-inspection==0.4.2
 typing_extensions==4.13.2
 urllib3==2.7.0


### PR DESCRIPTION
## What
Bumps **starlette 0.49.1 → 1.0.1** and **fastapi 0.132.0 → 0.133.1** together.

## Why
Resolves Dependabot alert **#47** (moderate): starlette `< 1.0.1` has missing `Host` header validation that poisons `request.url.path`, bypassing path-based security checks. Patched in 1.0.1.

starlette 1.0 is a **major** release, and `fastapi==0.132.0` pins `starlette<1.0.0`. So the standalone Dependabot PR #119 could never merge — its `test` and `pip-audit` jobs failed with `ResolutionImpossible`:
> `fastapi 0.132.0 depends on starlette<1.0.0 and >=0.40.0`

`fastapi 0.133.0` is the first release to drop the upper cap (`starlette>=0.40.0`), so both deps move in one commit. Pinned to `fastapi==0.133.1` (minimal bump that clears the cap).

**Supersedes #119** — that PR should be closed once this merges.