### PR TITLE
fix: operational hardening sweep (robots 404, deploy race, healthchecks)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Serialize runs per ref so two in-flight deploys cannot interleave the prod
+# Alembic migration and the Cloud Run traffic split (which would produce a
+# nondeterministic serving revision and fight the rollback step). Do NOT cancel
+# an in-progress run: a deploy mid-migration must finish before the next starts.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   PROJECT_ID: aifeelnews-prod
   SERVICE: aifeelnews-web

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,16 @@
-.PHONY: reset-db ingest pipeline migrate env-local env-docker env-production
+.PHONY: reset-db ingest pipeline migrate env-init
 
-# Switch to local environment
-env-local:
-		@echo "🔧 Switching to LOCAL environment (.env.local)..."
-		cp .env.local .env
-		@echo "✅ Now using LOCAL database and settings."
-
-# Switch to Docker environment
-env-docker:
-		@echo "🐳 Switching to DOCKER environment (.env.docker)..."
-		cp .env.docker .env
-		@echo "✅ Now using DOCKER database and settings."
-
-# Switch to production environment
-# env-production:
-#		@echo "☁️  Switching to PRODUCTION environment (.env.production)..."
-#		cp .env.production .env
-#		@echo "✅ Now using PRODUCTION database and settings."
+# Create a local .env from the tracked template (only the template ships in
+# the repo; there are no .env.local/.env.docker files to switch between).
+env-init:
+		@echo "🔧 Creating .env from .env.example…"
+		cp .env.example .env
+		@echo "✅ .env created. Fill in your secrets before running."
 
 # Reset the database schema using SQLAlchemy-based job
 reset-db:
 		@echo "🔄 Resetting database…"
-		python -m jobs.reset_db
+		python -m app.jobs.reset_db
 
 migrate:
 		@echo "📦 Running alembic migrations…"

--- a/app/utils/robots.py
+++ b/app/utils/robots.py
@@ -89,10 +89,12 @@ def fetch_robots_txt(domain: str) -> Optional[RobotFileParser]:
         # Handle different response codes
         if response.status_code == 404:
             logger.info(f"No robots.txt found for {domain} (404) - allowing all")
-            # No robots.txt means we can crawl (permissive default)
-            rp = RobotFileParser()
-            rp.set_url(robots_url)
-            return rp
+            # No robots.txt means we can crawl. Return None so is_url_allowed()
+            # applies its permissive parser-is-None default. A freshly-constructed
+            # RobotFileParser that was never .read()/.parse()'d has can_fetch()
+            # return False for every URL, which would silently DISALLOW all crawling
+            # of any site without a robots.txt — the inverse of what we want.
+            return None
 
         response.raise_for_status()
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,11 +15,8 @@ services:
       - ENV=production
       - MEDIASTACK_API_KEY=${MEDIASTACK_API_KEY}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    # No healthcheck override: curl is not installed in Dockerfile.web (slim
+    # base), so the image's own urllib-based HEALTHCHECK applies and works.
 
   # Background Worker Service (Production)
   worker:
@@ -32,7 +29,7 @@ services:
       - MEDIASTACK_API_KEY=${MEDIASTACK_API_KEY}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "from app.database import SessionLocal; db = SessionLocal(); db.execute('SELECT 1'); db.close()"]
+      test: ["CMD", "python", "-c", "from sqlalchemy import text; from app.database import SessionLocal; db = SessionLocal(); db.execute(text('SELECT 1')); db.close()"]
       interval: 60s
       timeout: 30s
       retries: 3
@@ -48,7 +45,7 @@ services:
       - MEDIASTACK_API_KEY=${MEDIASTACK_API_KEY}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "from app.database import SessionLocal; db = SessionLocal(); db.execute('SELECT 1'); db.close()"]
+      test: ["CMD", "python", "-c", "from sqlalchemy import text; from app.database import SessionLocal; db = SessionLocal(); db.execute(text('SELECT 1')); db.close()"]
       interval: 120s
       timeout: 30s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,12 @@ services:
     env_file:
       - .env
     depends_on:
-      - db
+      # Wait for Postgres to be HEALTHY (accepting connections), not merely
+      # started. web runs `alembic upgrade head` on boot; a short-form
+      # depends_on lets it fire during Postgres' initdb window and fail on
+      # connection-refused, leaving web down (it has no restart policy).
+      db:
+        condition: service_healthy
     volumes:
       - .:/app  # For development hot reload
     command: ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload"]
@@ -33,7 +38,8 @@ services:
     env_file:
       - .env
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - .:/app  # For development
     restart: unless-stopped
@@ -49,7 +55,8 @@ services:
     env_file:
       - .env
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - .:/app  # For development
     restart: unless-stopped

