### PR TITLE
test: close the audit's five coverage gaps

### DIFF
--- a/scripts/dev/manual_crawl_smoke.py
+++ b/scripts/dev/manual_crawl_smoke.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Test script for the crawl worker.
+
+This script creates some test articles and runs the crawl worker
+to validate that robots.txt compliance and content extraction work.
+"""
+
+from datetime import datetime, timezone
+
+from app.database import SessionLocal
+from app.jobs.crawl_worker import run_crawl_worker
+from app.models.article import Article
+from app.models.source import Source
+
+
+def create_test_articles():
+    """Create some test articles to crawl."""
+
+    db = SessionLocal()
+
+    try:
+        # Check if we already have test articles
+        existing_test_source = (
+            db.query(Source).filter(Source.name == "Test Source").first()
+        )
+
+        if existing_test_source:
+            print("✅ Test articles already exist")
+            return
+
+        # Create a test source
+        test_source = Source(name="Test Source")
+        db.add(test_source)
+        db.flush()  # Get the ID
+
+        # Create test articles (mix of allowed and blocked sites)
+        test_articles = [
+            {
+                "title": "Test BBC Article",
+                "url": "https://www.bbc.com/news/technology-12345678",
+                "description": "A test article from BBC (should be allowed by robots.txt)",
+            },
+            {
+                "title": "Test TechCrunch Article",
+                "url": "https://techcrunch.com/2024/01/01/test-article/",
+                "description": "A test article from TechCrunch (should be allowed by robots.txt)",
+            },
+            {
+                "title": "Test Example Article",
+                "url": "https://example.com/some-article",
+                "description": "A test article from Example.com (should be blocked by robots.txt)",
+            },
+        ]
+
+        for article_data in test_articles:
+            article = Article(
+                source_id=test_source.id,
+                title=article_data["title"],
+                description=article_data["description"],
+                url=article_data["url"],
+                published_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                language="en",
+            )
+            db.add(article)
+
+        db.commit()
+        print(f"✅ Created test source and {len(test_articles)} test articles")
+
+    finally:
+        db.close()
+
+
+def main():
+    """Run the crawl worker test."""
+
+    print("🧪 Testing Crawl Worker")
+    print("=" * 50)
+
+    # Step 1: Create test articles
+    print("\n📝 Creating test articles...")
+    create_test_articles()
+
+    # Step 2: Run the crawl worker
+    print("\n🚀 Running crawl worker...")
+    result = run_crawl_worker(max_jobs=5)
+
+    # Step 3: Show results
+    print("\n📊 Crawl Worker Test Results:")
+    print("=" * 50)
+    print(f"Status: {result['status']}")
+    print(f"Jobs Processed: {result['processed']}")
+    print(f"Successful Crawls: {result['successful']}")
+    print(f"Failed Crawls: {result['failed']}")
+    print(f"New Jobs Created: {result['new_jobs_created']}")
+    print(f"Duration: {result['duration']:.2f} seconds")
+
+    # Step 4: Check what happened
+    if result["processed"] > 0:
+        print(f"\n✅ Crawl worker processed {result['processed']} jobs!")
+
+        if result["successful"] > 0:
+            print(f"   {result['successful']} successful crawls")
+        if result["failed"] > 0:
+            print(f"   {result['failed']} failed crawls")
+
+        print("\nNote: Check the logs above for detailed crawling results.")
+        print("Robots.txt compliance should have blocked example.com URLs.")
+    else:
+        print("\nℹ️ No jobs were processed. This might be because:")
+        print("- No articles exist in the database yet")
+        print("- All articles already have crawl jobs")
+        print("- All jobs are already processed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -400,6 +400,33 @@ class TestSchedulerOidcGate:
         assert resp.status_code == 401
         assert "signer" in resp.json()["detail"].lower()
 
+    def test_oidc_dependency_rejects_unverified_signer_email(
+        self, production_client: TestClient
+    ) -> None:
+        """A token from the RIGHT service account but with email_verified=False
+        → 401. This is the only OIDC post-signature guard (oidc.py:124-129) with
+        no prior coverage: the wrong-signer test short-circuits before it, so
+        deleting the email_verified check would otherwise leave the suite green.
+        We return the correct signer + audience so verification reaches the
+        email_verified branch specifically.
+        """
+        from app.config import config
+
+        with patch(
+            "app.deps.oidc.id_token.verify_oauth2_token",
+            return_value={
+                "email": config.security.scheduler_service_account,
+                "email_verified": False,
+                "aud": config.security.cloud_run_url,
+            },
+        ):
+            resp = production_client.post(
+                "/api/v1/cleanup",
+                headers={"Authorization": "Bearer fake.but.cryptographically.valid"},
+            )
+        assert resp.status_code == 401
+        assert "verified" in resp.json()["detail"].lower()
+
 
 # -----------------------------------------------------------------------------
 # CORS

--- a/tests/test_crawl_worker.py
+++ b/tests/test_crawl_worker.py
@@ -1,117 +1,107 @@
-#!/usr/bin/env python3
+"""Branch tests for crawl_worker.crawl_article.
+
+The previous file of this name contained a manual real-HTTP smoke script with
+zero collectable pytest tests (moved to scripts/dev/manual_crawl_smoke.py).
+These mock the network + robots layer and assert the early-return branches that
+the live worker depends on: a robots.txt block and an active rate-limit must
+each park the job in the right terminal status without fetching. The
+network-error rollback path is covered in
+test_auth_security.py::TestCrawlWorkerRollbackHygiene.
 """
-Test script for the crawl worker.
 
-This script creates some test articles and runs the crawl worker
-to validate that robots.txt compliance and content extraction work.
-"""
+from __future__ import annotations
 
