### PR TITLE
feat(ui): dark-first design-token system with light/dark toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,17 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <meta name="description" content="News sentiment analysis — articles scored by Google's Natural Language AI." />
+    <title>aiFeelNews</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
     logout,
     getIdToken,
   } from "./lib/firebase";
+  import { theme, toggleTheme } from "./lib/theme";
   import {
     fetchArticles,
     fetchSources,
@@ -100,11 +101,13 @@
       const bookmarks = await listBookmarks(token);
       bookmarkStore.hydrate(bookmarks);
     } catch (e) {
-      if (e instanceof AuthExpiredError) {
-        await logout();
-      } else {
-        console.warn("Failed to hydrate bookmarks:", e);
-      }
+      // Hydration is a passive background fetch fired by the auth-state
+      // reactive block. A 401 here must NOT force a logout — otherwise a
+      // backend that can't verify the token (e.g. a local dev backend with
+      // no Firebase service account) would sign the user straight back out
+      // in a login→401→logout loop. Only user-initiated bookmark actions
+      // treat a 401 as a genuinely expired session.
+      console.warn("Failed to hydrate bookmarks (continuing signed in):", e);
     }
   }
 
@@ -240,142 +243,144 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50">
-  <!-- Header -->
-  <header class="bg-white shadow-sm border-b">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center h-16">
-        <div class="flex items-center space-x-6">
-          <h1 class="text-2xl font-bold text-gray-900">aiFeelNews</h1>
+<header class="header">
+  <div class="header-inner">
+    <div class="wordmark" aria-label="aiFeelNews">ai<span>Feel</span>News</div>
 