--- a/docker/Dockerfile.scheduler
+++ b/docker/Dockerfile.scheduler
@@ -29,9 +29,11 @@ COPY app/ app/
 RUN chown -R scheduler:scheduler /app
 USER scheduler
 
-# Health check for scheduler service
+# Health check for scheduler service. SQLAlchemy 2.0 removed bare-string
+# Session.execute(), so the query must be wrapped in text() or it raises
+# ArgumentError and the container is reported unhealthy forever.
 HEALTHCHECK --interval=120s --timeout=30s --start-period=10s --retries=3 \
-    CMD python -c "from app.database import SessionLocal; db = SessionLocal(); db.execute('SELECT 1'); db.close()" || exit 1
+    CMD python -c "from sqlalchemy import text; from app.database import SessionLocal; db = SessionLocal(); db.execute(text('SELECT 1')); db.close()" || exit 1
 
 # Run ingestion jobs on schedule (every hour)
 CMD ["sh", "-c", "while true; do echo 'Starting ingestion at $(date)'; python -m app.jobs.run_ingestion --max-crawl=5; echo 'Completed ingestion at $(date)'; sleep 3600; done"]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -31,9 +31,11 @@ COPY alembic.ini .
 RUN chown -R worker:worker /app
 USER worker
 
-# Health check for worker service
+# Health check for worker service. SQLAlchemy 2.0 removed bare-string
+# Session.execute(), so the query must be wrapped in text() or it raises
+# ArgumentError and the container is reported unhealthy forever.
 HEALTHCHECK --interval=60s --timeout=30s --start-period=10s --retries=3 \
-    CMD python -c "from app.database import SessionLocal; db = SessionLocal(); db.execute('SELECT 1'); db.close()" || exit 1
+    CMD python -c "from sqlalchemy import text; from app.database import SessionLocal; db = SessionLocal(); db.execute(text('SELECT 1')); db.close()" || exit 1
 
 # Run background worker jobs. ``-m`` runs as a module so the ``app``
 # package on /app is importable. Running the file by path puts the

--- a/infra/envs/staging.tfvars
+++ b/infra/envs/staging.tfvars
@@ -28,6 +28,14 @@ cloud_sql_database_name    = "aifeelnews_staging"
 ingestion_schedule = "0 12 * * *"
 cleanup_schedule   = "0 3 * * *"
 
+# Monitoring — required (no default); without it `terraform apply` halts asking
+# for the value, so the documented staging apply could not actually run.
+notification_email = "matias.cardone@code.berlin"
+
+# Staging runs ingestion once daily, so the stale-data alarm must tolerate a
+# ~24h gap (default 32400s = 9h would false-alarm against the daily cadence).
+ingestion_stale_threshold_seconds = 93600
+
 # BigQuery — same dataset (staging uses a prefix or separate tables)
 bigquery_dataset_id = "aifeelnews_staging"
 bigquery_location   = "europe-west1"

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -125,10 +125,11 @@ class TestBuffering:
             sentiment_score=-0.3,
             sentiment_label="negative",
         )
