### PR TITLE
refactor(api): global exception handler, shared limiter, fail-fast imports

### DIFF
--- a/app/deps/ratelimit.py
+++ b/app/deps/ratelimit.py
@@ -1,0 +1,11 @@
+"""Shared slowapi limiter — single source of truth for the rate-limit policy.
+
+Registered on ``app.state.limiter`` in ``app/main.py`` and imported by the
+routers for their ``@limiter.limit(...)`` decorators, so the keying function
+is defined in exactly one place.
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/app/main.py
+++ b/app/main.py
@@ -5,15 +5,25 @@ from typing import Any
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from slowapi import Limiter, _rate_limit_exceeded_handler
+from fastapi.responses import JSONResponse
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 
 from app import models  # noqa: F401
 from app.config import config as _app_config
 from app.database import Base, engine  # noqa: F401
 from app.deps.oidc import verify_scheduler_oidc
-from app.routers import articles, bookmarks, sources, users
+from app.deps.ratelimit import limiter
+from app.routers import (
+    analytics,
+    articles,
+    bookmarks,
+    db_analytics,
+    entities,
+    sentiment,
+    sources,
+    users,
+)
 from app.utils.logging import setup_logging
 
 # Structured logging (JSON in production, plain text locally)
@@ -26,59 +36,37 @@ logger.info(
     "SET" if _app_config.ingestion.mediastack_api_key else "EMPTY",
 )
 
-# Import sentiment router with error handling
-sentiment_available = False
-sentiment: Any = None
-try:
-    from app.routers import sentiment
-
-    sentiment_available = True
-except Exception as e:
-    logger.warning("Could not import sentiment router: %s", e, exc_info=True)
-    sentiment_available = False
-
-# Import entities router with error handling
-entities_available = False
-entities_mod: Any = None
-try:
-    from app.routers import entities as entities_mod
-
-    entities_available = True
-except Exception as e:
-    logger.warning("Could not import entities router: %s", e, exc_info=True)
-    entities_available = False
-
-# Import analytics router with error handling
-analytics_available = False
-analytics_mod: Any = None
-try:
-    from app.routers import analytics as analytics_mod
-
-    analytics_available = True
-except Exception as e:
-    logger.warning("Could not import analytics router: %s", e, exc_info=True)
-    analytics_available = False
-
 APP_VERSION = os.getenv("APP_VERSION", "1.0.1")
 app = FastAPI(title="aiFeelNews API", version=APP_VERSION)
 
 # --- Rate limiting (slowapi) -------------------------------------------------
-# `get_remote_address` keys requests by client IP. Cloud Run forwards the real
-# client IP via X-Forwarded-For; slowapi reads the request object's `client.host`
-# which Starlette populates from that header when running behind a proxy.
-# We register the limiter on app.state so route decorators can find it via
-# `request.app.state.limiter` and add a handler that translates the
-# RateLimitExceeded exception into a clean 429 response.
-limiter = Limiter(key_func=get_remote_address)
+# The shared limiter (app/deps/ratelimit.py) is registered on app.state so the
+# route decorators resolve it via `request.app.state.limiter`. The handler
+# translates RateLimitExceeded into a clean 429.
 app.state.limiter = limiter
-# slowapi's handler signature is `(Request, RateLimitExceeded) -> Response`
-# whereas Starlette's `add_exception_handler` expects the second arg to be
-# typed as `Exception`. The function itself works at runtime (RateLimitExceeded
-# IS-A Exception); we cast away the false-positive type mismatch here.
+# slowapi's handler is typed `(Request, RateLimitExceeded)`; Starlette expects
+# `Exception` for the second arg. It works at runtime (RateLimitExceeded IS-A
+# Exception) — cast away the false-positive mismatch.
 app.add_exception_handler(
     RateLimitExceeded,
     _rate_limit_exceeded_handler,  # type: ignore[arg-type]
 )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Last-resort handler for otherwise-unhandled exceptions.
+
+    Logs the cause server-side and returns a generic 500 so no stack trace or
+    internal detail leaks to the client. HTTPException and RequestValidationError
+    have their own handlers that take precedence, so domain 4xx responses and
+    the per-endpoint 503s are unaffected.
+    """
+    logger.error(
+        "Unhandled exception on %s %s", request.method, request.url.path, exc_info=exc
+    )
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
 
 # Allowed origins for CORS (production Firebase Hosting + local dev)
 ALLOWED_ORIGINS = [
@@ -96,36 +84,18 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type"],
 )
 
-# Register routers
+# Register routers. All imports are unconditional: a broken router import is a
+# programming error that should fail startup loudly (caught by the deploy
+# health check), not silently drop endpoints from the API.
 app.include_router(users.router, prefix="/users", tags=["Users"])
 app.include_router(articles.router, prefix="/articles", tags=["Articles"])
 app.include_router(bookmarks.router, prefix="/bookmarks", tags=["Bookmarks"])
 app.include_router(sources.router, prefix="/sources", tags=["Sources"])
