### PR TITLE
fix(docker): repair web healthcheck (curl not installed)

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -37,9 +37,10 @@ USER app
 # Expose port for Cloud Run (uses PORT environment variable)
 EXPOSE $PORT
 
-# Health check endpoint
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:$PORT/health || exit 1
+# Health check endpoint. Uses stdlib urllib (curl is not installed in the
+# slim base); start-period covers Python/uvicorn cold start.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD python -c "import os,urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:'+os.environ.get('PORT','8080')+'/health', timeout=5).status==200 else 1)" || exit 1
 
 # Run startup script with database migration retry logic
 CMD ["/app/startup.sh"]


### PR DESCRIPTION
## What

The `web` image's `HEALTHCHECK` ran `curl -f http://localhost:$PORT/health`, but **curl is never installed** in the `python:3.13-slim` base (only `gcc` + `libpq-dev` go in via apt). Every probe failed with `curl: not found`, so `docker-compose ps` reported `web` as `(unhealthy)` on every run — even though the app itself was fine.

Cloud Run uses its own readiness probe, so production was unaffected; this was a local/compose-only cosmetic defect.

## Change

- Swap the curl probe for a one-line stdlib `urllib.request` check — Python is already in the image, so no new layers or dependencies.
- Bump `--start-period` from 5s to 15s to cover Python/uvicorn cold start.

`Dockerfile.worker` and `Dockerfile.scheduler` already use Python-based healthchecks, so only the web image needed the fix.

## Verification (compose)

- `docker-compose build web && docker-compose up -d web` → `web` transitions `starting → healthy` within ~15s.
- `docker-compose ps web` → `Up (healthy)` (was `(unhealthy)`).
- Running the probe command inside the container exits `0`.
