### PR TITLE
fix: stop two data-driven 500s on the article-list and auth paths

### DIFF
--- a/app/deps/auth.py
+++ b/app/deps/auth.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -38,10 +39,37 @@ def get_current_user(
 
     user = db.query(User).filter(User.firebase_uid == uid).first()
     if not user:
+        # users.email is NOT NULL, so an email-less Firebase identity (phone /
+        # anonymous sign-in) cannot be provisioned. Reject with a clear 401
+        # rather than letting the INSERT fail with an opaque IntegrityError 500.
+        if not email:
+            logger.warning("Rejecting token for uid %s: no email claim", uid)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="An email-based account is required",
+            )
+
         user = User(firebase_uid=uid, email=email, hashed_password="")
         db.add(user)
-        db.commit()
-        db.refresh(user)
+        try:
+            db.commit()
+        except IntegrityError:
+            # Two concurrent first-requests for the same new uid can both miss
+            # the SELECT and both INSERT; the second hits the unique firebase_uid
+            # constraint. Roll back and re-SELECT the row the winner created —
+            # get-or-create idempotency on the auth path (mirrors bookmarks.py).
+            db.rollback()
+            user = db.query(User).filter(User.firebase_uid == uid).first()
+            if user is None:
+                # The conflict was something other than the uid race (e.g. the
+                # email is already taken by a different uid). Surface it cleanly.
+                logger.warning("User provisioning failed for uid %s", uid)
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Could not provision user account",
+                )
+        else:
+            db.refresh(user)
 
     # Transient, non-mapped attribute: never flushed to the DB, set after the
     # if/else (and after refresh) so it survives for both user branches.

--- a/app/schemas/article.py
+++ b/app/schemas/article.py
@@ -36,19 +36,25 @@ class ArticleBase(BaseModel):
             raise ValueError("Title cannot be empty or just whitespace")
         return v.strip()
 
-    @field_validator("image_url")
-    @classmethod
-    def validate_image_url(cls, v: Optional[str]) -> Optional[str]:
-        """Basic image URL validation."""
-        if v and not v.startswith(("http://", "https://")):
-            raise ValueError("Image URL must be a valid HTTP/HTTPS URL")
-        return v
-
 
 class ArticleCreate(ArticleBase):
     """Schema for creating new articles."""
 
     source_id: int = Field(..., gt=0, description="ID of the news source")
+
+    @field_validator("image_url")
+    @classmethod
+    def validate_image_url(cls, v: Optional[str]) -> Optional[str]:
+        """Write-side validation: reject non-HTTP(S) image URLs on create.
+
+        Lives on ArticleCreate (not ArticleBase) so it does NOT run on the read
+        model — a response-model validator that raises on its own stored data
+        would turn one bad row into a 500 for the whole list (see
+        ArticleRead.coerce_image_url).
+        """
+        if v and not v.startswith(("http://", "https://")):
+            raise ValueError("Image URL must be a valid HTTP/HTTPS URL")
+        return v
 
 
 class SourceInArticle(BaseModel):
@@ -67,6 +73,23 @@ class ArticleRead(ArticleBase):
 
     id: int = Field(..., description="Unique article identifier")
     source: SourceInArticle = Field(..., description="News source information")
