### PR TITLE
fix(db): drop NOT NULL on users.hashed_password to match ORM model

### DIFF
--- a/alembic/versions/54bff216cdb7_drop_not_null_users_hashed_password.py
+++ b/alembic/versions/54bff216cdb7_drop_not_null_users_hashed_password.py
@@ -1,0 +1,46 @@
+"""drop not null users hashed_password
+
+Aligns the DB with the ORM model. The initial migration 033994d9eedb created
+``users.hashed_password`` as NOT NULL, but the model later loosened it to
+``Mapped[Optional[str]]`` without a follow-up ALTER (6ad9a0b7d4b7 punted because
+SQLite cannot ALTER COLUMN). Firebase-federated users legitimately have no
+password, so the model is correct and the column should be nullable.
+
+Revision ID: 54bff216cdb7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-08 14:31:53.437498
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "54bff216cdb7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "users",
+        "hashed_password",
+        existing_type=sa.String(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Backfill any NULLs (Firebase users) before restoring NOT NULL, so the
+    # downgrade is reversible on real data.
+    op.execute("UPDATE users SET hashed_password = '' WHERE hashed_password IS NULL")
+    op.alter_column(
+        "users",
+        "hashed_password",
+        existing_type=sa.String(),
+        nullable=False,
+    )


### PR DESCRIPTION
## What

Fixes a long-standing ORM ↔ DB drift: `users.hashed_password` is declared `Mapped[Optional[str]]` (nullable) in the model, but the deployed Postgres column is `NOT NULL` (created that way in the initial migration `033994d9eedb`; the annotation was loosened later without a follow-up `ALTER`, which `6ad9a0b7d4b7` punted on because SQLite can't `ALTER COLUMN`).

Firebase-federated users legitimately have no password, so the model is correct and the DB should be loosened. Before this, a bare `INSERT INTO users (email) VALUES (...)` raised a not-null violation even though the model implied it shouldn't.

## Change

- New migration `54bff216cdb7` (`down_revision = a1b2c3d4e5f6`, the current head): `ALTER COLUMN hashed_password DROP NOT NULL`.
- `downgrade()` backfills `''` for any NULLs **before** restoring `NOT NULL`, so it stays reversible on real data (Firebase users would otherwise have NULLs).

The auth auto-provision path keeps passing `hashed_password=""`, so no app code changes; tests are unaffected (they build the schema from the nullable model via `create_all`).

## Verification (compose Postgres)

- `alembic upgrade head` → column nullable (`is_nullable = YES`)
- `INSERT INTO users (email) VALUES (...)` → **succeeds**, `hashed_password IS NULL`
- `alembic downgrade -1` → backfill + `NOT NULL` restored (`is_nullable = NO`)
- `alembic upgrade head` again → nullable (fully reversible)
- `alembic heads` → single head; `ruff` + `pytest` green