-from datetime import datetime, timezone
+from typing import Any
 
-from app.database import SessionLocal
-from app.jobs.crawl_worker import run_crawl_worker
-from app.models.article import Article
-from app.models.source import Source
+import pytest
+
+from app.jobs import crawl_worker
+from app.models.crawl_job import CrawlStatus
 
 
-def create_test_articles():
-    """Create some test articles to crawl."""
-
-    db = SessionLocal()
-
-    try:
-        # Check if we already have test articles
-        existing_test_source = (
-            db.query(Source).filter(Source.name == "Test Source").first()
-        )
-
-        if existing_test_source:
-            print("✅ Test articles already exist")
-            return
-
-        # Create a test source
-        test_source = Source(name="Test Source")
-        db.add(test_source)
-        db.flush()  # Get the ID
-
-        # Create test articles (mix of allowed and blocked sites)
-        test_articles = [
-            {
-                "title": "Test BBC Article",
-                "url": "https://www.bbc.com/news/technology-12345678",
-                "description": "A test article from BBC (should be allowed by robots.txt)",
-            },
-            {
-                "title": "Test TechCrunch Article",
-                "url": "https://techcrunch.com/2024/01/01/test-article/",
-                "description": "A test article from TechCrunch (should be allowed by robots.txt)",
-            },
-            {
-                "title": "Test Example Article",
-                "url": "https://example.com/some-article",
-                "description": "A test article from Example.com (should be blocked by robots.txt)",
-            },
-        ]
-
-        for article_data in test_articles:
-            article = Article(
-                source_id=test_source.id,
-                title=article_data["title"],
-                description=article_data["description"],
-                url=article_data["url"],
-                published_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-                language="en",
-            )
-            db.add(article)
-
-        db.commit()
-        print(f"✅ Created test source and {len(test_articles)} test articles")
-
-    finally:
-        db.close()
+class _Article:
+    url = "https://example.com/post"
 
 
-def main():
-    """Run the crawl worker test."""
+def _crawl_job() -> Any:
+    class _CrawlJob:
+        article = _Article()
+        status: Any = CrawlStatus.PENDING
+        error_code: Any = None
+        error_message: Any = None
+        updated_at: Any = None
+        robots_allowed: Any = None
+        http_status: Any = None
+        bytes_downloaded: Any = None
+        fetched_at: Any = None
 