+
+    @field_validator("image_url")
+    @classmethod
+    def coerce_image_url(cls, v: Optional[str]) -> Optional[str]:
+        """Read-side leniency: never RAISE on stored data.
+
+        The write-side ``ArticleBase.validate_image_url`` rejects non-HTTP(S)
+        values, but image_url is stored verbatim from upstream feeds and may
+        contain e.g. a protocol-relative ``//cdn/x.jpg``. A response-model
+        validator that raises on its own stored data turns one bad row into a
+        500 for the ENTIRE article list (FastAPI validates the whole
+        ``List[ArticleRead]``). Null out a bad value instead of raising so the
+        page still serves; the write path keeps the strict check.
+        """
+        if v and not v.startswith(("http://", "https://")):
+            return None
+        return v
 
     # Sentiment analysis results (from latest analysis)
     sentiment_label: Optional[Literal["positive", "negative", "neutral"]] = Field(

--- a/tests/test_articles_filters.py
+++ b/tests/test_articles_filters.py
@@ -182,3 +182,30 @@ def test_latest_accepts_same_query_params(client: TestClient) -> None:
     data = resp.json()
     assert len(data) == 3
     assert all(a["sentiment_label"] == "neutral" for a in data)
+
+
+def test_bad_stored_image_url_does_not_500_the_list(
+    seeded_db: Session, client: TestClient
+) -> None:
+    """A row with a non-HTTP(S) image_url (stored verbatim from upstream) must
+    not 500 the whole list. ArticleRead coerces it to null instead of raising."""
+    seeded_db.add(
+        Article(
+            source_id=1,
+            title="Protocol-relative image article",
+            url="https://example.com/articles/bad-image",
+            image_url="//cdn.example.com/x.jpg",  # no http(s) scheme
+            published_at=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            sentiment_label="neutral",
+            category="general",
+        )
+    )
+    seeded_db.commit()
+
+    resp = client.get("/api/v1/articles/?limit=50")
+    assert resp.status_code == 200
+    bad = [
+        a for a in resp.json() if a["url"] == "https://example.com/articles/bad-image"
+    ]
+    assert len(bad) == 1
+    assert bad[0]["image_url"] is None  # coerced, page still served

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -249,6 +249,93 @@ class TestAdminRbacGate:
 
 
 # -----------------------------------------------------------------------------
+# First-login user provisioning (get_current_user get-or-create)
+# -----------------------------------------------------------------------------
+
+
+class TestUserProvisioning:
+    """``get_current_user`` lazily provisions a User on first request.
+
+    The provisioning INSERT must fail closed, not 500: an email-less identity
+    is rejected with 401, and a concurrent first-login race (two requests both
+    INSERT the same new uid) recovers by re-SELECTing the winner's row.
+    """
+
+    @staticmethod
+    def _decoded(uid: str = "new-uid", email: str | None = "new@x.test") -> dict:
+        return {"uid": uid, "email": email}
+
+    def test_email_less_identity_is_rejected_401(self) -> None:
+        """A token with no email claim → 401, not an IntegrityError 500."""
+        from fastapi import HTTPException
+
+        from app.deps import auth
+
+        class _Db:
+            def query(self, *_a: Any) -> Any:
+                class _Q:
+                    def filter(self, *_x: Any) -> "_Q":
+                        return self
+
+                    def first(self) -> None:
+                        return None  # no existing user
+
+                return _Q()
+
+        with patch.object(
+            auth, "verify_firebase_token", return_value=self._decoded(email=None)
+        ):
+            with pytest.raises(HTTPException) as exc:
+                auth.get_current_user(authorization="Bearer t", db=_Db())  # type: ignore[arg-type]
+        assert exc.value.status_code == 401
+
+    def test_concurrent_first_login_race_recovers(self) -> None:
+        """When the provisioning INSERT loses a unique-uid race, the dep rolls
+        back and returns the row the winning request already created."""
+        from app.deps import auth
+        from app.models.user import User
+
+        winner = User(
+            id=7, firebase_uid="new-uid", email="new@x.test", hashed_password=""
+        )
+
+        class _Db:
+            def __init__(self) -> None:
+                self._select_calls = 0
+
+            def query(self, *_a: Any) -> Any:
+                outer = self
+
+                class _Q:
+                    def filter(self, *_x: Any) -> "_Q":
+                        return self
+
+                    def first(self_inner) -> Any:
+                        outer._select_calls += 1
+                        # 1st SELECT: no user yet → triggers INSERT path.
+                        # 2nd SELECT (post-rollback): the winner's row exists.
+                        return None if outer._select_calls == 1 else winner
+
+                return _Q()
+
+            def add(self, _obj: Any) -> None:
+                pass
+
+            def commit(self) -> None:
+                from sqlalchemy.exc import IntegrityError
+
+                raise IntegrityError("INSERT", {}, Exception("dup firebase_uid"))
+
+            def rollback(self) -> None:
+                pass
+
+        with patch.object(auth, "verify_firebase_token", return_value=self._decoded()):
+            user = auth.get_current_user(authorization="Bearer t", db=_Db())  # type: ignore[arg-type]
+        assert user is winner
+        assert getattr(user, "role", "unset") is None  # transient role applied
+
+
+# -----------------------------------------------------------------------------
 # OIDC-protected scheduler endpoints
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two correctness defects from the repo audit, both of which turned edge-case data into a 500 rather than a graceful response. Neither touches the happy path.

## `ArticleRead` image_url validator can 500 the whole list

`image_url` is stored verbatim from upstream feeds and can be non-HTTP(S) (e.g. a protocol-relative `//cdn/x.jpg`). `ArticleRead` inherited the write-side `validate_image_url` from `ArticleBase`, which **raises** on such a value — and because FastAPI validates the entire `List[ArticleRead]`, one bad stored row becomes a `ResponseValidationError` → **500 for the whole `/articles` page** (list, latest, and that article's detail).

Fix: moved the strict, raising validator to `ArticleCreate` (write path stays strict) and gave `ArticleRead` a lenient validator that coerces a bad `image_url` to `null` instead of raising. (Pydantic v2 runs both a parent and a child `field_validator` on the same field, so the validator had to be relocated, not just overridden.)

## `get_current_user` first-login provisioning was unguarded

The lazy "insert a `User` on first request" path committed with no `try/except`. Two failure modes each produced an opaque 500 on the **auth** path:
- email-less Firebase identities (phone / anonymous) violate the `NOT NULL` `users.email`;
- two concurrent first-requests for the same new uid both INSERT, and the second hits the unique `firebase_uid` constraint.

Fix: `email=None` is rejected with a clear **401** before the insert; the commit is wrapped in `try/except IntegrityError` that rolls back and re-SELECTs the winner's row (get-or-create idempotency, mirroring `bookmarks.py`). A conflict that isn't the uid race surfaces as a clean **409**.

## Testing
- HTTP-level: a seeded row with a protocol-relative `image_url` no longer 500s the list and comes back with `image_url=null`.
- Unit: `get_current_user` rejects an email-less token with 401 and recovers from a simulated concurrent-insert `IntegrityError`.
- Both new tests are **mutation-verified** (they fail against the unpatched code).
- Full suite: 71 passed / 9 skipped; `ruff` + `mypy` clean.
