### PR TITLE
refactor(api): unify all routes under /api/v1 (full cutover)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,7 +253,7 @@ jobs:
         # 4. Verify the primary read API. An empty DB returns 200 with `[]`,
         # so curl -sf only fails on 404/5xx — safe to make this fatal so it
         # actually gates the rollback step instead of silently warning.
-        if curl -sf "$URL/articles/?skip=0&limit=1" > /dev/null; then
+        if curl -sf "$URL/api/v1/articles/?skip=0&limit=1" > /dev/null; then
           echo "Articles API responding"
         else
           echo "::error::Articles API check failed"

--- a/app/main.py
+++ b/app/main.py
@@ -87,10 +87,15 @@ app.add_middleware(
 # Register routers. All imports are unconditional: a broken router import is a
 # programming error that should fail startup loudly (caught by the deploy
 # health check), not silently drop endpoints from the API.
-app.include_router(users.router, prefix="/users", tags=["Users"])
-app.include_router(articles.router, prefix="/articles", tags=["Articles"])
-app.include_router(bookmarks.router, prefix="/bookmarks", tags=["Bookmarks"])
-app.include_router(sources.router, prefix="/sources", tags=["Sources"])
+#
+# Every domain router is mounted under the single ``/api/v1`` surface so the
+# API has one versioned namespace (no unprefixed legacy paths). Operational
+# endpoints (/health, /ready, /version, /metrics) stay unprefixed by design —
+# they're infrastructure probes, not part of the versioned data API.
+app.include_router(users.router, prefix="/api/v1/users", tags=["Users"])
+app.include_router(articles.router, prefix="/api/v1/articles", tags=["Articles"])
+app.include_router(bookmarks.router, prefix="/api/v1/bookmarks", tags=["Bookmarks"])
+app.include_router(sources.router, prefix="/api/v1/sources", tags=["Sources"])
 app.include_router(sentiment.router, prefix="/api/v1/sentiment")
 app.include_router(entities.router, prefix="/api/v1/entities")
 app.include_router(analytics.router, prefix="/api/v1/analytics")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,7 +74,7 @@ export type ArticleFilterParams = {
 };
 
 /**
- * Fetch articles from the canonical filtered endpoint `/articles/`.
+ * Fetch articles from the canonical filtered endpoint `/api/v1/articles/`.
  *
  * Query params are serialised via URLSearchParams; empty / undefined values
  * are skipped so the backend gets a clean URL. Order is server-stable
@@ -95,8 +95,8 @@ export async function fetchArticles(
 
   const queryString = qs.toString();
   const url = queryString
-    ? `${API_BASE}/articles/?${queryString}`
-    : `${API_BASE}/articles/`;
+    ? `${API_BASE}/api/v1/articles/?${queryString}`
+    : `${API_BASE}/api/v1/articles/`;
 
   const res = await fetch(url);
 
@@ -114,7 +114,7 @@ export async function fetchArticles(
  * article details after listing the user's bookmarks.
  */
 export async function fetchArticleById(id: number): Promise<ArticleDto> {
-  const res = await fetch(`${API_BASE}/articles/${id}`);
+  const res = await fetch(`${API_BASE}/api/v1/articles/${id}`);
   if (!res.ok) {
     const errorText = await res.text();
     throw new Error(`Failed to fetch article ${id}: ${res.status} ${errorText}`);
@@ -132,7 +132,7 @@ export type SourceDto = {
 };
 
 export async function fetchSources(): Promise<SourceDto[]> {
-  const res = await fetch(`${API_BASE}/sources/`);
+  const res = await fetch(`${API_BASE}/api/v1/sources/`);
   if (!res.ok) {
     throw new Error(`Failed to fetch sources: ${res.status}`);
   }
@@ -168,7 +168,7 @@ export async function createBookmark(
   articleId: number,
   idToken: string
 ): Promise<BookmarkDto | null> {
-  const res = await fetch(`${API_BASE}/bookmarks/`, {
+  const res = await fetch(`${API_BASE}/api/v1/bookmarks/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -191,7 +191,7 @@ export async function createBookmark(
 }
 
 export async function listBookmarks(idToken: string): Promise<BookmarkDto[]> {
-  const res = await fetch(`${API_BASE}/bookmarks/`, {
+  const res = await fetch(`${API_BASE}/api/v1/bookmarks/`, {
     headers: { Authorization: `Bearer ${idToken}` },
   });
   if (res.status === 401) {
@@ -211,7 +211,7 @@ export async function deleteBookmark(
   bookmarkId: number,
   idToken: string
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/bookmarks/${bookmarkId}`, {
+  const res = await fetch(`${API_BASE}/api/v1/bookmarks/${bookmarkId}`, {
     method: "DELETE",
     headers: { Authorization: `Bearer ${idToken}` },
   });

--- a/tests/test_articles_filters.py
+++ b/tests/test_articles_filters.py
@@ -1,8 +1,8 @@
-"""Tests for the filter / search / pagination contract on /articles routes.
+"""Tests for the filter / search / pagination contract on /api/v1/articles routes.
 
 These exercise the shared ``_query_articles`` helper through the public
-``/articles/`` endpoint via TestClient. ``/articles/latest`` reuses the same
-helper so a single smoke test covers it.
+``/api/v1/articles/`` endpoint via TestClient. ``/api/v1/articles/latest``
+reuses the same helper so a single smoke test covers it.
 
 The tests run against the in-memory SQLite ``test_db`` fixture from
 ``tests/conftest.py``. Auth is irrelevant here because the article list
@@ -86,11 +86,11 @@ def client(seeded_db: Session) -> Iterator[TestClient]:
 
 
 class TestArticleFilters:
-    """Filter / search / pagination + 422 boundary cases on /articles/."""
+    """Filter / search / pagination + 422 boundary cases on /api/v1/articles/."""
 
     def test_articles_default(self, client: TestClient) -> None:
         """No params: default page returns all 10 seeded rows."""
-        resp = client.get("/articles/")
+        resp = client.get("/api/v1/articles/")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 10
@@ -100,7 +100,7 @@ class TestArticleFilters:
 
     def test_articles_filter_by_sentiment(self, client: TestClient) -> None:
         """sentiment_label=positive returns exactly the 4 positive rows."""
-        resp = client.get("/articles/?sentiment_label=positive")
+        resp = client.get("/api/v1/articles/?sentiment_label=positive")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 4
@@ -108,7 +108,7 @@ class TestArticleFilters:
 
     def test_articles_filter_by_category(self, client: TestClient) -> None:
         """category=business returns exactly the 3 business rows."""
-        resp = client.get("/articles/?category=business")
+        resp = client.get("/api/v1/articles/?category=business")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 3
@@ -116,7 +116,7 @@ class TestArticleFilters:
 
     def test_articles_filter_by_source(self, client: TestClient) -> None:
         """source_id=1 returns exactly the 5 rows from source 1."""
-        resp = client.get("/articles/?source_id=1")
+        resp = client.get("/api/v1/articles/?source_id=1")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 5
@@ -124,7 +124,7 @@ class TestArticleFilters:
 
     def test_articles_search_substring(self, client: TestClient) -> None:
         """Case-insensitive substring search on title; matches "trump"."""
-        resp = client.get("/articles/?search=trump")
+        resp = client.get("/api/v1/articles/?search=trump")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
@@ -132,8 +132,8 @@ class TestArticleFilters:
 
     def test_articles_pagination(self, client: TestClient) -> None:
         """skip+limit yield disjoint id sets across consecutive pages."""
-        page1 = client.get("/articles/?skip=0&limit=5").json()
-        page2 = client.get("/articles/?skip=5&limit=5").json()
+        page1 = client.get("/api/v1/articles/?skip=0&limit=5").json()
+        page2 = client.get("/api/v1/articles/?skip=5&limit=5").json()
 
         assert len(page1) == 5
         assert len(page2) == 5
@@ -145,7 +145,9 @@ class TestArticleFilters:
 
     def test_articles_filter_combination(self, client: TestClient) -> None:
         """Filters AND together: positive + business = 1 row (Trump speech)."""
-        resp = client.get("/articles/?sentiment_label=positive&category=business")
+        resp = client.get(
+            "/api/v1/articles/?sentiment_label=positive&category=business"
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
@@ -154,28 +156,28 @@ class TestArticleFilters:
 
     def test_articles_invalid_sentiment_returns_422(self, client: TestClient) -> None:
         """Values outside the regex enum (positive|negative|neutral) → 422."""
-        resp = client.get("/articles/?sentiment_label=ecstatic")
+        resp = client.get("/api/v1/articles/?sentiment_label=ecstatic")
         assert resp.status_code == 422
         assert "detail" in resp.json()
 
     def test_articles_invalid_skip_returns_422(self, client: TestClient) -> None:
         """skip < 0 violates the ge=0 constraint → 422."""
-        resp = client.get("/articles/?skip=-1")
+        resp = client.get("/api/v1/articles/?skip=-1")
         assert resp.status_code == 422
         assert "detail" in resp.json()
 
     def test_articles_search_too_short_returns_422(self, client: TestClient) -> None:
         """search shorter than min_length=2 → 422."""
-        resp = client.get("/articles/?search=a")
+        resp = client.get("/api/v1/articles/?search=a")
         assert resp.status_code == 422
         assert "detail" in resp.json()
 
 
 def test_latest_accepts_same_query_params(client: TestClient) -> None:
-    """Smoke test: /articles/latest shares the helper, so the same filter
+    """Smoke test: /api/v1/articles/latest shares the helper, so the same filter
     surface must work end-to-end. We assert filter semantics, not response
     shape (already covered above)."""
-    resp = client.get("/articles/latest?sentiment_label=neutral&limit=10")
+    resp = client.get("/api/v1/articles/latest?sentiment_label=neutral&limit=10")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 3

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -100,7 +100,7 @@ class TestFirebaseAuthGate:
 
     def test_protected_route_requires_token(self, client: TestClient) -> None:
         """No Authorization header → 401."""
-        resp = client.get("/bookmarks/")
+        resp = client.get("/api/v1/bookmarks/")
         assert resp.status_code == 401
         assert "token" in resp.json()["detail"].lower()
 
@@ -111,7 +111,7 @@ class TestFirebaseAuthGate:
             side_effect=Exception("invalid signature"),
         ):
             resp = client.get(
-                "/bookmarks/",
+                "/api/v1/bookmarks/",
                 headers={"Authorization": "Bearer not-a-real-token"},
             )
         assert resp.status_code == 401
@@ -120,7 +120,7 @@ class TestFirebaseAuthGate:
     def test_protected_route_rejects_malformed_header(self, client: TestClient) -> None:
         """Header without 'Bearer ' prefix → 401, never reaches Firebase."""
         resp = client.get(
-            "/bookmarks/",
+            "/api/v1/bookmarks/",
             headers={"Authorization": "totally-bogus"},
         )
         assert resp.status_code == 401
@@ -132,11 +132,11 @@ class TestFirebaseAuthGate:
 
 
 class TestAdminRbacGate:
-    """``POST /sources/`` requires the signed ``role=admin`` custom claim.
+    """``POST /api/v1/sources/`` requires the signed ``role=admin`` custom claim.
 
     Authorization is sourced from the Firebase ID token (a transient
     ``user.role`` attribute set by ``get_current_user`` from the verified
-    custom claim), NOT from any database column. ``GET /sources/`` stays
+    custom claim), NOT from any database column. ``GET /api/v1/sources/`` stays
     public. Authentication (401) is enforced before authorization (403).
     """
 
@@ -192,7 +192,7 @@ class TestAdminRbacGate:
 
         live_app.dependency_overrides[get_current_user] = lambda: self._stub_user(None)
         try:
-            resp = client.post("/sources/", json={"name": "BBC"})
+            resp = client.post("/api/v1/sources/", json={"name": "BBC"})
         finally:
             live_app.dependency_overrides.pop(get_current_user, None)
         assert resp.status_code == 403
@@ -210,7 +210,7 @@ class TestAdminRbacGate:
         )
         live_app.dependency_overrides[sources_get_db] = self._override_db
         try:
-            resp = client.post("/sources/", json={"name": "BBC"})
+            resp = client.post("/api/v1/sources/", json={"name": "BBC"})
         finally:
             live_app.dependency_overrides.pop(get_current_user, None)
             live_app.dependency_overrides.pop(sources_get_db, None)
@@ -221,7 +221,7 @@ class TestAdminRbacGate:
     def test_no_token_is_401_not_403(self, client: TestClient) -> None:
         """No Authorization header → 401 from get_current_user, before
         require_admin's 403 branch can run (authn precedes authz)."""
-        resp = client.post("/sources/", json={"name": "BBC"})
+        resp = client.post("/api/v1/sources/", json={"name": "BBC"})
         assert resp.status_code == 401
 
     def test_role_is_read_from_token_not_db(self, client: TestClient) -> None:
@@ -238,7 +238,7 @@ class TestAdminRbacGate:
                 return_value={"uid": "abc", "email": "a@x", "role": "admin"},
             ):
                 resp = client.post(
-                    "/sources/",
+                    "/api/v1/sources/",
                     json={"name": "BBC"},
                     headers={"Authorization": "Bearer fake"},
                 )
@@ -457,7 +457,7 @@ class TestBookmarkConflictHandling:
         live_app.dependency_overrides[bookmarks_get_db] = _override_get_db
         live_app.dependency_overrides[get_current_user] = _override_get_current_user
         try:
-            resp = client.post("/bookmarks/", json={"article_id": 42})
+            resp = client.post("/api/v1/bookmarks/", json={"article_id": 42})
         finally:
             live_app.dependency_overrides.pop(bookmarks_get_db, None)
             live_app.dependency_overrides.pop(get_current_user, None)
@@ -656,7 +656,7 @@ class TestGlobalExceptionHandler:
         # response instead of TestClient re-raising the exception.
         local_client = TestClient(live_app, raise_server_exceptions=False)
         try:
-            resp = local_client.get("/sources/")
+            resp = local_client.get("/api/v1/sources/")
         finally:
             live_app.dependency_overrides.pop(sources_get_db, None)
 


### PR DESCRIPTION
## Unify the API under a single `/api/v1` namespace (full cutover)

Mounts every domain router under `/api/v1` and **deletes** the legacy unprefixed
mounts — no aliases, clean end state. `sentiment` / `entities` / `analytics` /
`db-analytics` were already there; this brings `users` / `articles` / `bookmarks` /
`sources` in line, so `/docs` now shows exactly one versioned surface.

Operational probes (`/health`, `/ready`, `/version`, `/metrics`, `/`) stay
**unprefixed by design** — they're infrastructure for load balancers and the deploy
pipeline, not part of the versioned data API.

### ⚠️ Coordinated deploy (backend + frontend together)
This is a deliberate flag-day cutover. The backend no longer serves the old
unprefixed paths, and the SPA now calls `/api/v1/...`. **Both must deploy in the same
release** — an un-redeployed SPA against the new backend (or vice-versa) would 404.
This lands in `develop`; the single `develop → main` release ships them together.

### Changes
- **`app/main.py`** — re-prefix `users` / `articles` / `bookmarks` / `sources` to `/api/v1/...`; drop legacy mounts.
- **`frontend/src/lib/api.ts`** — migrate every data-path fetch (articles, sources, bookmarks) to `/api/v1`. Analytics already used it.
- **tests** — update the legacy-path assertions in `test_articles_filters.py` and `test_auth_security.py` (including the RBAC `/sources/` admin gate) to `/api/v1`.
- **`.github/workflows/deploy.yml`** — point the post-deploy articles smoke check at `/api/v1/articles/`.

### Verification
- `ruff check` / `mypy app/` — clean
- `pytest tests/` — **59 passed, 9 skipped**
- frontend `npm run check` — 0 errors / 0 warnings; `npm run build` — clean
- route-table inspection: **zero legacy unprefixed data routes**; all data routes under `/api/v1`; probes unprefixed
