### PR TITLE
test(ci): Postgres-backed test job + view/function/analytics tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,24 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      # Postgres 14 to match prod Cloud SQL. Exercises the real migration chain
+      # (views / PL-pgSQL functions / triggers) and the Postgres-only analytics
+      # tests, which SQLite cannot run.
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: aifeelnews_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     - name: Enforce merge policy
       if: |
@@ -52,13 +70,25 @@ jobs:
         python -m ruff check app/
         python -m mypy app/
 
+    # Build the real schema (views / PL-pgSQL functions / triggers / indexes)
+    # on the Postgres service so the @pytest.mark.postgres tests have something
+    # to query. ENV=test keeps OIDC enforcement off; alembic only needs the URL.
+    - name: Run database migrations (Postgres)
+      run: |
+        alembic upgrade head
+      env:
+        ENV: test
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/aifeelnews_test
+
     - name: Run tests
       run: |
         python -m pytest tests/ -v --tb=short
       env:
-        # Set environment to test mode and provide database URL
+        # SQLite for the create_all `test_db` fixture and the TestClient tests.
         ENV: test
         DATABASE_URL: sqlite:///test.db
+        # Postgres for the @pytest.mark.postgres tests; its presence un-skips them.
+        TEST_POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/aifeelnews_test
 
   build-and-deploy:
     needs: test

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 addopts = -v
 python_files = test_*.py
 pythonpath = .
+markers =
+    postgres: test requires a real PostgreSQL backend (migrations/views/functions/triggers); skipped automatically when no TEST_POSTGRES_URL is configured.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,24 @@
 """Test configuration and fixtures."""
 
+import os
+
 import pytest
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app import models  # noqa: F401 — register all ORM models on Base.metadata
 from app.database import Base
+
+# A dedicated env var (NOT DATABASE_URL) so the Postgres fixtures never
+# accidentally point at the file-SQLite the test job uses for the SQLite suite.
+# CI sets this to the postgres service URL; locally it is unset, so the
+# @pytest.mark.postgres tests skip and `pytest tests/` stays green with no DB.
+TEST_POSTGRES_URL = os.environ.get("TEST_POSTGRES_URL", "")
+
+
+def _postgres_available() -> bool:
+    return TEST_POSTGRES_URL.startswith("postgresql")
 
 
 @pytest.fixture(scope="function")
@@ -42,3 +54,63 @@ def test_db():
     finally:
         db.close()
         engine.dispose()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip @pytest.mark.postgres tests when no Postgres is configured.