-        # flush_sentiment calls _flush_buffer
-        # The auto-flush in queue_sentiment_event calls flush_sentiment()
-        # which calls _flush_buffer. Since we mocked _flush_buffer,
-        # verify it was called.
+        # The auto-flush in queue_sentiment_event calls flush_sentiment(),
+        # which calls the (mocked) _flush_buffer exactly once. Asserting this
+        # guards the threshold check, the flush_sentiment -> _flush_buffer
+        # delegation, and that the first event did NOT prematurely flush.
+        assert mock_flush.call_count == 1
 
         # Cleanup
         bq_mod._sentiment_buffer.clear()

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,0 +1,82 @@
+"""Regression tests for robots.txt compliance edge cases.
+
+The headline case here is the 404 path: a site with NO robots.txt must be
+treated as permissive (crawl allowed). A regression once made it the inverse —
+a freshly-constructed, never-read RobotFileParser has can_fetch() return False
+for every URL, so returning that parser silently DISALLOWED all crawling of any
+site without a robots.txt. The fix returns None on 404 so is_url_allowed()
+applies its permissive parser-is-None default.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.utils import robots
+
+
+@pytest.fixture(autouse=True)
+def _clear_robots_cache():
+    """Each test starts with an empty robots.txt cache (module-global)."""
+    robots._robots_cache.clear()
+    yield
+    robots._robots_cache.clear()
+
+
+def _mock_response(status_code: int, text: str = ""):
+    """Minimal stand-in for a requests.Response."""
+
+    def raise_for_status():
+        if status_code >= 400:
+            raise robots.requests.HTTPError(f"{status_code}")
+
+    return SimpleNamespace(
+        status_code=status_code, text=text, raise_for_status=raise_for_status
+    )
+
+
+def test_404_robots_is_permissive(monkeypatch):
+    """A 404 on robots.txt must ALLOW crawling (no policy = permissive)."""
+    monkeypatch.setattr(robots.requests, "get", lambda *a, **k: _mock_response(404))
+
+    allowed, reason = robots.is_url_allowed("https://no-robots.example.com/article")
+
+    assert allowed is True, f"404 robots.txt should allow crawling, got: {reason}"
+
+
+def test_404_fetch_returns_none(monkeypatch):
+    """fetch_robots_txt returns None on 404 so the None-default path is used."""
+    monkeypatch.setattr(robots.requests, "get", lambda *a, **k: _mock_response(404))
+
+    assert robots.fetch_robots_txt("no-robots.example.com") is None
+
+
+def test_network_failure_is_permissive(monkeypatch):
+    """A network error fetching robots.txt must ALLOW crawling (fail-open)."""
+
+    def _raise(*a, **k):
+        raise robots.requests.RequestException("connection refused")
+
+    monkeypatch.setattr(robots.requests, "get", _raise)
+
+    allowed, _ = robots.is_url_allowed("https://unreachable.example.com/article")
+
+    assert allowed is True
+
+
+def test_disallow_rule_is_respected(monkeypatch):
+    """A real Disallow rule for our path must still BLOCK crawling.
+
+    Mocks at the parser level (not the temp-file file:// read, which is
+    platform-fragile on Windows) so the policy-enforcement path is exercised
+    deterministically: a populated parser must DENY a disallowed URL.
+    """
+    from urllib.robotparser import RobotFileParser
+
+    rp = RobotFileParser()
+    rp.parse(["User-agent: *", "Disallow: /private/"])
+    monkeypatch.setattr(robots, "get_robots_parser", lambda domain: rp)
+
+    allowed, _ = robots.is_url_allowed("https://example.com/private/secret")
+
+    assert allowed is False


### PR DESCRIPTION
## Summary

A batch of small operational and correctness fixes. None of them change the live web/API behaviour — each closes a latent failure mode or a misleading dev/CI signal.

## robots.txt 404 was silently disallowing crawling

`fetch_robots_txt` returned a fresh `RobotFileParser` on a 404 without ever calling `.read()`/`.parse()`. On an unread parser, `can_fetch()` returns `False` for every URL — so any site **without** a robots.txt got treated as forbidden, the opposite of what we want (and against robots-compliance hard-rule 6). Now returns `None` so `is_url_allowed()` falls through to its permissive default, matching the other failure branches.

## deploy.yml had no concurrency control

Two overlapping deploys could interleave the prod Alembic migration and the Cloud Run traffic split, leaving a nondeterministic serving revision that fights the rollback step. Added a per-ref `concurrency` group with `cancel-in-progress: false`, so a deploy that's mid-migration finishes before the next one starts.

## A BigQuery test asserted nothing

`test_auto_flush_at_batch_size` queued the event that should trip the auto-flush, then had only comments where the assertion belonged — so breaking the flush trigger kept it green. Added the missing `call_count == 1` check.

## Docker / compose healthchecks

- Worker and scheduler healthchecks ran `db.execute("SELECT 1")` as a bare string, which raises `ArgumentError` on SQLAlchemy 2.0, so those containers showed `UNHEALTHY` forever. Wrapped in `text()`, same as the app's own `/health` probe.
- `docker-compose.prod.yml` web healthcheck used `curl`, which isn't in the slim image. Dropped the override so the image's own urllib HEALTHCHECK applies.
- `docker-compose.yml` services only waited for the db container to start, not to be healthy; `web` runs `alembic` on boot and could fire during Postgres initdb. Switched to `depends_on: condition: service_healthy`.

## IaC and Makefile

- `staging.tfvars` was missing the required `notification_email`, so the documented `terraform apply -var-file=envs/staging.tfvars` would halt asking for it. Added it, plus an `ingestion_stale_threshold` override for the daily staging cadence.
- `Makefile` `reset-db` pointed at `jobs.reset_db` (no such package) and the `env-local`/`env-docker` targets copied `.env.local`/`.env.docker`, neither of which exists. Fixed the module path to `app.jobs.reset_db` and replaced the env targets with a single `env-init` off `.env.example`.

## Testing

- New `tests/test_robots.py`: 404 → allowed, network failure → fail-open, real Disallow rule → blocked.
- Full suite: 63 passed, 9 skipped (Postgres-gated) on the SQLite path.
- `ruff` and `mypy` clean; all edited YAML/compose files parse.
