### PR TITLE
fix(ci): repair the dead post-deploy articles smoke check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,11 +250,14 @@ jobs:
           exit 1
         fi
 
-        # 4. Verify primary API router
-        if curl -sf "$URL/api/v1/articles/?skip=0&limit=1" > /dev/null 2>&1; then
+        # 4. Verify the primary read API. An empty DB returns 200 with `[]`,
+        # so curl -sf only fails on 404/5xx — safe to make this fatal so it
+        # actually gates the rollback step instead of silently warning.
+        if curl -sf "$URL/articles/?skip=0&limit=1" > /dev/null; then
           echo "Articles API responding"
         else
-          echo "::warning::Articles API check failed (may be empty DB — non-fatal)"
+          echo "::error::Articles API check failed"
+          exit 1
         fi
 
         echo "All deployment checks passed"


### PR DESCRIPTION
## What

The post-deploy "verify primary API router" step has never actually validated the articles API: it curled `$URL/api/v1/articles/`, but the router is mounted at **`/articles/`** (unprefixed), so the path **404s**. The check was wrapped in `2>&1` + a non-fatal `::warning::`, so the failure was swallowed — it could never fail the deploy, and its warning misattributed the cause to "empty DB".

This undercut the pipeline's otherwise-solid "verified rollout + auto-rollback" story (revision-pinning + rollback steps sit right around it).

## Change

- Point the check at the real `/articles/` path.
- Drop the `2>&1` suppression so a real error is visible in logs.
- Make it **fatal** with an explicit `exit 1` (the `run:` block isn't under `set -e`, so a bare failing `curl` wouldn't fail the step) — it now genuinely gates the rollback step.

An empty DB returns `200` with `[]`, so `curl -sf` only trips on `404`/`5xx` — no false alarm on a fresh database.

## Note

When the `/api/v1` unification PR lands, this path moves to `/api/v1/articles/`.

## Verification

`deploy.yml` is valid YAML; the change is isolated to the smoke-check block (rebased onto the merged Postgres-CI changes to `deploy.yml`).