+
+    This is what lets `pytest tests/` pass on a machine with no Postgres: the
+    view/function tests are collected but skipped, never errored.
+    """
+    if _postgres_available():
+        return
+    skip_pg = pytest.mark.skip(reason="requires Postgres (set TEST_POSTGRES_URL)")
+    for item in items:
+        if "postgres" in item.keywords:
+            item.add_marker(skip_pg)
+
+
+@pytest.fixture(scope="session")
+def postgres_engine():
+    """Engine bound to the migrated CI Postgres. The schema is built by the
+    CI `alembic upgrade head` step before pytest runs — this fixture does NOT
+    call create_all, so the views/functions/triggers actually exist."""
+    if not _postgres_available():
+        pytest.skip("requires Postgres (set TEST_POSTGRES_URL)")
+    engine = create_engine(TEST_POSTGRES_URL, echo=False, future=True)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def postgres_db(postgres_engine):
+    """Function-scoped Session on the migrated Postgres DB. Teardown truncates
+    every public table so each test starts from a known state (the seed loader
+    commits, so an outer-transaction rollback would not isolate)."""
+    SessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=postgres_engine, future=True
+    )
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.rollback()
+        # Build the truncate list dynamically so it stays in sync with the
+        # schema (avoids a hand-maintained list drifting from the migrations).
+        tables = (
+            db.execute(
+                text(
+                    "SELECT tablename FROM pg_tables "
+                    "WHERE schemaname = 'public' AND tablename <> 'alembic_version'"
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if tables:
+            joined = ", ".join(f'"{t}"' for t in tables)
+            db.execute(text(f"TRUNCATE {joined} RESTART IDENTITY CASCADE"))
+            db.commit()
+        db.close()

--- a/tests/test_db_analytics.py
+++ b/tests/test_db_analytics.py
@@ -1,0 +1,74 @@
+"""Exercise the advanced-SQL analytics in app/crud/analytics.py — window
+functions, CTEs, RANK() and GROUPING SETS — against a real Postgres backend.
+
+These are the most complex and most regression-prone queries in the repo and
+the showcase for the Relational Databases work, but they were previously
+untested (SQLite can't run GROUPING SETS / RANK() OVER / STDDEV). Postgres-only:
+skipped when no TEST_POSTGRES_URL is set.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.crud.analytics import (
+    sentiment_grouping_sets,
+    sentiment_rolling_average,
+    source_sentiment_ranked,
+)
+from app.seeds.seed_db import seed_database
+
+pytestmark = pytest.mark.postgres
+
+# Seed articles are all >30 days old; use a wide window so the cutoff includes
+# them (every crud function filters published_at >= now() - days).
+WIDE_DAYS = 3650
+
+
+@pytest.fixture()
+def seeded(postgres_db):
+    seed_database(postgres_db)  # commits
+    return postgres_db
+
+
+def test_rolling_average_is_smoothed_window(seeded):
+    rows = sentiment_rolling_average(seeded, days=WIDE_DAYS, window=7)
+    assert rows, "rolling average returned no rows"
+    # Each row carries the day's avg plus the windowed rolling avg.
+    first = rows[0]
+    assert {"day", "article_count", "avg_sentiment", "rolling_avg"} <= set(first)
+    # The first row's rolling avg equals its own daily avg (no preceding rows).
+    assert float(first["rolling_avg"]) == pytest.approx(
+        float(first["avg_sentiment"]), abs=1e-4
+    )
+
+
+def test_source_ranked_is_descending_by_sentiment(seeded):
+    rows = source_sentiment_ranked(seeded, days=WIDE_DAYS)
+    assert rows, "source ranking returned no rows (need >=3 articles/source)"
+    # RANK() assigns 1 to the most positive source; ranks are non-decreasing
+    # and avg_sentiment is non-increasing down the list.
+    assert rows[0]["positivity_rank"] == 1
+    ranks = [r["positivity_rank"] for r in rows]
+    assert ranks == sorted(ranks)
+    sentiments = [float(r["avg_sentiment"]) for r in rows]
+    assert sentiments == sorted(sentiments, reverse=True)
+
+
+def test_grouping_sets_has_grand_total_row(seeded):
+    rows = sentiment_grouping_sets(seeded, days=WIDE_DAYS)
+    assert rows
+    # The grand-total row has both grouping flags set and aggregates everything.
+    grand = [
+        r for r in rows if r["is_category_total"] == 1 and r["is_label_total"] == 1
+    ]
+    assert len(grand) == 1, "expected exactly one grand-total row"
+    total = grand[0]["article_count"]
+    # Per-label subtotals (label present, category rolled up) must sum to the
+    # grand total.
+    label_subtotals = [
+        r["article_count"]
+        for r in rows
+        if r["is_category_total"] == 1 and r["is_label_total"] == 0
+    ]
+    assert sum(label_subtotals) == total

--- a/tests/test_db_views.py
+++ b/tests/test_db_views.py
@@ -1,0 +1,102 @@
+"""Exercise the PostgreSQL views and stored functions from migration
+e1f2a3b4c5d6 (fn fix a1b2c3d4e5f6).
+
+Postgres-only: these objects use CREATE VIEW ... FILTER, PL/pgSQL functions
+and GROUPING-SETS-adjacent SQL that SQLite cannot run, so every test is
+@pytest.mark.postgres and skips when no TEST_POSTGRES_URL is set
+(see conftest.pytest_collection_modifyitems).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from app.seeds.seed_db import seed_database
+
+pytestmark = pytest.mark.postgres
+
+# Seed articles span 2026-01-14..2026-05-03 (all well over 30 days old), so the
+# functions' default 30-day window would return zero rows. Use a wide window.
+WIDE_DAYS = 3650
+
+
+@pytest.fixture()
+def seeded(postgres_db):
+    """Load the bundled seed dataset so the views have rows behind them."""
+    seed_database(postgres_db)  # commits
+    return postgres_db
+
+
+class TestViews:
+    def test_v_article_summary_joins_source_name(self, seeded):
+        rows = seeded.execute(
+            text(
+                "SELECT article_id, title, source_name, sentiment_label "
+                "FROM v_article_summary LIMIT 5"
+            )
+        ).fetchall()
+        assert rows, "v_article_summary returned no rows after seeding"
+        assert all(r.source_name for r in rows)
+
+    def test_v_source_stats_aggregates_counts(self, seeded):
+        rows = seeded.execute(
+            text(
+                "SELECT source_name, article_count, avg_sentiment "
+                "FROM v_source_stats ORDER BY article_count DESC"
+            )
+        ).fetchall()
+        assert rows
+        assert sum(r.article_count for r in rows) >= 1
+
+    def test_v_daily_sentiment_buckets_by_day(self, seeded):
+        rows = seeded.execute(
+            text(
+                "SELECT day, article_count, positive_count, negative_count, "
+                "neutral_count FROM v_daily_sentiment"
+            )
+        ).fetchall()
+        assert rows
+        # Seed labels are all in {positive, negative, neutral}, so per-day the
+        # three bucket counts must sum to the article_count for that day.
+        for r in rows:
+            assert r.article_count == (
+                r.positive_count + r.negative_count + r.neutral_count
+            )
+
+    def test_v_trending_entities_is_queryable(self, seeded):
+        # Seed JSON has no entities and the view filters to the last 7 days, so
+        # an empty result set is expected — this proves the view DDL is sound.
+        rows = seeded.execute(
+            text(
+                "SELECT entity_id, entity_name, total_mentions FROM v_trending_entities"
+            )
+        ).fetchall()
+        assert isinstance(rows, list)
+
+
+class TestStoredFunctions:
+    def test_fn_sentiment_distribution_returns_percentages(self, seeded):
+        # Regression guard for a1b2c3d4e5f6: the pre-fix definition raised
+        # 'column reference "sentiment_label" is ambiguous'. Success here proves
+        # the migration chain actually ran (not create_all).
+        rows = seeded.execute(
+            text(
+                "SELECT sentiment_label, article_count, percentage "
+                f"FROM fn_sentiment_distribution({WIDE_DAYS})"
+            )
+        ).fetchall()
+        assert rows, "fn_sentiment_distribution returned no rows"
+        total_pct = sum(float(r.percentage) for r in rows)
+        assert 99.0 <= total_pct <= 101.0  # rounding tolerance
+
+    def test_fn_source_performance_returns_rows(self, seeded):
+        rows = seeded.execute(
+            text(
+                "SELECT source_name, article_count, avg_sentiment, "
+                "entity_richness, crawl_success_rate "
+                f"FROM fn_source_performance({WIDE_DAYS})"
+            )
+        ).fetchall()
+        assert rows
+        assert all(r.article_count >= 1 for r in rows)


### PR DESCRIPTION
## What

The test suite ran only against **SQLite** (`Base.metadata.create_all`), which bypasses the Alembic migration chain — so the **views, PL/pgSQL functions, and triggers** (and the Postgres-only advanced-SQL analytics) were **never exercised in CI**. This adds a real `postgres:14` service to the deploy `test` job and Postgres-backed tests, while keeping the existing SQLite suite and local `pytest tests/` fully working.

## Changes

- **`pytest.ini`** — register the `postgres` marker.
- **`tests/conftest.py`** — new `postgres_engine` / `postgres_db` fixtures driven by a dedicated `TEST_POSTGRES_URL` (not `DATABASE_URL`, so the SQLite suite is never repointed). They use the **migrated** schema (no `create_all`, so the views/functions/triggers exist). A `pytest_collection_modifyitems` hook **skips** the `@pytest.mark.postgres` tests when no Postgres is configured. The existing `test_db` SQLite fixture is untouched.
- **`tests/test_db_views.py`** — the 4 views + 2 stored functions. `fn_sentiment_distribution` doubles as a regression guard: its success proves migration `a1b2c3d4e5f6` (the ambiguous-column fix) actually ran.
- **`tests/test_db_analytics.py`** — exercises `app/crud/analytics.py`: the rolling-average window function, `RANK()` ordering, and the `GROUPING SETS` grand-total invariant — previously untested (SQLite can't run them).
- **`.github/workflows/deploy.yml`** — `services: postgres` on the test job + a `alembic upgrade head` step before pytest. The pytest step keeps `ENV=test` and `DATABASE_URL=sqlite:///test.db`, and adds `TEST_POSTGRES_URL` to un-skip the new tests. `ENV` stays `test` throughout (so the OIDC-bypass test is unaffected); the Cloud SQL Proxy block in the deploy job is untouched.

## Verification

- **With Postgres** (compose, migrated to head, `TEST_POSTGRES_URL` set): all 9 new tests pass.
- **Without Postgres** (`TEST_POSTGRES_URL` unset): `pytest tests/` → **58 passed, 9 skipped** — the local-dev story holds and nothing in the SQLite suite regressed.
- `ruff` clean; `deploy.yml` is valid YAML.

## Notes

- Seed articles are all >30 days old, so the function/analytics tests pass a wide lookback window (3650 days) to include them.
- The first real-Postgres CI run is the first time the full migration chain runs against Postgres in CI — if it surfaces a latent migration issue masked by `create_all`, that's a genuine finding to fix.
