### PR TITLE
perf(db): size the connection pool against Cloud SQL max_connections

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -29,7 +29,23 @@ def _initialize() -> None:
     # pool_pre_ping detects connections killed by Cloud SQL idle-timeout
     # before SQLAlchemy hands them to a request; pool_recycle forces a
     # refresh every hour so long-lived idle pools don't hit DB-side TTLs.
-    _engine = create_engine(url, echo=False, pool_pre_ping=True, pool_recycle=3600)
+    #
+    # Pool sized explicitly against the deployment, not left at the SQLAlchemy
+    # default (5 + 10 = 15/instance). Cloud SQL caps max_connections at 50
+    # (infra/main.tf), and max-instances=10 web + the ingestion/crawl/ttl jobs
+    # all draw from this same config, so the default 15/instance (150 at full
+    # scale-out) would over-subscribe the DB. 4/instance keeps the web fleet at
+    # 40 worst-case, leaving headroom for jobs + Postgres' reserved slots.
+    # pool_timeout=10 fails fast instead of the silent 30s default.
+    _engine = create_engine(
+        url,
+        echo=False,
+        pool_pre_ping=True,
+        pool_recycle=3600,
+        pool_size=2,
+        max_overflow=2,
+        pool_timeout=10,
+    )
     _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
 
 


### PR DESCRIPTION
## What

Sizes the SQLAlchemy connection pool explicitly instead of leaving it at the defaults, turning an invisible default into a reasoned capacity decision tied to the actual Cloud SQL limit.

## Why

`create_engine` set no `pool_size`/`max_overflow`, so the defaults applied: **5 + 10 = 15 connections per instance**. But:

- Cloud SQL caps `max_connections` at **50** (`infra/main.tf`).
- Cloud Run runs with `--max-instances=10`, and the ingestion/crawl/ttl jobs all import the same `SessionLocal`, so they draw from this same pool config too.
- At full scale-out the default would allow **150 web connections alone** against a hard cap of 50 — over-subscribed ~3× — while each instance's behaviour under contention was implicit.

## Change

```python
create_engine(url, pool_pre_ping=True, pool_recycle=3600,
              pool_size=2, max_overflow=2, pool_timeout=10)
```

- `pool_size=2, max_overflow=2` → **4/instance** → web fleet at ~40 worst-case (`4 × 10`), leaving headroom for the job tier and Postgres' reserved superuser slots.
- `pool_timeout=10` fails fast instead of the silent 30s default.
- `pool_pre_ping`/`pool_recycle` unchanged.

This is sized for the current small-DB tier; at scale the production answer is a pooler (PgBouncer / Cloud SQL connection pooling), noted as a documented trade-off.

## Verification

- `ruff` + `mypy` clean.
- Engine builds with the params applied (`pool_size: 2, max_overflow: 2, timeout: 10`).
- Full suite: **58 passed, 9 skipped** — SQLite ignores QueuePool sizing, so tests are unaffected.