-
-# Register sentiment router if available
-if sentiment_available and sentiment:
-    app.include_router(sentiment.router, prefix="/api/v1/sentiment")
-
-# Register entities router if available
-if entities_available and entities_mod:
-    app.include_router(entities_mod.router, prefix="/api/v1/entities")
-
-# Register analytics router if available
-if analytics_available and analytics_mod:
-    app.include_router(analytics_mod.router, prefix="/api/v1/analytics")
-
-# Register PostgreSQL analytics router (advanced SQL: window functions, CTEs, GROUPING SETS)
-db_analytics_available = False
-db_analytics_mod: Any = None
-try:
-    from app.routers import db_analytics as db_analytics_mod
-
-    db_analytics_available = True
-except Exception as e:
-    logger.warning("Could not import db_analytics router: %s", e, exc_info=True)
-
-if db_analytics_available and db_analytics_mod:
-    app.include_router(db_analytics_mod.router, prefix="/api/v1/db-analytics")
+app.include_router(sentiment.router, prefix="/api/v1/sentiment")
+app.include_router(entities.router, prefix="/api/v1/entities")
+app.include_router(analytics.router, prefix="/api/v1/analytics")
+# PostgreSQL analytics (advanced SQL: window functions, CTEs, GROUPING SETS)
+app.include_router(db_analytics.router, prefix="/api/v1/db-analytics")
 
 
 @app.get("/")

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -8,10 +8,9 @@ applied per-IP via slowapi. Decorators look up the limiter via
 from typing import Dict, List, Optional, Union
 
 from fastapi import APIRouter, Query, Request
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.config import config
+from app.deps.ratelimit import limiter as _limiter
 from app.schemas.analytics import (
     CategoryBreakdown,
     EntitySentiment,
@@ -33,11 +32,6 @@ from app.services.bigquery import (
 
 router = APIRouter(tags=["Analytics"])
 
-# Local limiter handle. The limiter object on app.state is the canonical
-# one (registered in app/main.py); keeping a module-level Limiter here
-# keeps the decorators readable and works because slowapi looks up the
-# canonical limiter via request.app.state.limiter at call time.
-_limiter = Limiter(key_func=get_remote_address)
 _RATE = config.security.rate_limit_analytics
 
 

--- a/app/routers/sentiment.py
+++ b/app/routers/sentiment.py
@@ -9,10 +9,9 @@ import logging
 from typing import Dict, List, Union
 
 from fastapi import APIRouter, Request
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.config import config
+from app.deps.ratelimit import limiter as _limiter
 
 # Import at module level to catch import errors early
 from app.utils.sentiment import get_sentiment_provider_info
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["sentiment"])
 
-_limiter = Limiter(key_func=get_remote_address)
 _RATE = config.security.rate_limit_sentiment
 
 

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -633,3 +633,33 @@ class TestErrorDetailDoesNotLeakInternals:
         assert response.status_code == 503
         assert response.json() == {"detail": "Service temporarily unavailable"}
         assert secret_token not in response.text
+
+
+class TestGlobalExceptionHandler:
+    """An unhandled (non-HTTPException) error must surface as a generic 500
+    with no internal detail, via the app-level Exception handler."""
+
+    def test_unhandled_error_returns_generic_500(self) -> None:
+        from fastapi.testclient import TestClient
+
+        from app.main import app as live_app
+        from app.routers.sources import get_db as sources_get_db
+
+        secret = "INTERNAL_LEAK_db://prod-secret"
+
+        def _boom_db() -> Any:
+            raise RuntimeError(secret)
+            yield  # pragma: no cover — unreachable, makes this a generator
+
+        live_app.dependency_overrides[sources_get_db] = _boom_db
+        # raise_server_exceptions=False lets the app's handler produce the
+        # response instead of TestClient re-raising the exception.
+        local_client = TestClient(live_app, raise_server_exceptions=False)
+        try:
+            resp = local_client.get("/sources/")
+        finally:
+            live_app.dependency_overrides.pop(sources_get_db, None)
+
+        assert resp.status_code == 500
+        assert resp.json() == {"detail": "Internal server error"}
+        assert secret not in resp.text


### PR DESCRIPTION
## What

Three maintainability improvements to the application wiring, from the backend audit.

### 1. Global exception handler

A single `@app.exception_handler(Exception)` in `app/main.py` logs the cause server-side and returns a generic `{"detail": "Internal server error"}` 500. Previously, an unhandled error in a data router (e.g. an unexpected `SQLAlchemyError`) fell through to Starlette's default 500 — there was no single place guaranteeing the contract.

`HTTPException` and `RequestValidationError` have their own dedicated handlers that take precedence, so:
- domain 4xx responses (404/409/400/401) are unchanged,
- the existing per-endpoint **503** blocks on `/health` and `/ready` are unchanged (probe semantics preserved — 503 ≠ 500 to the load balancer),
- the 401-`detail` and 422-`detail` test assertions stay green.

### 2. Shared rate limiter

A single `Limiter` in `app/deps/ratelimit.py` replaces the **three** separate module-level `Limiter` instances (`main.py`, `analytics.py`, `sentiment.py`). Those locals existed only so the `@limiter.limit(...)` decorators had an object — the actual limiting always resolved `request.app.state.limiter`. Now there's one source of truth for the keying function.

### 3. Fail-fast router imports

`sentiment` / `entities` / `analytics` / `db_analytics` were imported inside `try/except` that logged a warning and **silently dropped the router** (and its routes from `/docs`) on any import error — converting a loud, catchable failure into an invisible degradation. These deps are hard-pinned and import cleanly, so a broken import is a programming error that should crash startup loudly (caught by the deploy health-check → rollback). Hoisted to unconditional top-level imports, matching the core routers. ~30 lines of boilerplate removed.

## Verification

- `ruff` + `mypy` clean (68 files); app imports and all routers mount; the `Exception` handler is registered.
- New test `TestGlobalExceptionHandler` asserts an unhandled error → 500 `{"detail": "Internal server error"}` with no internal detail leaked.
- Full suite: **59 passed, 9 skipped** (incl. the existing rate-limit test, now exercising the shared limiter).