-    print("🧪 Testing Crawl Worker")
-    print("=" * 50)
-
-    # Step 1: Create test articles
-    print("\n📝 Creating test articles...")
-    create_test_articles()
-
-    # Step 2: Run the crawl worker
-    print("\n🚀 Running crawl worker...")
-    result = run_crawl_worker(max_jobs=5)
-
-    # Step 3: Show results
-    print("\n📊 Crawl Worker Test Results:")
-    print("=" * 50)
-    print(f"Status: {result['status']}")
-    print(f"Jobs Processed: {result['processed']}")
-    print(f"Successful Crawls: {result['successful']}")
-    print(f"Failed Crawls: {result['failed']}")
-    print(f"New Jobs Created: {result['new_jobs_created']}")
-    print(f"Duration: {result['duration']:.2f} seconds")
-
-    # Step 4: Check what happened
-    if result["processed"] > 0:
-        print(f"\n✅ Crawl worker processed {result['processed']} jobs!")
-
-        if result["successful"] > 0:
-            print(f"   {result['successful']} successful crawls")
-        if result["failed"] > 0:
-            print(f"   {result['failed']} failed crawls")
-
-        print("\nNote: Check the logs above for detailed crawling results.")
-        print("Robots.txt compliance should have blocked example.com URLs.")
-    else:
-        print("\nℹ️ No jobs were processed. This might be because:")
-        print("- No articles exist in the database yet")
-        print("- All articles already have crawl jobs")
-        print("- All jobs are already processed")
+    return _CrawlJob()
 
 
-if __name__ == "__main__":
-    main()
+class _StubSession:
+    """Records commit/rollback; fails loudly if the fetch path is reached."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def commit(self) -> None:
+        self.calls.append("commit")
+
+    def rollback(self) -> None:  # pragma: no cover - not expected on these paths
+        self.calls.append("rollback")
+
+    def add(self, *_a: Any) -> None:  # pragma: no cover
+        raise AssertionError("add() should not be reached on an early-return branch")
+
+
+def test_robots_block_parks_job_forbidden_without_fetching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """robots.txt disallow → FORBIDDEN_BY_ROBOTS, and requests.get is never
+    called (we make it explode to prove the early return)."""
+    monkeypatch.setattr(
+        crawl_worker,
+        "check_robots_compliance",
+        lambda _url: {"allowed": False, "reason": "Disallowed by robots.txt"},
+    )
+
+    def _boom_get(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("requests.get must not run when robots disallows")
+
+    monkeypatch.setattr(crawl_worker.requests, "get", _boom_get)
+
+    job = _crawl_job()
+    session = _StubSession()
+    result = crawl_worker.crawl_article(job, session)  # type: ignore[arg-type]
+
+    assert result is False
+    assert job.status == CrawlStatus.FORBIDDEN_BY_ROBOTS
+    assert job.robots_allowed is False
+    assert "robots" in job.error_message.lower()
+
+
+def test_rate_limited_parks_job_without_fetching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """robots allows but the crawl-delay isn't satisfied → RATE_LIMITED, and
+    again no fetch happens."""
+    monkeypatch.setattr(
+        crawl_worker,
+        "check_robots_compliance",
+        lambda _url: {"allowed": True, "reason": "ok"},
+    )
+    # respect_crawl_delay returning False means "too soon, back off".
+    monkeypatch.setattr(crawl_worker, "respect_crawl_delay", lambda *_a: False)
+
+    def _boom_get(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("requests.get must not run when rate-limited")
+
+    monkeypatch.setattr(crawl_worker.requests, "get", _boom_get)
+
+    job = _crawl_job()
+    session = _StubSession()
+    result = crawl_worker.crawl_article(job, session)  # type: ignore[arg-type]
+
+    assert result is False
+    assert job.status == CrawlStatus.RATE_LIMITED
+    assert "rate limited" in job.error_message.lower()

--- a/tests/test_db_analytics.py
+++ b/tests/test_db_analytics.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import pytest
 
 from app.crud.analytics import (
+    daily_category_sentiment_pivot,
+    entity_momentum,
     sentiment_grouping_sets,
     sentiment_rolling_average,
     source_sentiment_ranked,
@@ -72,3 +74,44 @@ def test_grouping_sets_has_grand_total_row(seeded):
         if r["is_category_total"] == 1 and r["is_label_total"] == 0
     ]
     assert sum(label_subtotals) == total
+
+
+def test_entity_momentum_runs_and_returns_expected_shape(seeded):
+    """entity_momentum (FULL OUTER JOIN + CASE growth_pct over two windows) is
+    one of the two most complex Postgres-only queries and was untested. The
+    seed creates no entities, so the result is legitimately empty — but the
+    query must still EXECUTE without error and return the documented columns
+    when rows exist. A broken FULL OUTER JOIN / CASE / cast would raise here."""
+    rows = entity_momentum(seeded, days=14)
+    assert isinstance(rows, list)
+    for r in rows:  # only iterates if entities were present
+        assert {
+            "entity_name",
+            "entity_type",
+            "recent_mentions",
+            "previous_mentions",
+            "growth_pct",
+        } <= set(r)
+
+
+def test_daily_category_pivot_cumulative_is_monotonic(seeded):
+    """daily_category_sentiment_pivot uses SUM() OVER (PARTITION BY category
+    ORDER BY day) for a running total. Within each category the cumulative
+    count must be non-decreasing by day and end at that category's total."""
+    rows = daily_category_sentiment_pivot(seeded, days=WIDE_DAYS)
+    assert rows, "pivot returned no rows (seed sets sentiment_score)"
+    assert {
+        "day",
+        "category",
+        "article_count",
+        "avg_sentiment",
+        "cumulative_articles",
+    } <= set(rows[0])
+
+    by_category: dict[str, list[dict]] = {}
+    for r in rows:
+        by_category.setdefault(r["category"], []).append(r)
+    for cat_rows in by_category.values():
+        cumulative = [int(r["cumulative_articles"]) for r in cat_rows]
+        assert cumulative == sorted(cumulative), "cumulative must be monotonic"
+        assert cumulative[-1] == sum(int(r["article_count"]) for r in cat_rows)

