### PR TITLE
fix(ingest): make the ingestion pipeline resilient to one bad article

### DIFF
--- a/app/jobs/ingest_articles.py
+++ b/app/jobs/ingest_articles.py
@@ -1,9 +1,13 @@
+import logging
 from typing import Dict, List
 
+from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.article import Article
 from app.models.source import Source
+
+logger = logging.getLogger(__name__)
 
 
 def get_or_create_source(db: Session, name: str) -> Source:
@@ -36,22 +40,33 @@ def ingest_articles(db: Session, articles: List[Dict]) -> int:
         if article_exists(db, url) or url in seen_urls:
             continue
 
-        src = get_or_create_source(db, a["source_name"])
-        db.add(
-            Article(
-                title=a["title"],
-                description=a["description"],
-                url=url,
-                image_url=a["image_url"],
-                published_at=a["published_at"],
-                language=a["language"],
-                country=a["country"],
-                category=a["category"],
-                sentiment_label=a["sentiment_label"],
-                sentiment_score=a["sentiment_score"],
-                source_id=src.id,
-            )
-        )
+        # Isolate each insert in a SAVEPOINT so a single bad row (a constraint
+        # the normalizer didn't anticipate, or a duplicate that races the
+        # exists-check) rolls back only itself instead of aborting the whole
+        # batch on commit. The normalizer is the first line of defence; this
+        # is the safety net that keeps one poison record from costing a run.
+        try:
+            with db.begin_nested():
+                src = get_or_create_source(db, a["source_name"])
+                db.add(
+                    Article(
+                        title=a["title"],
+                        description=a["description"],
+                        url=url,
+                        image_url=a["image_url"],
+                        published_at=a["published_at"],
+                        language=a["language"],
+                        country=a["country"],
+                        category=a["category"],
+                        sentiment_label=a["sentiment_label"],
+                        sentiment_score=a["sentiment_score"],
+                        source_id=src.id,
+                    )
+                )
+        except (IntegrityError, DataError) as e:
+            logger.warning("Skipping article %s: insert failed: %s", url, e)
+            continue
+
         seen_urls.add(url)
         added += 1
 

--- a/app/jobs/normalize_articles.py
+++ b/app/jobs/normalize_articles.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 from urllib.parse import urlparse, urlunparse
 
 from dateutil import parser
@@ -7,6 +7,26 @@ from dateutil import parser
 from app.utils.sentiment import analyze_sentiment
 
 logger = logging.getLogger(__name__)
+
+# Article column limits (app/models/article.py). Over-length values raise a
+# DataError on Postgres (SQLite silently truncates), so the normalizer is the
+# place to enforce them: short metadata fields are truncated, while the
+# identity/dedup fields (title, url) are skipped if they blow the limit, since
+# a 1000+ char URL or 255+ char title signals a malformed record and
+# truncating the URL would break its UNIQUE/dedup contract.
+_TITLE_MAX = 255
+_URL_MAX = 1000
+_LANGUAGE_MAX = 2
+_COUNTRY_MAX = 2
+_CATEGORY_MAX = 50
+_IMAGE_URL_MAX = 1000
+
+
+def _clamp(value: Optional[str], limit: int) -> Optional[str]:
+    """Truncate a string to ``limit`` chars; pass None through."""
+    if value is None:
+        return None
+    return value[:limit]
 
 
 def normalize_articles(raw: List[Dict]) -> List[Dict]:
@@ -28,15 +48,28 @@ def normalize_articles(raw: List[Dict]) -> List[Dict]:
             continue
         seen.add(key)
 
-        # parse date — dateutil raises ValueError on bad strings, TypeError
-        # when passed something non-stringy (None, int) and OverflowError
-        # on absurd values. Catch the data-shape failures, let anything
-        # else propagate.
+        # parse date — dateutil raises ValueError on bad strings and
+        # OverflowError on absurd values. published_at is NOT NULL downstream,
+        # so a row with a missing or unparseable date is dropped here rather
+        # than poisoning the batch insert with an IntegrityError. ``.get``
+        # avoids a KeyError when the key is entirely absent.
+        raw_published = item.get("published_at")
+        if not isinstance(raw_published, str):
+            logger.warning("Skipping article %s: missing published_at", canon)
+            continue
         try:
-            published = parser.isoparse(item["published_at"])
-        except (ValueError, TypeError, OverflowError) as e:
-            logger.warning("Failed to parse published_at for article %s: %s", canon, e)
-            published = None
+            published = parser.isoparse(raw_published)
+        except (ValueError, OverflowError) as e:
+            logger.warning(
+                "Skipping article %s: unparseable published_at: %s", canon, e
+            )
+            continue
+
+        # Drop records whose identity fields exceed the column limits rather
+        # than truncate them (truncating a URL would break the dedup contract).
+        if len(title) > _TITLE_MAX or len(canon) > _URL_MAX:
+            logger.warning("Skipping article %s: title/url exceeds column limit", canon)
+            continue
 
         # sentiment
         label, score = analyze_sentiment(f"{title} {desc}")
@@ -47,11 +80,13 @@ def normalize_articles(raw: List[Dict]) -> List[Dict]:
                 "title": title,
                 "description": desc,
                 "url": canon,
-                "image_url": item.get("image") or item.get("image_url"),
+                "image_url": _clamp(
+                    item.get("image") or item.get("image_url"), _IMAGE_URL_MAX
+                ),
                 "published_at": published,
-                "language": item.get("language"),
-                "country": item.get("country"),
-                "category": item.get("category"),
+                "language": _clamp(item.get("language"), _LANGUAGE_MAX),
+                "country": _clamp(item.get("country"), _COUNTRY_MAX),
+                "category": _clamp(item.get("category"), _CATEGORY_MAX),
                 "sentiment_label": label,
                 "sentiment_score": score,
             }

--- a/app/jobs/run_ingestion.py
+++ b/app/jobs/run_ingestion.py
@@ -3,6 +3,8 @@ import sys
 import time
 from datetime import datetime, timezone
 
+from sqlalchemy.exc import DataError, IntegrityError
+
 from app.database import SessionLocal
 from app.jobs.crawl_worker import run_crawl_worker
 from app.jobs.fetch_from_mediastack import fetch_all_sources
@@ -40,9 +42,17 @@ def run_ingestion(include_crawling: bool = True, max_crawl_jobs: int = 5) -> Non
     # Step 3: Ingest articles into database
     logging.info("💾 Ingesting articles into database...")
     db = SessionLocal()
+    new = 0
     try:
         new = ingest_articles(db, norm)
         logging.info("✅ Ingested %d new articles", new)
+    except (IntegrityError, DataError):
+        # ingest_articles isolates each row in a savepoint, so reaching here
+        # means the final commit itself failed. Roll back and keep going: the
+        # crawl and BigQuery-metrics steps should still run rather than the
+        # whole pipeline dying on a batch the inserts couldn't reconcile.
+        db.rollback()
+        logging.exception("⚠️ Article ingestion failed; continuing pipeline")
     finally:
         db.close()
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -89,3 +89,97 @@ def test_ingest_articles(test_db):
     # Verify only 1 article exists in DB
     count = test_db.query(Article).count()
     assert count == 1