-          <nav class="nav">
-            <button
-              on:click={() => (currentPage = "articles")}
-              class="nav-button"
-              class:nav-button-active={currentPage === "articles"}
-              aria-current={currentPage === "articles" ? "page" : undefined}
-            >
-              Articles
-            </button>
-            {#if $userStore}
-              <button
-                on:click={() => (currentPage = "bookmarks")}
-                class="nav-button"
-                class:nav-button-active={currentPage === "bookmarks"}
-                aria-current={currentPage === "bookmarks" ? "page" : undefined}
-              >
-                Bookmarks
-              </button>
-              <button
-                on:click={() => (currentPage = "analytics")}
-                class="nav-button"
-                class:nav-button-active={currentPage === "analytics"}
-                aria-current={currentPage === "analytics" ? "page" : undefined}
-              >
-                Analytics
-              </button>
-            {/if}
-          </nav>
-        </div>
-
-        <div class="flex items-center space-x-4">
-          {#if $userStore}
-            <span class="text-sm text-gray-600">Welcome, {$userStore.email}</span>
-            <button
-              on:click={logout}
-              class="bg-red-600 text-white px-4 py-2 rounded-md text-sm hover:bg-red-700"
-            >
-              Logout
-            </button>
-          {:else}
-            <button
-              on:click={loginWithGoogle}
-              class="bg-blue-600 text-white px-4 py-2 rounded-md text-sm hover:bg-blue-700"
-            >
-              Login with Google
-            </button>
-          {/if}
-        </div>
-      </div>
-    </div>
-  </header>
-
-  <!-- Main Content -->
-  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    {#if currentPage === "articles"}
-      <FilterBar
-        {sentiment}
-        {category}
-        {sourceId}
-        {search}
-        categories={CATEGORY_OPTIONS}
-        {sources}
-        on:change={handleFilterChange}
-      />
-
-      {#if error}
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
-          <div class="flex items-center justify-between">
-            <span>{error}</span>
-            <button
-              on:click={handleRetry}
-              class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
+    <nav class="nav" aria-label="Main navigation">
+      <button
+        on:click={() => (currentPage = "articles")}
+        class="nav-button"
+        class:nav-button-active={currentPage === "articles"}
+        aria-current={currentPage === "articles" ? "page" : undefined}
+      >
+        Articles
+      </button>
+      {#if $userStore}
+        <button
+          on:click={() => (currentPage = "bookmarks")}
+          class="nav-button"
+          class:nav-button-active={currentPage === "bookmarks"}
+          aria-current={currentPage === "bookmarks" ? "page" : undefined}
+        >
+          Bookmarks
+        </button>
+        <button
+          on:click={() => (currentPage = "analytics")}
+          class="nav-button"
+          class:nav-button-active={currentPage === "analytics"}
+          aria-current={currentPage === "analytics" ? "page" : undefined}
+        >
+          Analytics
+        </button>
       {/if}
+    </nav>
 
-      {#if loading}
-        <div class="text-center py-12">
-          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p class="mt-4 text-gray-600">Loading latest articles...</p>
-        </div>
+    <div class="header-right">
+      {#if $userStore}
+        <span class="user-email" title={$userStore.email ?? undefined}>{$userStore.email}</span>
+      {/if}
+      <button
+        class="theme-toggle"
+        on:click={toggleTheme}
+        aria-label="Toggle light/dark theme"
+        title="Toggle theme"
+      >
+        {$theme === "dark" ? "☀" : "☾"}
+      </button>
+      {#if $userStore}
+        <button class="btn" on:click={logout}>Logout</button>
       {:else}
-        <div class="mb-6">
-          <h2 class="text-xl font-semibold text-gray-900">
-            Latest Articles ({articles.length})
-          </h2>
-          <p class="text-gray-600">Recent news with sentiment analysis</p>
-        </div>
-
-        {#if articles.length === 0}
-          <div class="text-center py-12">
-            <p class="text-gray-600">
-              No articles match the current filters.
-            </p>
-          </div>
-        {:else}
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {#each articles as article (article.id)}
-              <ArticleCard
-                {article}
-                showBookmarkButton={!!$userStore}
-                isBookmarked={$bookmarkStore.bookmarkedIds.has(article.id)}
-                actionVariant="toggle"
-                on:bookmark={handleBookmarkToggle}
-              />
-            {/each}
-          </div>
-        {/if}
-
-        <Pagination
-          current={skip}
-          pageSize={limit}
-          {hasMore}
-          on:prev={handlePrevPage}
-          on:next={handleNextPage}
-        />
+        <button class="btn btn-primary" on:click={loginWithGoogle}>Sign in with Google</button>
       {/if}
-    {:else if currentPage === "bookmarks" && $userStore}
-      <BookmarksView />
-    {:else if currentPage === "analytics" && $userStore}
-      <Dashboard />
-    {:else}
-      <div class="text-center py-12">
-        <p class="text-gray-600">Please log in to access this page.</p>
+    </div>
+  </div>
+</header>
+
+<main class="main">
+  {#if currentPage === "articles"}
+    <FilterBar
+      {sentiment}
+      {category}
+      {sourceId}
+      {search}
+      categories={CATEGORY_OPTIONS}
+      {sources}
+      on:change={handleFilterChange}
+    />
+
+    {#if error}
+      <div class="error-banner" role="alert">
+        <span class="error-icon" aria-hidden="true">⚠</span>
+        <span style="flex:1">{error}</span>
+        <button class="btn" on:click={handleRetry}>Retry</button>
       </div>
     {/if}
-  </main>
-</div>
+
+    {#if loading}
+      <div style="text-align:center;padding:var(--sp-10) 0">
+        <div class="spinner"></div>
+        <p class="text-sec">Loading latest articles…</p>
+      </div>
+    {:else}
+      <div class="page-head">
+        <h1 class="page-title">
+          Latest Articles
+          <span class="text-ter" style="font-weight:400">({articles.length})</span>
+        </h1>
+        <p class="page-subtitle">Recent news with sentiment analysis</p>
+      </div>
+
+      {#if articles.length === 0}
+        <div class="empty-state">
+          <div class="empty-icon" aria-hidden="true">◳</div>
+          <p class="empty-title">No articles match these filters</p>
+          <p class="empty-sub">Try clearing a filter or broadening your search.</p>
+        </div>
+      {:else}
+        <div class="articles-grid">
+          {#each articles as article (article.id)}
+            <ArticleCard
+              {article}
+              showBookmarkButton={!!$userStore}
+              isBookmarked={$bookmarkStore.bookmarkedIds.has(article.id)}
+              actionVariant="toggle"
+              on:bookmark={handleBookmarkToggle}
+            />
+          {/each}
+        </div>
+      {/if}
+
+      <Pagination
+        current={skip}
+        pageSize={limit}
+        {hasMore}
+        on:prev={handlePrevPage}
+        on:next={handleNextPage}
+      />
+    {/if}
+  {:else if currentPage === "bookmarks" && $userStore}
+    <BookmarksView />
+  {:else if currentPage === "analytics" && $userStore}
+    <Dashboard />
+  {:else}
+    <div class="empty-state">
+      <div class="empty-icon" aria-hidden="true">◌</div>
+      <p class="empty-title">Sign in to continue</p>
+      <p class="empty-sub">This page needs an account. Sign in with Google to access it.</p>
+    </div>
+  {/if}
+</main>
+
+<style>
+  .articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: var(--sp-5);
+    margin-bottom: var(--sp-6);
+  }
+  .error-icon { font-size: 16px; flex-shrink: 0; }
+  @media (max-width: 768px) {
+    .articles-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,468 +1,362 @@
-/* Reset and base styles */
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+/* ===========================================================================
+   aiFeelNews — dark-first design-token system
+   Dark-first analytical data product. Design tokens drive the whole UI; a
+   single data-theme attribute on <html> swaps the colour system (no FOUC,
+   no JS class toggling). Brand accent is indigo-violet; sentiment is a
+   separate emerald / slate / rose scale so a sentiment colour can never be
+   confused with a brand colour.
+   =========================================================================== */
 
+/* ─── DESIGN TOKENS ──────────────────────────────────────────────────────── */
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  --accent:      #7C5CFC;
+  --accent-hover:#9070FD;
+  --accent-dim:  rgba(124, 92, 252, 0.15);
+  --accent-glow: 0 0 0 3px rgba(124, 92, 252, 0.35);
+
+  /* Sentiment scale — deliberately distinct from the brand accent */
+  --pos:     #34D399;
+  --pos-dim: rgba(52, 211, 153, 0.15);
+  --neu:     #94A3B8;
+  --neu-dim: rgba(148, 163, 184, 0.15);
+  --neg:     #FB7185;
+  --neg-dim: rgba(251, 113, 133, 0.15);
+
+  /* Spacing scale */
+  --sp-1: 4px;  --sp-2: 8px;  --sp-3: 12px; --sp-4: 16px;
+  --sp-5: 20px; --sp-6: 24px; --sp-8: 32px; --sp-10: 40px;
+
+  /* Radii */
+  --r-sm: 4px; --r-md: 6px; --r-lg: 10px; --r-xl: 14px;
+
+  /* Type */
+  --font-ui:   'Space Grotesk', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Courier New', monospace;
+
+  --transition: 0.18s ease;
 }
+
+[data-theme="dark"] {
+  --bg-app:    #0B0F17;
+  --bg-panel:  #111827;
+  --bg-raised: #1F2937;
+  --bg-hover:  #273244;
+  --border:    #273244;
+  --border-med:#374151;
+  --border-hi: #4B5563;
+  --text-pri:  #F8FAFC;
+  --text-sec:  #94A3B8;
+  --text-ter:  #64748B;
+  --shadow:    0 1px 3px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --skeleton-bg: #1F2937;
+  --skeleton-hi: #273244;
+}
+
+[data-theme="light"] {
+  --bg-app:    #F1F5F9;
+  --bg-panel:  #FFFFFF;
+  --bg-raised: #F8FAFC;
+  --bg-hover:  #F1F5F9;
+  --border:    #E2E8F0;
+  --border-med:#CBD5E1;
+  --border-hi: #94A3B8;
+  --text-pri:  #0F172A;
+  --text-sec:  #475569;
+  --text-ter:  #94A3B8;
+  --shadow:    0 1px 3px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.10);
+  --skeleton-bg: #E2E8F0;
+  --skeleton-hi: #CBD5E1;
+}
+
+/* ─── RESET + BASE ───────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 15px; scroll-behavior: smooth; }
 
 body {
-  margin: 0;
-  font-family: inherit;
-}
-
-/* Utility classes */
-.text-2xl { font-size: 1.5rem; }
-.text-xl { font-size: 1.25rem; }
-.text-lg { font-size: 1.125rem; }
-.text-sm { font-size: 0.875rem; }
-.text-xs { font-size: 0.75rem; }
-
-.font-bold { font-weight: 700; }
-.font-semibold { font-weight: 600; }
-.font-medium { font-weight: 500; }
-
-.text-gray-900 { color: #111827; }
-.text-gray-600 { color: #4b5563; }
-.text-gray-500 { color: #6b7280; }
-.text-gray-400 { color: #9ca3af; }
-.text-blue-600 { color: #2563eb; }
-.text-blue-800 { color: #1e40af; }
-.text-green-600 { color: #16a34a; }
-.text-red-600 { color: #dc2626; }
-.text-red-700 { color: #b91c1c; }
-.text-white { color: #ffffff; }
-
-.bg-gray-50 { background-color: #f9fafb; }
-.bg-white { background-color: #ffffff; }
-.bg-blue-600 { background-color: #2563eb; }
-.bg-blue-700 { background-color: #1d4ed8; }
-.bg-blue-100 { background-color: #dbeafe; }
-.bg-red-600 { background-color: #dc2626; }
-.bg-red-700 { background-color: #b91c1c; }
-.bg-red-100 { background-color: #fee2e2; }
-
-.min-h-screen { min-height: 100vh; }
-.max-w-7xl { max-width: 80rem; }
-.mx-auto { margin-left: auto; margin-right: auto; }
-
-.px-4 { padding-left: 1rem; padding-right: 1rem; }
-.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.p-6 { padding: 1.5rem; }
-
-.mb-2 { margin-bottom: 0.5rem; }
-.mb-3 { margin-bottom: 0.75rem; }
-.mb-4 { margin-bottom: 1rem; }
-.mb-6 { margin-bottom: 1.5rem; }
-.mt-4 { margin-top: 1rem; }
-
-.flex { display: flex; }
-.grid { display: grid; }
-.items-center { align-items: center; }
-.justify-between { justify-content: space-between; }
-.space-x-4 > * + * { margin-left: 1rem; }
-
-.h-16 { height: 4rem; }
-.h-12 { height: 3rem; }
-.w-12 { width: 3rem; }
-.h-5 { height: 1.25rem; }
-.w-5 { width: 1.25rem; }
-
-.rounded { border-radius: 0.375rem; }
-.rounded-md { border-radius: 0.375rem; }
-.rounded-lg { border-radius: 0.5rem; }
-.rounded-full { border-radius: 9999px; }
-
-.border { border-width: 1px; border-color: #d1d5db; }
-.border-b { border-bottom-width: 1px; border-bottom-color: #d1d5db; }
-.border-red-400 { border-color: #f87171; }
-
-.shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
-.shadow-md { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); }
-
-.hover\:bg-blue-700:hover { background-color: #1d4ed8; }
-.hover\:bg-red-700:hover { background-color: #b91c1c; }
-.hover\:text-blue-800:hover { color: #1e40af; }
-.hover\:text-gray-600:hover { color: #4b5563; }
-.hover\:shadow-md:hover { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); }
-
-.transition-shadow { transition: box-shadow 0.15s ease-in-out; }
-
-.text-center { text-align: center; }
-
-.gap-1 { gap: 0.25rem; }
-.gap-2 { gap: 0.5rem; }
-.gap-6 { gap: 1.5rem; }
-.flex-wrap { flex-wrap: wrap; }
-.mr-1 { margin-right: 0.25rem; }
-.mt-1 { margin-top: 0.25rem; }
-.bg-green-100 { background-color: #dcfce7; }
-.bg-gray-100 { background-color: #f3f4f6; }
-
-/* --- Sentiment bar --- */
-.sentiment-section {
-  border-top: 1px solid #e5e7eb;
-  padding-top: 0.75rem;
-}
-
-.sentiment-bar-track {
-  position: relative;
-  width: 100%;
-  height: 6px;
-  background-color: #e5e7eb;
-  border-radius: 3px;
-  overflow: visible;
-}
-
-.sentiment-bar-fill {
-  height: 100%;
-  border-radius: 3px;
-  transition: width 0.3s ease;
-  min-width: 2px;
-}
-
-.sentiment-bar-midpoint {
-  position: absolute;
-  top: -2px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 2px;
-  height: 10px;
-  background-color: #9ca3af;
-  border-radius: 1px;
-}
-
-.sentiment-explanation {
-  font-style: italic;
-}
-
-/* --- Category chips --- */
-.category-chip {
-  display: inline-flex;
-  align-items: center;
-  line-height: 1.5;
-  border: 1px solid #e5e7eb;
-  padding: 0 0.5rem;
-  border-radius: 0.375rem;
-  font-size: 0.75rem;
-  background-color: #f3f4f6;
-  color: #4b5563;
-}
-
-/* --- Entity chips --- */
-.entity-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  line-height: 1.5;
-  padding: 0 0.5rem;
-  border-radius: 0.375rem;
-  font-size: 0.75rem;
-  background-color: #eff6ff;
-  color: #1e40af;
-  border: 1px solid #bfdbfe;
-}
-
-.entity-chip-link {
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.entity-chip-link:hover {
-  background-color: #dbeafe;
-  border-color: #93c5fd;
-}
-
-.entity-type {
-  font-weight: 400;
-  opacity: 0.6;
-  font-size: 0.65rem;
-}
-
-/* --- Article card image --- */
-.card-image-wrapper {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-  border-radius: 0.5rem 0.5rem 0 0;
-  background: linear-gradient(135deg, #e5e7eb 0%, #d1d5db 50%, #e5e7eb 100%);
-  flex-shrink: 0;
-}
-
-.card-image {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.card-image-placeholder {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 50%, #d1d5db 100%);
-}
-
-.card-image-placeholder-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  color: #9ca3af;
-  opacity: 0.5;
-}
-
-.card-body {
-  padding: 1.5rem;
-}
-
-/* --- Source favicon --- */
-.source-favicon {
-  width: 20px;
-  height: 20px;
-  border-radius: 2px;
-  flex-shrink: 0;
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.source-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-}
-
-.overflow-hidden { overflow: hidden; }
-
-.animate-spin {
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-.border-b-2 { border-bottom-width: 2px; }
-
-/* --- Filter bar --- */
-.filter-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: center;
-  margin-bottom: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-}
-
-.filter-select,
-.search-input {
-  font-family: inherit;
-  font-size: 0.875rem;
-  padding: 0.4rem 0.6rem;
-  border-radius: 0.375rem;
-  border: 1px solid #d1d5db;
-  background-color: #ffffff;
-  color: #111827;
-  line-height: 1.25rem;
-  min-height: 2.25rem;
-}
-
-.filter-select {
-  min-width: 9rem;
-  cursor: pointer;
-}
-
-.search-input {
-  flex: 1 1 14rem;
-  min-width: 12rem;
-}
-
-.filter-select:focus,
-.search-input:focus {
-  outline: 2px solid #2563eb;
-  outline-offset: -1px;
-  border-color: #2563eb;
-}
-
-/* --- Pagination --- */
-.pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  margin-top: 2rem;
-  padding: 1rem 0;
-}
-
-.pagination-button {
-  font-family: inherit;
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
-  border: 1px solid #d1d5db;
-  background-color: #ffffff;
-  color: #1f2937;
-  cursor: pointer;
-  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-}
-
-.pagination-button:hover:not(:disabled) {
-  background-color: #f3f4f6;
-  border-color: #9ca3af;
-}
-
-.pagination-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  background-color: #f9fafb;
-  color: #9ca3af;
-}
-
-.pagination-page {
-  font-size: 0.875rem;
-  color: #4b5563;
-  min-width: 4rem;
-  text-align: center;
-}
-
-/* --- Top nav --- */
-.nav {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-button {
-  font-family: inherit;
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 0.375rem 0.75rem;
-  border-radius: 0.375rem;
-  border: 1px solid transparent;
-  background-color: transparent;
-  color: #4b5563;
-  cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease;
-}
-
-.nav-button:hover {
-  background-color: #f3f4f6;
-  color: #111827;
-}
-
-.nav-button-active,
-.nav-button-active:hover {
-  background-color: #dbeafe;
-  color: #1d4ed8;
-}
-
-/* --- Bookmark card remove button --- */
-.bookmark-card-remove {
-  font-family: inherit;
-  font-size: 0.75rem;
-  font-weight: 500;
-  padding: 0.25rem 0.6rem;
-  border-radius: 0.375rem;
-  border: 1px solid #fecaca;
-  background-color: #fee2e2;
-  color: #b91c1c;
-  cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease;
-}
-
-.bookmark-card-remove:hover {
-  background-color: #fecaca;
-  color: #7f1d1d;
-}
-
-@media (min-width: 768px) {
-  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-}
-
-@media (min-width: 1024px) {
-  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .lg\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  font-family: var(--font-ui);
+  background: var(--bg-app);
+  color: var(--text-pri);
   min-height: 100vh;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  transition: background var(--transition), color var(--transition);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+button { cursor: pointer; font-family: var(--font-ui); }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
-.card {
-  padding: 2em;
-}
+:focus-visible { outline: none; box-shadow: var(--accent-glow); }
 
-#app {
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-med); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-hi); }
+
+/* ─── LAYOUT PRIMITIVES ──────────────────────────────────────────────────── */
+.container {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 0 var(--sp-6);
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+.main {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--sp-8) var(--sp-6);
+}
+
+.page-head { margin-bottom: var(--sp-6); }
+.page-title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  color: var(--text-pri);
+}
+.page-subtitle {
+  font-size: 13px;
+  color: var(--text-sec);
+  margin-top: var(--sp-1);
+  line-height: 1.5;
+}
+
+/* ─── HEADER + NAV ───────────────────────────────────────────────────────── */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+}
+.header-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 var(--sp-6);
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+}
+.wordmark {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-pri);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.wordmark span { color: var(--accent); }
+
+.nav { display: flex; align-items: center; gap: 2px; }
+.nav-button {
+  background: none;
+  border: none;
+  padding: 6px 12px;
+  border-radius: var(--r-md);
+  font-size: 13px;
   font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
+  color: var(--text-sec);
+  transition: color var(--transition), background var(--transition);
+  white-space: nowrap;
 }
-button:hover {
-  border-color: #646cff;
+.nav-button:hover { color: var(--text-pri); background: var(--bg-hover); }
+.nav-button-active,
+.nav-button-active:hover { color: var(--accent); background: var(--accent-dim); }
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-left: auto;
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.user-email {
+  font-size: 12px;
+  color: var(--text-sec);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* ─── BUTTONS ────────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--r-md);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--font-ui);
+  transition: all var(--transition);
+  border: 1px solid var(--border-med);
+  background: var(--bg-raised);
+  color: var(--text-sec);
+}
+.btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-pri);
+  border-color: var(--border-hi);
+  text-decoration: none;
+}
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
+}
+
+.theme-toggle {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-med);
+  background: var(--bg-raised);
+  color: var(--text-sec);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  transition: all var(--transition);
+}
+.theme-toggle:hover { background: var(--bg-hover); border-color: var(--border-hi); }
+
+/* ─── SURFACES ───────────────────────────────────────────────────────────── */
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow);
+}
+
+/* ─── FORM CONTROLS ──────────────────────────────────────────────────────── */
+select,
+input[type="text"],
+input[type="search"] {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-med);
+  border-radius: var(--r-md);
+  color: var(--text-pri);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  padding: 6px 10px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+  appearance: none;
+  -webkit-appearance: none;
+}
+select {
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none' viewBox='0 0 10 6'%3E%3Cpath stroke='%2394A3B8' stroke-width='1.5' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  cursor: pointer;
+}
+select:focus,
+input[type="text"]:focus,
+input[type="search"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+/* The native option popup is rendered by the OS, which ignores most theming.
+   Pin explicit colours so the list text stays legible in either theme rather
+   than inheriting an OS default that can clash (e.g. light text on light). */
+select option {
+  background: var(--bg-panel);
+  color: var(--text-pri);
+}
+
+/* ─── ERROR / EMPTY / LOADING STATES ─────────────────────────────────────── */
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--neg-dim);
+  border: 1px solid rgba(251, 113, 133, 0.25);
+  border-radius: var(--r-lg);
+  color: var(--neg);
+  font-size: 13px;
+  margin-bottom: var(--sp-5);
+}
+
+.empty-state {
+  text-align: center;
+  padding: var(--sp-10) var(--sp-6);
+  border: 1px dashed var(--border-med);
+  border-radius: var(--r-xl);
+  margin-top: var(--sp-5);
+}
+.empty-icon { font-size: 36px; margin-bottom: var(--sp-4); opacity: 0.3; }
+.empty-title { font-size: 16px; font-weight: 600; color: var(--text-pri); margin-bottom: 6px; }
+.empty-sub { font-size: 13px; color: var(--text-sec); }
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 2px solid var(--border);
+  border-bottom-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto var(--sp-4);
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ─── SKELETON ───────────────────────────────────────────────────────────── */
+@keyframes shimmer {
+  0%   { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+.skeleton {
+  background: linear-gradient(90deg, var(--skeleton-bg) 25%, var(--skeleton-hi) 50%, var(--skeleton-bg) 75%);
+  background-size: 800px 100%;
+  animation: shimmer 1.6s infinite linear;
+  border-radius: var(--r-md);
+}
+
+/* ─── SENTIMENT PRIMITIVES (shared by cards + dashboard) ─────────────────── */
+.sentiment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: var(--r-sm);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.sentiment-chip.pos { background: var(--pos-dim); color: var(--pos); border: 1px solid rgba(52, 211, 153, 0.25); }
+.sentiment-chip.neu { background: var(--neu-dim); color: var(--neu); border: 1px solid rgba(148, 163, 184, 0.25); }
+.sentiment-chip.neg { background: var(--neg-dim); color: var(--neg); border: 1px solid rgba(251, 113, 133, 0.25); }
+.chip-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.pos .chip-dot { background: var(--pos); }
+.neu .chip-dot { background: var(--neu); }
+.neg .chip-dot { background: var(--neg); }
+
+/* ─── UTILITIES (minimal, token-backed) ──────────────────────────────────── */
+.mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.text-sec { color: var(--text-sec); }
+.text-ter { color: var(--text-ter); }
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
 }

--- a/frontend/src/lib/ArticleCard.svelte
+++ b/frontend/src/lib/ArticleCard.svelte
@@ -25,34 +25,24 @@
   }>();
 
   // ── Sentiment helpers ──────────────────────────────────────────────
+  // The sentiment scale (emerald / slate / rose) is intentionally distinct
+  // from the indigo brand accent, so a sentiment colour can never read as a
+  // brand colour. `sentimentClass` maps a label to the shared chip modifier
+  // (.pos / .neu / .neg in app.css); the score bar reads the same token vars.
 
-  function getSentimentColor(label?: string | null): string {
-    if (!label) return "text-gray-500";
-    switch (label.toLowerCase()) {
-      case "positive": return "text-green-600";
-      case "negative": return "text-red-600";
-      case "neutral":  return "text-blue-600";
-      default:         return "text-gray-500";
-    }
-  }
-
-  function getSentimentBgColor(label?: string | null): string {
-    if (!label) return "bg-gray-100";
-    switch (label.toLowerCase()) {
-      case "positive": return "bg-green-100";
-      case "negative": return "bg-red-100";
-      case "neutral":  return "bg-blue-100";
-      default:         return "bg-gray-100";
+  function sentimentClass(label?: string | null): "pos" | "neu" | "neg" {
+    switch ((label ?? "").toLowerCase()) {
+      case "positive": return "pos";
+      case "negative": return "neg";
+      default:         return "neu";
     }
   }
 
   function getSentimentBarColor(label?: string | null): string {
-    if (!label) return "#9ca3af";
-    switch (label.toLowerCase()) {
-      case "positive": return "#16a34a";
-      case "negative": return "#dc2626";
-      case "neutral":  return "#2563eb";
-      default:         return "#9ca3af";
+    switch ((label ?? "").toLowerCase()) {
+      case "positive": return "var(--pos)";
+      case "negative": return "var(--neg)";
+      default:         return "var(--neu)";
     }
   }
 
@@ -144,7 +134,7 @@
   }
 </script>
 
-<div class="bg-white rounded-lg shadow-sm border overflow-hidden hover:shadow-md transition-shadow">
+<article class="card">
   <!-- Article image / placeholder -->
   <div class="card-image-wrapper">
     <div class="card-image-placeholder">
@@ -167,72 +157,71 @@
     {/if}
   </div>
 
-  <div class="card-body">
-    <!-- Source (with favicon) -->
-    <div class="flex items-center justify-between mb-3">
-      <span class="source-badge text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded">
-        {#if getDomain(article.url)}
-          <img
-            src={getFaviconUrl(article.url)}
-            alt=""
-            class="source-favicon"
-            loading="lazy"
-            on:error={handleImageError}
-          />
-        {/if}
-        {article.source?.name || `Source #${article.source?.id || "Unknown"}`}
-      </span>
-      <span class="text-xs text-gray-500">{formatDate(article.published_at)}</span>
-    </div>
+  <div class="card-meta">
+    <span class="source-badge">
+      {#if getDomain(article.url)}
+        <img
+          src={getFaviconUrl(article.url)}
+          alt=""
+          class="source-favicon"
+          loading="lazy"
+          on:error={handleImageError}
+        />
+      {/if}
+      {article.source?.name || `Source #${article.source?.id || "Unknown"}`}
+    </span>
+    <span class="pub-date mono">{formatDate(article.published_at)}</span>
+  </div>
 
+  <div class="card-body">
     <!-- Title -->
-    <h3 class="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
-      {article.title}
-    </h3>
+    <h3 class="card-title">{article.title}</h3>
 
     <!-- Description -->
     {#if article.description}
-      <p class="text-gray-600 text-sm mb-3 line-clamp-3">
-        {article.description}
-      </p>
+      <p class="card-desc">{article.description}</p>
     {/if}
 
     <!-- Sentiment analysis -->
     {#if article.sentiment_label && article.sentiment_score !== null && article.sentiment_score !== undefined}
-      <div class="sentiment-section mb-3">
-        <div class="flex items-center justify-between mb-2">
-          <span class="text-xs font-semibold px-2 rounded {getSentimentBgColor(article.sentiment_label)} {getSentimentColor(article.sentiment_label)}">
-            {article.sentiment_label.toUpperCase()}
+      <div class="sentiment-box" aria-label="Sentiment analysis">
+        <div class="sentiment-row">
+          <span class="sentiment-chip {sentimentClass(article.sentiment_label)}">
+            <span class="chip-dot" aria-hidden="true"></span>
+            {article.sentiment_label}
           </span>
           <span
-            class="text-xs text-gray-500"
+            class="sentiment-score mono"
             title="Sentiment score from -1.0 (very negative) to 1.0 (very positive)"
           >
-            Score: {article.sentiment_score.toFixed(2)}
+            {article.sentiment_score > 0 ? "+" : ""}{article.sentiment_score.toFixed(2)}
           </span>
         </div>
 
-        <div class="sentiment-bar-track">
+        <div class="score-bar">
+          <div class="score-bar-mid"></div>
           <div
-            class="sentiment-bar-fill"
-            style="width: {sentimentScoreToPercent(article.sentiment_score)}%; background-color: {getSentimentBarColor(article.sentiment_label)};"
+            class="score-bar-fill"
+            style="width: {Math.abs(sentimentScoreToPercent(article.sentiment_score) - 50)}%;
+                   {article.sentiment_score >= 0 ? 'left:50%' : `left:${sentimentScoreToPercent(article.sentiment_score)}%`};
+                   background: {getSentimentBarColor(article.sentiment_label)};"
           ></div>
-          <div class="sentiment-bar-midpoint"></div>
         </div>
 
-        <p class="text-xs text-gray-400 mt-1 sentiment-explanation">
-          {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
-        </p>
+        {#if getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
+          <p class="sentiment-note">
+            {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
+          </p>
+        {/if}
       </div>
     {/if}
 
     <!-- Content categories -->
     {#if getTopCategories(article.article_categories).length > 0}
-      <div class="flex items-center flex-wrap gap-1 mb-2">
-        <span class="text-xs text-gray-400 mr-1">Topics:</span>
+      <div class="chips-row" aria-label="Topics">
         {#each getTopCategories(article.article_categories) as cat}
           <span
-            class="category-chip"
+            class="chip chip-topic"
             title="Category: {cat.name} (confidence: {(cat.confidence * 100).toFixed(0)}%)"
           >
             {formatCategoryName(cat.name)}
@@ -243,15 +232,14 @@
 
     <!-- Key entities -->
     {#if getTopEntities(article.article_entities).length > 0}
-      <div class="flex items-center flex-wrap gap-1 mb-3">
-        <span class="text-xs text-gray-400 mr-1">Entities:</span>
+      <div class="chips-row" aria-label="Named entities">
         {#each getTopEntities(article.article_entities) as ae}
           {#if ae.entity.wikipedia_url}
             <a
               href={ae.entity.wikipedia_url}
               target="_blank"
               rel="noopener noreferrer"
-              class="entity-chip entity-chip-link"
+              class="chip chip-entity"
               title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
             >
               {ae.entity.name}
@@ -259,7 +247,7 @@
             </a>
           {:else}
             <span
-              class="entity-chip"
+              class="chip chip-entity"
               title="{ae.entity.name} ({ae.entity.type}) — Relevance: {(ae.salience * 100).toFixed(0)}%, Mentions: {ae.mention_count}"
             >
               {ae.entity.name}
@@ -269,64 +257,238 @@
         {/each}
       </div>
     {/if}
-
-    <!-- Actions -->
-    <div class="flex items-center justify-between">
-      <a
-        href={article.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-blue-600 hover:text-blue-800 text-sm font-medium"
-      >
-        Read Article →
-      </a>
-
-      {#if showBookmarkButton && actionVariant === "toggle"}
-        <button
-          on:click={handleBookmarkClick}
-          class="text-gray-400 hover:text-gray-600"
-          aria-label={isBookmarked ? "Remove bookmark" : "Bookmark this article"}
-          aria-pressed={isBookmarked}
-          title={isBookmarked ? "Remove bookmark" : "Bookmark this article"}
-        >
-          <svg
-            class="w-5 h-5"
-            fill={isBookmarked ? "currentColor" : "none"}
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
-          </svg>
-        </button>
-      {:else if actionVariant === "remove"}
-        <button
-          on:click={handleRemoveClick}
-          class="bookmark-card-remove"
-          aria-label="Remove bookmark"
-          title="Remove bookmark"
-          type="button"
-        >
-          ✕ Remove
-        </button>
-      {/if}
-    </div>
   </div>
-</div>
+
+  <!-- Footer / actions -->
+  <div class="card-footer">
+    <a
+      href={article.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="read-link"
+    >
+      Read Article →
+    </a>
+
+    {#if showBookmarkButton && actionVariant === "toggle"}
+      <button
+        on:click={handleBookmarkClick}
+        class="bookmark-btn"
+        class:bookmarked={isBookmarked}
+        aria-label={isBookmarked ? "Remove bookmark" : "Bookmark this article"}
+        aria-pressed={isBookmarked}
+        title={isBookmarked ? "Remove bookmark" : "Bookmark this article"}
+      >
+        <svg viewBox="0 0 24 24" fill={isBookmarked ? "currentColor" : "none"} stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+        </svg>
+      </button>
+    {:else if actionVariant === "remove"}
+      <button
+        on:click={handleRemoveClick}
+        class="bookmark-card-remove"
+        aria-label="Remove bookmark"
+        title="Remove bookmark"
+        type="button"
+      >
+        ✕ Remove
+      </button>
+    {/if}
+  </div>
+</article>
 
 <style>
-  .line-clamp-2 {
+  .card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xl);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow);
+    transition: box-shadow var(--transition), border-color var(--transition), transform var(--transition);
+  }
+  .card:hover {
+    border-color: var(--border-med);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+  }
+
+  .card-image-wrapper {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: linear-gradient(135deg, var(--bg-raised) 0%, var(--bg-hover) 100%);
+  }
+  .card-image { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+  .card-image-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .card-image-placeholder-icon { width: 2.25rem; height: 2.25rem; color: var(--text-ter); opacity: 0.4; }
+
+  .card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--sp-3) var(--sp-4) 0;
+  }
+  .source-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-sec);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .source-favicon { width: 16px; height: 16px; border-radius: 3px; flex-shrink: 0; }
+  .pub-date { font-size: 11px; color: var(--text-ter); }
+
+  .card-body {
+    padding: var(--sp-3) var(--sp-4);
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+  .card-title {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: -0.01em;
+    color: var(--text-pri);
     display: -webkit-box;
-    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     line-clamp: 2;
     overflow: hidden;
   }
-
-  .line-clamp-3 {
+  .card-desc {
+    font-size: 13px;
+    color: var(--text-sec);
+    line-height: 1.55;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
     line-clamp: 3;
     overflow: hidden;
   }
+
+  /* Sentiment block */
+  .sentiment-box {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: var(--sp-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+  }
+  .sentiment-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); }
+  .sentiment-score { font-size: 12px; font-weight: 600; color: var(--text-pri); white-space: nowrap; }
+
+  .score-bar {
+    position: relative;
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .score-bar-mid {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    width: 1px;
+    height: 100%;
+    background: var(--border-hi);
+    transform: translateX(-0.5px);
+    z-index: 1;
+  }
+  .score-bar-fill { position: absolute; top: 0; height: 100%; border-radius: 2px; }
+  .sentiment-note { font-size: 11px; font-style: italic; color: var(--text-ter); line-height: 1.4; }
+
+  /* Chips */
+  .chips-row { display: flex; flex-wrap: wrap; gap: 5px; }
+  .chip {
+    padding: 2px 7px;
+    border-radius: 3px;
+    font-size: 11px;
+    font-weight: 500;
+    border: 1px solid;
+    white-space: nowrap;
+  }
+  .chip-topic {
+    background: var(--accent-dim);
+    color: var(--accent);
+    border-color: rgba(124, 92, 252, 0.25);
+  }
+  .chip-entity {
+    background: var(--bg-raised);
+    color: var(--text-sec);
+    border-color: var(--border-med);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .chip-entity:hover { border-color: var(--border-hi); text-decoration: none; }
+  .entity-type {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-ter);
+  }
+
+  /* Footer */
+  .card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--sp-3) var(--sp-4);
+    border-top: 1px solid var(--border);
+    margin-top: auto;
+  }
+  .read-link {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+    transition: gap var(--transition);
+  }
+  .read-link:hover { text-decoration: none; opacity: 0.85; }
+
+  .bookmark-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--r-md);
+    background: none;
+    border: 1px solid var(--border-med);
+    color: var(--text-ter);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition);
+  }
+  .bookmark-btn svg { width: 15px; height: 15px; }
+  .bookmark-btn:hover { color: var(--accent); border-color: var(--accent); background: var(--accent-dim); }
+  .bookmark-btn.bookmarked { color: var(--accent); border-color: var(--accent); background: var(--accent-dim); }
+
+  .bookmark-card-remove {
+    font-size: 12px;
+    font-weight: 600;
+    font-family: var(--font-ui);
+    padding: 4px 10px;
+    border-radius: var(--r-md);
+    border: 1px solid rgba(251, 113, 133, 0.3);
+    background: var(--neg-dim);
+    color: var(--neg);
+    transition: background var(--transition);
+  }
+  .bookmark-card-remove:hover { background: rgba(251, 113, 133, 0.28); }
 </style>

--- a/frontend/src/lib/BookmarksView.svelte
+++ b/frontend/src/lib/BookmarksView.svelte
@@ -117,46 +117,39 @@
   });
 </script>
 
-<div class="mb-6">
-  <h2 class="text-xl font-semibold text-gray-900">Your Bookmarks</h2>
-  <p class="text-gray-600">Articles you've saved for later</p>
+<div class="page-head">
+  <h1 class="page-title">Your Bookmarks</h1>
+  <p class="page-subtitle">Articles you've saved for later</p>
 </div>
 
 {#if !$userStore}
-  <div class="text-center py-12">
-    <p class="text-gray-600 mb-4">Please sign in to view your bookmarks.</p>
-    <button
-      on:click={loginWithGoogle}
-      class="bg-blue-600 text-white px-4 py-2 rounded-md text-sm hover:bg-blue-700"
-    >
-      Login with Google
+  <div class="empty-state">
+    <div class="empty-icon" aria-hidden="true">◌</div>
+    <p class="empty-title">Sign in to see your bookmarks</p>
+    <p class="empty-sub">Bookmarks are tied to your account.</p>
+    <button class="btn btn-primary" style="margin-top:var(--sp-4)" on:click={loginWithGoogle}>
+      Sign in with Google
     </button>
   </div>
 {:else if error}
-  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
-    <div class="flex items-center justify-between">
-      <span>Couldn't load bookmarks. {error}</span>
-      <button
-        on:click={handleRetry}
-        class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
-      >
-        Retry
-      </button>
-    </div>
+  <div class="error-banner" role="alert">
+    <span class="error-icon" aria-hidden="true">⚠</span>
+    <span style="flex:1">Couldn't load bookmarks. {error}</span>
+    <button class="btn" on:click={handleRetry}>Retry</button>
   </div>
 {:else if loading}
-  <div class="text-center py-12">
-    <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-    <p class="mt-4 text-gray-600">Loading your bookmarks...</p>
+  <div style="text-align:center;padding:var(--sp-10) 0">
+    <div class="spinner"></div>
+    <p class="text-sec">Loading your bookmarks…</p>
   </div>
 {:else if items.length === 0}
-  <div class="text-center py-12">
-    <p class="text-gray-600">
-      No bookmarks yet. Click the 🔖 icon on any article in the feed to save it here.
-    </p>
+  <div class="empty-state">
+    <div class="empty-icon" aria-hidden="true">◻</div>
+    <p class="empty-title">No bookmarks yet</p>
+    <p class="empty-sub">Click the bookmark icon on any article in the feed to save it here.</p>
   </div>
 {:else}
-  <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+  <div class="articles-grid">
     {#each items as item (item.bookmark.id)}
       <ArticleCard
         article={item.article}
@@ -168,3 +161,15 @@
     {/each}
   </div>
 {/if}
+
+<style>
+  .articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: var(--sp-5);
+  }
+  .error-icon { font-size: 16px; flex-shrink: 0; }
+  @media (max-width: 768px) {
+    .articles-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -19,6 +19,7 @@
     type TopEntity,
     type NlpCategoryBreakdown,
   } from './api';
+  import { theme } from './theme';
 
   Chart.register(...registerables);
 
@@ -110,7 +111,22 @@
   let bqEntityCanvas: HTMLCanvasElement;
   let bqCatCanvas: HTMLCanvasElement;
 
+  // Resolve theme-aware chart colours from the live CSS custom properties so
+  // the charts follow the dark/light token system instead of hardcoding.
+  function themeVars(): { grid: string; tick: string; panel: string; border: string; text: string } {
+    const css = getComputedStyle(document.documentElement);
+    const v = (name: string, fallback: string) => css.getPropertyValue(name).trim() || fallback;
+    return {
+      grid: 'rgba(148,163,184,0.15)',
+      tick: v('--text-sec', '#94A3B8'),
+      panel: v('--bg-panel', '#111827'),
+      border: v('--border', '#273244'),
+      text: v('--text-pri', '#F8FAFC'),
+    };
+  }
+
   function baseOptions(indexAxis: 'x' | 'y' = 'x'): Record<string, unknown> {
+    const tv = themeVars();
     return {
       indexAxis,
       responsive: true,
@@ -118,11 +134,19 @@
       interaction: { mode: 'index', intersect: false },
       plugins: {
         legend: { display: false },
-        tooltip: { padding: 10, cornerRadius: 6 },
+        tooltip: {
+          padding: 10,
+          cornerRadius: 6,
+          backgroundColor: tv.panel,
+          borderColor: tv.border,
+          borderWidth: 1,
+          titleColor: tv.text,
+          bodyColor: tv.tick,
+        },
       },
       scales: {
-        x: { grid: { color: 'rgba(148,163,184,0.15)' }, ticks: { color: '#64748b' } },
-        y: { grid: { color: 'rgba(148,163,184,0.15)' }, ticks: { color: '#64748b' } },
+        x: { grid: { color: tv.grid }, ticks: { color: tv.tick } },
+        y: { grid: { color: tv.grid }, ticks: { color: tv.tick } },
       },
     };
   }
@@ -279,7 +303,7 @@
     opts.scales.x.stacked = true;
     opts.scales.y.stacked = true;
     opts.scales.y.beginAtZero = true;
-    opts.plugins.legend = { display: true, position: 'bottom', labels: { color: '#64748b', boxWidth: 10 } };
+    opts.plugins.legend = { display: true, position: 'bottom', labels: { color: themeVars().tick, boxWidth: 10 } };
 
     breakdownChart = new Chart(breakdownCanvas, {
       type: 'bar',
@@ -312,7 +336,7 @@
 
     const opts = baseOptions('y') as Record<string, any>;
     opts.scales.y.grid = { display: false };
-    opts.scales.x.ticks = { color: '#64748b', callback: (v: number) => `${v}%` };
+    opts.scales.x.ticks = { color: themeVars().tick, callback: (v: number) => `${v}%` };
     opts.plugins.tooltip.callbacks = {
       label: (ctx: any) => {
         const e = picks[ctx.dataIndex];
@@ -350,7 +374,7 @@
 
     const opts = baseOptions('x') as Record<string, any>;
     opts.scales.y.beginAtZero = true;
-    opts.plugins.legend = { display: true, position: 'bottom', labels: { color: '#64748b', boxWidth: 10 } };
+    opts.plugins.legend = { display: true, position: 'bottom', labels: { color: themeVars().tick, boxWidth: 10 } };
 
     catChart = new Chart(catCanvas, {
       type: 'line',
@@ -429,24 +453,35 @@
     loadData();
   }
 
+  let mounted = false;
+
   onMount(() => {
-    Chart.defaults.font.family = "Inter, system-ui, sans-serif";
+    Chart.defaults.font.family = "'Space Grotesk', system-ui, sans-serif";
     Chart.defaults.font.size = 11;
+    mounted = true;
     loadData();
   });
   onDestroy(() => destroyCharts());
+
+  // Re-render the charts when the theme flips so grid/tick/tooltip colours
+  // follow the token system. Guarded by `mounted` + data presence so it never
+  // fires before the first load.
+  $: if (mounted && $theme && !loading && rolling.length >= 0) {
+    void $theme;
+    renderCharts();
+  }
 </script>
 
 <div class="dashboard">
   <div class="controls">
     <div>
-      <h2 class="text-xl font-semibold text-gray-900">Analytics Dashboard</h2>
-      <p class="text-sm text-gray-500">
+      <h2 class="page-title">Analytics Dashboard</h2>
+      <p class="page-subtitle">
         Sentiment scored by Google's Natural Language AI on every ingested
         article, then aggregated live from the database.
       </p>
     </div>
-    <select on:change={handleDaysChange} value={days} class="select" aria-label="Time range">
+    <select on:change={handleDaysChange} value={days} aria-label="Time range">
       <option value={7}>Last 7 days</option>
       <option value={30}>Last 30 days</option>
       <option value={90}>Last 90 days</option>
@@ -455,13 +490,16 @@
   </div>
 
   {#if error}
-    <div class="error-banner" role="alert">{error}</div>
+    <div class="error-banner" role="alert">
+      <span class="error-icon" aria-hidden="true">⚠</span>
+      <span style="flex:1">{error}</span>
+    </div>
   {/if}
 
   {#if loading}
-    <div class="loading">
+    <div style="text-align:center;padding:var(--sp-10) 0">
       <div class="spinner"></div>
-      <p class="text-gray-600">Loading analytics…</p>
+      <p class="text-sec">Loading analytics…</p>
     </div>
   {:else}
     <!-- KPI tiles (derived from the GROUPING SETS grand-total + subtotals) -->
@@ -494,7 +532,6 @@
         <p class="chart-sub">
           How positive or negative the news has felt each day. The bold line is a
           7-day rolling average that smooths out daily noise to reveal the trend.
-          <span class="method-tag" title="PostgreSQL window function">SQL window function</span>
         </p>
         {#if rolling.length}
           <div class="chart-wrap"><canvas bind:this={rollingCanvas}></canvas></div>
@@ -508,7 +545,6 @@
         <p class="chart-sub">
           News outlets ranked by the average sentiment of their coverage. Hover a
           bar for its rank, article count, and how much its tone varies.
-          <span class="method-tag" title="Common Table Expression + RANK() window function">SQL CTE + RANK()</span>
         </p>
         {#if ranked.length}
           <div class="chart-wrap"><canvas bind:this={rankedCanvas}></canvas></div>
@@ -522,7 +558,6 @@
         <p class="chart-sub">
           The mix of positive, neutral, and negative articles within each news
           category.
-          <span class="method-tag" title="GROUPING SETS aggregation">SQL GROUPING SETS</span>
         </p>
         {#if breakdown.length}
           <div class="chart-wrap"><canvas bind:this={breakdownCanvas}></canvas></div>
@@ -536,7 +571,6 @@
         <p class="chart-sub">
           People and organizations gaining or losing coverage compared with the
           previous period. Green is rising, rose is falling.
-          <span class="method-tag" title="Two CTEs joined with a FULL OUTER JOIN">SQL period-over-period join</span>
         </p>
         {#if momentum.length}
           <div class="chart-wrap"><canvas bind:this={momentumCanvas}></canvas></div>
@@ -550,7 +584,6 @@
         <p class="chart-sub">
           Total articles accumulated per category over time — steeper lines mean
           a topic is being covered more heavily.
-          <span class="method-tag" title="Running total via SUM() OVER (PARTITION BY)">SQL running total</span>
         </p>
         {#if catDaily.length}
           <div class="chart-wrap"><canvas bind:this={catCanvas}></canvas></div>
@@ -605,61 +638,32 @@
 
 <style>
   .dashboard { padding: 0; }
+  .error-icon { font-size: 16px; flex-shrink: 0; }
 
   .controls {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    margin-bottom: 1.5rem;
-    gap: 1rem;
+    margin-bottom: var(--sp-6);
+    gap: var(--sp-4);
     flex-wrap: wrap;
   }
-
-  .select {
-    padding: 0.5rem 1rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    background: white;
-    font-size: 0.875rem;
-    cursor: pointer;
-  }
-
-  .error-banner {
-    background: #fef2f2;
-    border: 1px solid #fca5a5;
-    color: #b91c1c;
-    padding: 0.75rem 1rem;
-    border-radius: 0.375rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .loading { text-align: center; padding: 3rem 0; }
-
-  .spinner {
-    width: 3rem; height: 3rem;
-    border: 2px solid transparent;
-    border-bottom-color: #7C5CFC;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-    margin: 0 auto 1rem;
-  }
-  @keyframes spin { to { transform: rotate(360deg); } }
 
   /* KPI row */
   .kpi-row {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 0.75rem;
-    margin-bottom: 1.5rem;
+    gap: var(--sp-3);
+    margin-bottom: var(--sp-6);
   }
   .kpi-tile {
     position: relative;
     overflow: hidden;
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.625rem;
-    padding: 1rem 1.25rem;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-4) var(--sp-5);
+    box-shadow: var(--shadow);
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
@@ -669,27 +673,29 @@
     position: absolute;
     top: 0; left: 0; right: 0;
     height: 2px;
-    background: var(--accent, #e5e7eb);
+    background: var(--accent, var(--border));
   }
   .kpi-label {
     font-size: 0.6875rem;
     font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #94a3b8;
+    color: var(--text-ter);
   }
   .kpi-value {
     font-size: 1.625rem;
-    font-weight: 700;
+    font-weight: 600;
     line-height: 1;
-    color: #18181b;
+    color: var(--text-pri);
+    font-family: var(--font-mono);
     font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
   }
 
   .grid-2 {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 1.25rem;
+    gap: var(--sp-5);
   }
   @media (min-width: 900px) {
     .grid-2 { grid-template-columns: 1fr 1fr; }
@@ -697,39 +703,26 @@
   }
 
   .card {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.625rem;
-    padding: 1.25rem;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xl);
+    padding: var(--sp-5);
+    box-shadow: var(--shadow);
   }
 
   .chart-title {
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     font-weight: 600;
-    color: #18181b;
+    color: var(--text-pri);
+    letter-spacing: -0.01em;
   }
   .chart-sub {
     font-size: 0.75rem;
-    color: #94a3b8;
-    margin: 0.15rem 0 0.75rem;
-    line-height: 1.5;
-  }
-
-  /* Quiet technical footnote: names the SQL technique for the curious /
-     the Relational-DB assessment, without cluttering the plain-language copy. */
-  .method-tag {
-    display: inline-block;
-    font-size: 0.625rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    color: #7C5CFC;
-    background: rgba(124,92,252,0.10);
-    border: 1px solid rgba(124,92,252,0.20);
-    padding: 0.05rem 0.4rem;
-    border-radius: 4px;
-    white-space: nowrap;
-    vertical-align: middle;
+    color: var(--text-ter);
+    margin: 0.25rem 0 0.9rem;
+    line-height: 1.6;
+    /* a hair of padding so descenders (y, g, p) clear the next element */
+    padding-bottom: 1px;
   }
 
   .chart-wrap { position: relative; height: 260px; }
@@ -739,23 +732,25 @@
     text-align: center;
     padding: 2.5rem 0;
     font-size: 0.875rem;
-    color: #94a3b8;
+    color: var(--text-ter);
   }
 
   .bq-header {
     display: flex;
     align-items: center;
-    gap: 0.625rem;
-    margin: 1.75rem 0 1rem;
+    justify-content: space-between;
+    gap: var(--sp-4);
+    flex-wrap: wrap;
+    margin: var(--sp-8) 0 var(--sp-4);
   }
   .bq-badge {
     font-size: 0.625rem;
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #7C5CFC;
-    background: rgba(124,92,252,0.12);
-    border: 1px solid rgba(124,92,252,0.25);
+    color: var(--accent);
+    background: var(--accent-dim);
+    border: 1px solid rgba(124, 92, 252, 0.25);
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
   }

--- a/frontend/src/lib/FilterBar.svelte
+++ b/frontend/src/lib/FilterBar.svelte
@@ -52,7 +52,7 @@
   }
 </script>
 
-<div class="filter-bar">
+<div class="filter-bar" role="search" aria-label="Filter articles">
   <select
     class="filter-select"
     bind:value={sentiment}
@@ -89,12 +89,52 @@
     {/each}
   </select>
 
-  <input
-    type="search"
-    class="search-input"
-    placeholder="Search titles..."
-    value={search}
-    on:input={handleSearchInput}
-    aria-label="Search article titles"
-  />
+  <div class="search-wrap">
+    <span class="search-icon" aria-hidden="true">⌕</span>
+    <input
+      type="search"
+      class="search-input"
+      placeholder="Search titles…"
+      value={search}
+      on:input={handleSearchInput}
+      aria-label="Search article titles"
+    />
+  </div>
 </div>
+
+<style>
+  .filter-bar {
+    display: flex;
+    align-items: center;
+    /* row-gap > column-gap so wrapped rows aren't cramped together */
+    gap: var(--sp-3) var(--sp-4);
+    flex-wrap: wrap;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-4) var(--sp-5);
+    margin-bottom: var(--sp-6);
+    box-shadow: var(--shadow);
+  }
+  .filter-select {
+    min-width: 8rem;
+    flex: 0 1 auto;
+  }
+  .search-wrap {
+    position: relative;
+    flex: 1 1 200px;
+    min-width: 180px;
+    max-width: 320px;
+    margin-left: auto;
+  }
+  .search-wrap .search-input { width: 100%; padding-left: 30px; }
+  .search-icon {
+    position: absolute;
+    left: 9px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-ter);
+    font-size: 14px;
+    pointer-events: none;
+  }
+</style>

--- a/frontend/src/lib/Pagination.svelte
+++ b/frontend/src/lib/Pagination.svelte
@@ -30,7 +30,7 @@
   >
     ← Prev
   </button>
-  <span class="pagination-page">Page {pageNumber}</span>
+  <span class="pagination-page mono">Page {pageNumber}</span>
   <button
     class="pagination-button"
     disabled={nextDisabled}
@@ -41,3 +41,39 @@
     Next →
   </button>
 </nav>
+
+<style>
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--sp-3);
+    padding: var(--sp-4) 0;
+  }
+  .pagination-button {
+    padding: 6px 14px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border-med);
+    background: var(--bg-raised);
+    color: var(--text-sec);
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font-ui);
+    transition: all var(--transition);
+  }
+  .pagination-button:hover:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: var(--accent-dim);
+  }
+  .pagination-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .pagination-page {
+    font-size: 13px;
+    color: var(--text-sec);
+    min-width: 5rem;
+    text-align: center;
+  }
+</style>

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,36 @@
+import { writable } from "svelte/store";
+
+export type Theme = "dark" | "light";
+
+const STORAGE_KEY = "aifeelnews-theme";
+
+function readInitial(): Theme {
+  if (typeof window === "undefined") return "dark";
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "dark" || stored === "light") return stored;
+  // Default to dark (the design is dark-first); honour an explicit OS light pref.
+  const prefersLight = window.matchMedia?.("(prefers-color-scheme: light)").matches;
+  return prefersLight ? "light" : "dark";
+}
+
+function applyTheme(theme: Theme): void {
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+}
+
+const initial = readInitial();
+applyTheme(initial);
+
+export const theme = writable<Theme>(initial);
+
+theme.subscribe((value) => {
+  applyTheme(value);
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  }
+});
+
+export function toggleTheme(): void {
+  theme.update((t) => (t === "dark" ? "light" : "dark"));
+}


### PR DESCRIPTION
## Dark-first design-token system + light/dark toggle (PR5b)

Replaces the ad-hoc utility-class styling (and the leftover Vite-template cruft
in `app.css`) with a coherent, token-driven design system. Dark-first, with a
**light/dark toggle** persisted to `localStorage`; a single `data-theme`
attribute on `<html>` swaps the entire colour system. Fonts: Space Grotesk (UI)
+ JetBrains Mono (figures).

This is the visual follow-up to PR5a (#132), which wired the data-rich dashboard.

### What changed
- **`app.css`** — design tokens (colour / spacing / radius / type), the `data-theme` system, and shared component classes (header/nav, buttons, forms, cards, error/empty/loading/skeleton). Removed the conflicting Vite scaffold rules (`#app{text-align:center}`, `h1{3.2em}`, dark `button{}`, `body{place-items:center}`, `a{#646cff}`).
- **Sentiment scale** is emerald / slate / rose — deliberately distinct from the indigo brand accent, fixing the old blue-neutral / brand-colour collision.
- **App.svelte** — sticky header, `ai`**`Feel`**`News` wordmark, indigo active-tab nav, theme toggle, sign-in/out.
- **ArticleCard** — dark card, sentiment chip + centre-anchored score bar, topic/entity chips, bookmark control.
- **FilterBar / Pagination / BookmarksView** — token-styled with consistent empty/error/loading states.
- **Dashboard** — theme-aware chart colours (grid/ticks/tooltips follow the tokens and re-render on theme flip); KPI tiles + cards on the token system. Removed the SQL-technique "method tags" from the user-facing copy (they belong in the docs, not the dashboard).
- **theme.ts** (new) — small store managing the `data-theme` attribute + persistence.

### Bug fix included
While testing locally I found a real auth bug: a **401 on the background bookmark
hydration** was caught as `AuthExpiredError` and forced a logout — so any backend
that couldn't verify the token bounced a freshly-signed-in user in a
**login → 401 → logout loop** (and the login-gated nav tabs vanished). Hydration
now warns and stays signed in; only *user-initiated* bookmark actions treat a 401
as an expired session.

### Verification
- Ran a seeded local stack (Postgres + backend + `npm run dev`) and exercised login, the article feed, filters, pagination, the analytics dashboard, and the light/dark toggle end-to-end.
- `svelte-check` — 0 errors / 0 warnings; `npm run build` clean.

> Ships with the same `develop → main` release as the rest of the capstone work.