--- a/tests/test_db_analytics_routes.py
+++ b/tests/test_db_analytics_routes.py
@@ -1,0 +1,85 @@
+"""HTTP-layer tests for the /api/v1/db-analytics router.
+
+The advanced-SQL CRUD functions are exercised against real Postgres in
+test_db_analytics.py (Postgres-gated, skipped in default CI). This file covers
+the ROUTER itself — query-bound validation (422), route wiring, get_db
+override, and response serialization — without Postgres, by mocking the CRUD
+layer. So the rate-limit decorator, the Query(ge/le) bounds, and the router
+include all have regression coverage on the default SQLite CI path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.main import app
+
+
+@pytest.fixture
+def client(test_db) -> Iterator[TestClient]:
+    """TestClient with get_db overridden to the in-memory SQLite session.
+
+    The CRUD functions are mocked per-test, so the session is only needed to
+    satisfy the Depends(get_db) wiring; no Postgres-only SQL actually runs.
+    """
+
+    def _override_get_db() -> Iterator[object]:
+        yield test_db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+_BASE = "/api/v1/db-analytics"
+
+# (path, crud function name patched in app.routers.db_analytics, a valid query)
+_ROUTES = [
+    ("/sentiment/rolling", "sentiment_rolling_average", "days=30&window=7"),
+    ("/sources/ranked", "source_sentiment_ranked", "days=30"),
+    ("/sentiment/breakdown", "sentiment_grouping_sets", "days=30"),
+    ("/entities/momentum", "entity_momentum", "days=14"),
+    ("/categories/daily", "daily_category_sentiment_pivot", "days=14"),
+]
+
+
+@pytest.mark.parametrize("path,crud_name,query", _ROUTES)
+def test_route_wires_to_crud_and_serializes(
+    client: TestClient, path: str, crud_name: str, query: str
+) -> None:
+    """Each route dispatches to its CRUD function and serializes the result."""
+    sentinel = [{"k": "v", "n": 1}]
+    with patch(f"app.routers.db_analytics.{crud_name}", return_value=sentinel):
+        resp = client.get(f"{_BASE}{path}?{query}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == sentinel
+
+
+# Each tuple: (path, an out-of-bounds query that must 422)
+_BOUNDARY_CASES = [
+    ("/sentiment/rolling", "days=6"),  # days ge=7
+    ("/sentiment/rolling", "days=366"),  # days le=365
+    ("/sentiment/rolling", "days=30&window=2"),  # window ge=3
+    ("/sentiment/rolling", "days=30&window=31"),  # window le=30
+    ("/sources/ranked", "days=0"),  # days ge=1
+    ("/entities/momentum", "days=3"),  # days ge=4
+    ("/entities/momentum", "days=61"),  # days le=60
+    ("/categories/daily", "days=91"),  # days le=90
+]
+
+
+@pytest.mark.parametrize("path,query", _BOUNDARY_CASES)
+def test_query_bounds_rejected_with_422(
+    client: TestClient, path: str, query: str
+) -> None:
+    """Out-of-range query params are rejected by FastAPI before the handler
+    runs (so no DB/CRUD is touched)."""
+    resp = client.get(f"{_BASE}{path}?{query}")
+    assert resp.status_code == 422

--- a/tests/test_new_models.py
+++ b/tests/test_new_models.py
@@ -245,6 +245,69 @@ def test_ttl_cleanup_functionality(test_db):
     assert stats_after["active_records"] == 1
 
 
+def test_ttl_cleanup_error_path_rolls_back_and_reports_error(test_db, monkeypatch):
+    """A failing delete must NOT report success and MUST roll back.
+
+    TTL deletion is a data-minimisation compliance contract, so the error
+    branch (rollback + status='error', deleted_count=0) needs a regression
+    guard. We seed an expired row, force db.commit to raise, and assert the
+    job reports the failure honestly and leaves the row intact.
+    """
+    source = Source(name="ttl-error-source")
+    test_db.add(source)
+    test_db.flush()
+
+    now = datetime.now(timezone.utc)
+    article = Article(
+        source_id=source.id,
+        title="Has expired content",
+        url="https://example.com/ttl-error",
+        published_at=now,
+    )
+    test_db.add(article)
+    test_db.flush()
+    test_db.add(
+        ArticleContent(
+            article_id=article.id,
+            content_text="expired",
+            content_hash="ttl_error_hash",
+            content_length=7,
+            expires_at=now - timedelta(hours=1),
+        )
+    )
+    test_db.commit()
+
+    rolled_back = {"called": False}
+    real_rollback = test_db.rollback
+
+    def _tracking_rollback() -> None:
+        rolled_back["called"] = True
+        real_rollback()
+
+    def _boom() -> None:
+        raise RuntimeError("simulated delete/commit failure")
+
+    monkeypatch.setattr(test_db, "commit", _boom)
+    monkeypatch.setattr(test_db, "rollback", _tracking_rollback)
+
+    result = cleanup_expired_content(test_db)
+
+    assert result["status"] == "error"
+    assert result["deleted_count"] == 0
+    assert rolled_back["called"] is True
+
+    # The expired row must still exist — a failed delete must not silently
+    # destroy data while reporting success. (commit is restored by monkeypatch
+    # teardown; re-query on the same session sees the un-deleted row.)
+    monkeypatch.undo()
+    assert (
+        test_db.query(ArticleContent)
+        .filter(ArticleContent.content_hash == "ttl_error_hash")
+        .count()
+        == 1
+    )
+
+
 def test_cascade_deletions(test_db):
     """Test that cascade deletions work properly."""
     # Create source and article


### PR DESCRIPTION
## Summary

Closes the five test-coverage gaps from the repo audit. This PR is **test-only** — no production code changes, just regression guards for paths that previously shipped untested. Verified against real Postgres locally (full suite: 99 passed, 0 skipped).

## Gaps closed

**db-analytics router (rank 13)** — new `tests/test_db_analytics_routes.py` adds HTTP-layer coverage (route wiring, response serialization, and the `Query` ge/le **422 boundaries**) on the default SQLite CI path by mocking the CRUD layer. Previously the router had zero coverage in default CI (the CRUD tests are Postgres-gated).

**Advanced-SQL queries (rank 14)** — Postgres-gated tests for `entity_momentum` (FULL OUTER JOIN + `growth_pct`) and `daily_category_sentiment_pivot` (`SUM() OVER` running total), the two most complex queries, previously untested. The pivot test asserts the cumulative count is monotonic per category and ends at the category total.

**OIDC `email_verified` branch (rank 17)** — the existing wrong-signer test short-circuits before the `email_verified` guard, so deleting that guard left the suite green. Added a test with the **correct** signer + audience but `email_verified=False`, asserting 401.

**TTL cleanup error path (rank 18)** — the data-minimisation contract (a failing delete must roll back and report `status='error'`/`deleted_count=0`, never silently destroy data while reporting success) now has a regression guard.

**crawl_worker (rank 25)** — `tests/test_crawl_worker.py` was a manual real-HTTP smoke script with **zero collectable tests**. Moved it to `scripts/dev/manual_crawl_smoke.py` (mypy-excluded) and replaced it with real branch tests for the `FORBIDDEN_BY_ROBOTS` and `RATE_LIMITED` early-returns (asserting no fetch happens). The network-error rollback path stays covered in `TestCrawlWorkerRollbackHygiene`.

## Testing
- Full suite against **real Postgres** (CI parity): **99 passed, 0 skipped**.
- SQLite-only path: 88 passed, 11 skipped (Postgres-gated).
- `ruff` + `mypy` clean.
- Rebased onto develop after #140 merged (clean 3-way; the two `test_auth_security.py` additions coexist).