+
+
+def _raw(**overrides):
+    """A well-formed raw Mediastack-style record, with field overrides."""
+    base = {
+        "title": "A title",
+        "description": "A description",
+        "url": "https://example.com/ok",
+        "published_at": "2025-11-18T10:00:00Z",
+        "source_name": "test-source",
+        "language": "en",
+        "country": "us",
+        "category": "general",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_normalize_skips_missing_published_at():
+    """A record with no published_at is dropped, not emitted with None.
+
+    published_at is NOT NULL on the Article model; emitting None would abort
+    the whole batch insert on Postgres.
+    """
+    raw = _raw()
+    del raw["published_at"]
+
+    assert normalize_articles([raw]) == []
+
+
+def test_normalize_skips_unparseable_published_at():
+    """A record with a garbage date string is dropped."""
+    assert normalize_articles([_raw(published_at="not-a-date")]) == []
+
+
+def test_normalize_skips_overlong_title_and_url():
+    """Title/url over the column limit are dropped (truncating url would
+    break the UNIQUE/dedup contract)."""
+    assert normalize_articles([_raw(title="x" * 256)]) == []
+
+    long_url = "https://example.com/" + ("a" * 1001)
+    assert normalize_articles([_raw(url=long_url)]) == []
+
+
+def test_normalize_truncates_short_metadata_fields():
+    """Over-length language/country/category are truncated to fit the column."""
+    out = normalize_articles(
+        [_raw(language="english", country="usa", category="x" * 80)]
+    )
+
+    assert len(out) == 1
+    assert out[0]["language"] == "en"
+    assert out[0]["country"] == "us"
+    assert len(out[0]["category"]) == 50
+
+
+def test_ingest_isolates_a_bad_row(test_db):
+    """One row that violates a DB constraint must not abort the whole batch.
+
+    Each insert runs in its own SAVEPOINT, so a NOT NULL violation (here a
+    None title that bypassed the normalizer) rolls back only that row; the
+    valid rows around it still commit.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+
+    def _article(url, title="ok"):
+        return {
+            "title": title,
+            "description": "d",
+            "url": url,
+            "image_url": None,
+            "published_at": now,
+            "language": "en",
+            "country": "us",
+            "category": "general",
+            "sentiment_label": "neutral",
+            "sentiment_score": 0.0,
+            "source_name": "test-source",
+        }
+
+    batch = [
+        _article("https://example.com/good1"),
+        _article("https://example.com/bad", title=None),  # NOT NULL violation
+        _article("https://example.com/good2"),
+    ]
+
+    added = ingest_articles(test_db, batch)
+
+    # The two good rows commit; the bad one is skipped — not all-or-nothing.
+    assert added == 2
+    urls = {a.url for a in test_db.query(Article).all()}
+    assert urls == {"https://example.com/good1", "https://example.com/good2"}


### PR DESCRIPTION
## Summary

Makes the ingestion pipeline tolerate a single malformed Mediastack record instead of letting it abort the whole run. This failure mode was invisible to the test suite because SQLite (the default test backend) enforces neither `NOT NULL`-with-default nor `VARCHAR` length limits — it only bites on Postgres.

## The problem

Three defects compounded into one all-or-nothing failure:

1. `normalize_articles` set `published_at = None` when a date wouldn't parse, but still emitted the row — and `published_at` is `NOT NULL` on the `Article` model.
2. `normalize_articles` passed `title`/`url`/`language`/`country`/`category` through unbounded, but the columns are limited (`title` 255, `language`/`country` 2, `category` 50, `url`/`image_url` 1000). An over-length value raises a `DataError` on Postgres.
3. `ingest_articles` added every row to one Session and committed once, so a single `IntegrityError`/`DataError` rolled back the **entire** batch — and `run_ingestion` had no `except`, so the exception propagated and the crawl + BigQuery-metrics steps never ran. Since the same bad record comes back each cycle, a run could stay stuck.

## The fix (defence in depth)

- **`normalize_articles`** (first line of defence): skip rows with a missing or unparseable `published_at` (using `.get` to avoid a `KeyError`), skip rows whose `title`/`url` exceed the column limit (truncating a URL would break the UNIQUE/dedup contract), and truncate the short metadata fields to fit.
- **`ingest_articles`** (safety net): wrap each insert in a `SAVEPOINT` (`db.begin_nested()`) and catch `IntegrityError`/`DataError` per row, so one bad row rolls back only itself and the rest of the batch still commits.
- **`run_ingestion`** (outermost net): catch `IntegrityError`/`DataError` around the ingest call, roll back, and let the pipeline continue so crawl + BigQuery metrics still run; initialise `new = 0` so the metrics step is always safe.

## Testing

New cases in `tests/test_ingestion.py`:
- missing / unparseable date → row skipped (not emitted with `None`)
- over-length title or url → skipped
- over-length language/country/category → truncated
- a batch with one `NOT NULL`-violating row still commits the surrounding good rows

The savepoint-isolation test is mutation-verified: it fails against the old all-or-nothing code and passes against the fix. Full suite green (64 passed, 9 Postgres-gated skips); `ruff` + `mypy` clean.
