### PR TITLE
fix: API-correctness + ORM-consistency polish (ranks 11,12,15,33)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Any, Generator, Optional
 
-from sqlalchemy import create_engine
+from sqlalchemy import DateTime, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
@@ -10,7 +11,15 @@ from app.config import settings
 class Base(DeclarativeBase):
     """SQLAlchemy 2.0 declarative base using Mapped[] annotation style."""
 
-    pass
+    # Map every Mapped[datetime] to a timezone-aware column. All migrations
+    # already create `timestamptz`, but the bare Mapped[datetime] default maps
+    # to TIMESTAMP WITHOUT TIME ZONE — so `alembic revision --autogenerate`
+    # would emit a spurious tz-stripping migration. Aligning the model with the
+    # real schema here (one place) removes that footgun. SQLite ignores the
+    # timezone flag, so the test fixtures are unaffected.
+    type_annotation_map = {
+        datetime: DateTime(timezone=True),
+    }
 
 
 _engine: Optional[Engine] = None

--- a/app/jobs/ingest_articles.py
+++ b/app/jobs/ingest_articles.py
@@ -19,10 +19,6 @@ def get_or_create_source(db: Session, name: str) -> Source:
     return src  # type: ignore[no-any-return]
 
 
-def article_exists(db: Session, url: str) -> bool:
-    return db.query(Article).filter_by(url=url).first() is not None
-
-
 def ingest_articles(db: Session, articles: List[Dict]) -> int:
     """
     Insert each normalized dict into the DB if its canonical URL isn't
@@ -33,11 +29,22 @@ def ingest_articles(db: Session, articles: List[Dict]) -> int:
     added = 0
     seen_urls = set()  # Track URLs in current batch
 
+    # Pre-load the URLs from this batch that already exist, in ONE indexed query,
+    # instead of a per-row SELECT (the old N+1 in the serial loop). The savepoint
+    # below still covers the rare insert-time race, so correctness is unchanged.
+    batch_urls = [a["url"] for a in articles]
+    existing_urls = set()
+    if batch_urls:
+        existing_urls = {
+            row[0]
+            for row in db.query(Article.url).filter(Article.url.in_(batch_urls)).all()
+        }
+
     for a in articles:
         url = a["url"]
 
         # Skip if already exists in DB or already processed in this batch
-        if article_exists(db, url) or url in seen_urls:
+        if url in existing_urls or url in seen_urls:
             continue
 
         # Isolate each insert in a SAVEPOINT so a single bad row (a constraint

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.routers import (
     sources,
     users,
 )
+from app.services.bigquery import BigQueryQueryError
 from app.utils.logging import setup_logging
 
 # Structured logging (JSON in production, plain text locally)
@@ -54,6 +55,29 @@ app.add_exception_handler(
     RateLimitExceeded,
     _rate_limit_exceeded_handler,  # type: ignore[arg-type]
 )
+
+
+@app.exception_handler(BigQueryQueryError)
+async def bigquery_query_error_handler(
+    request: Request, exc: BigQueryQueryError
+) -> JSONResponse:
+    """A BigQuery analytics query failed at runtime → 503, not a silent 200 [].
+
+    The analytics services raise this (instead of swallowing the error and
+    returning []) so a real failure (auth/quota/schema drift) is distinguishable
+    from a legitimately empty result. The frontend can then show a failure state
+    rather than an empty chart that looks like "no data".
+    """
+    logger.error(
+        "BigQuery analytics query failed on %s %s",
+        request.method,
+        request.url.path,
+        exc_info=exc,
+    )
+    return JSONResponse(
+        status_code=503,
+        content={"detail": "Analytics temporarily unavailable"},
+    )
 
 
 @app.exception_handler(Exception)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -20,5 +20,5 @@ class User(Base):
     )
 
     bookmarks: Mapped[List["Bookmark"]] = relationship(
-        back_populates="user", cascade="all, delete"
+        back_populates="user", cascade="all, delete-orphan"
     )

--- a/app/routers/bookmarks.py
+++ b/app/routers/bookmarks.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.deps.auth import get_current_user
+from app.models.article import Article
 from app.models.bookmark import Bookmark as BookmarkModel
 from app.models.user import User
 from app.schemas.bookmark import BookmarkCreate, BookmarkRead
@@ -19,14 +20,25 @@ def create_bookmark(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> BookmarkRead:
+    # Verify the article exists first. Without this, a non-existent article_id
+    # hits the FK constraint and the blanket IntegrityError handler below would
+    # mislabel it 409 "already exists" instead of the correct 404. Doing the
+    # check explicitly keeps the disambiguation backend-agnostic (the duplicate
+    # is enforced by a trigger, not a unique constraint with a portable code).
+    if db.get(Article, bm.article_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Article not found",
+        )
+
     bookmark = BookmarkModel(user_id=current_user.id, article_id=bm.article_id)
     db.add(bookmark)
     try:
         db.commit()
     except IntegrityError:
-        # The trg_prevent_duplicate_bookmark trigger (migration e1f2a3b4c5d6)
-        # raises on a duplicate (user_id, article_id). Translate the DB-layer
-        # constraint violation into the correct HTTP semantics: 409 Conflict.
+        # The article exists (checked above), so the only remaining violation is
+        # the trg_prevent_duplicate_bookmark trigger (migration e1f2a3b4c5d6) on
+        # a duplicate (user_id, article_id). Translate it to 409 Conflict.
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -18,6 +18,16 @@ from app.config import config
 
 logger = logging.getLogger(__name__)
 
+
+class BigQueryQueryError(Exception):
+    """A BigQuery analytics query failed at runtime (auth/quota/schema drift).
+
+    Raised instead of swallowing the error and returning [] so the API can
+    distinguish 'the query failed' (→ 503) from 'there are legitimately no
+    rows' (→ 200 []). Caught by a dedicated handler in app/main.py.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Lazy client initialisation
 # ---------------------------------------------------------------------------
@@ -504,7 +514,7 @@ def get_sentiment_trends(
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Sentiment trends query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("Sentiment trends query failed") from e
 
 
 def get_source_comparison(days: int = 30) -> List[Dict[str, Any]]:
@@ -544,7 +554,7 @@ def get_source_comparison(days: int = 30) -> List[Dict[str, Any]]:
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Source comparison query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("Source comparison query failed") from e
 
 
 def get_category_breakdown(days: int = 30) -> List[Dict[str, Any]]:
@@ -580,7 +590,7 @@ def get_category_breakdown(days: int = 30) -> List[Dict[str, Any]]:
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Category breakdown query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("Category breakdown query failed") from e
 
 
 def get_pipeline_stats(days: int = 7) -> List[Dict[str, Any]]:
@@ -619,7 +629,7 @@ def get_pipeline_stats(days: int = 7) -> List[Dict[str, Any]]:
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Pipeline stats query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("Pipeline stats query failed") from e
 
 
 # ---------------------------------------------------------------------------
@@ -669,7 +679,7 @@ def get_top_entities(
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Top entities query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("Top entities query failed") from e
 
 
 def get_entity_sentiment(
@@ -714,7 +724,7 @@ def get_entity_sentiment(
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("Entity sentiment query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("Entity sentiment query failed") from e
 
 
 def get_nlp_categories(
@@ -755,4 +765,4 @@ def get_nlp_categories(
         return [dict(row) for row in results]
     except Exception as e:
         logger.error("NLP categories query failed: %s", e, exc_info=True)
-        return []
+        raise BigQueryQueryError("NLP categories query failed") from e

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -561,6 +561,10 @@ class TestBookmarkConflictHandling:
             def __init__(self) -> None:
                 self.rolled_back = False
 
+            def get(self, _model: Any, _pk: Any) -> Any:
+                # Article exists, so the route proceeds to the duplicate path.
+                return object()
+
             def add(self, _obj: Any) -> None:  # pragma: no cover — trivial
                 pass
 
@@ -599,6 +603,47 @@ class TestBookmarkConflictHandling:
             "leaving the session in PendingRollbackError state breaks "
             "subsequent requests on the same connection."
         )
+
+    def test_create_bookmark_for_missing_article_returns_404_not_409(
+        self, client: TestClient
+    ) -> None:
+        """A non-existent article_id is a 404, not a misleading 409.
+
+        Previously the blanket IntegrityError handler mapped the FK violation
+        to 409 'already exists'. The route now pre-checks the article exists
+        (db.get → None) and returns 404, so the duplicate path is only reached
+        for genuine duplicates.
+        """
+        from app.deps.auth import get_current_user
+        from app.main import app as live_app
+        from app.models.user import User
+        from app.routers.bookmarks import get_db as bookmarks_get_db
+
+        fake_user = User(id=1, firebase_uid="u", email="t@x", hashed_password="")
+
+        class _StubDb:
+            def get(self, _model: Any, _pk: Any) -> Any:
+                return None  # article does not exist
+
+            def add(self, _obj: Any) -> None:  # pragma: no cover — not reached
+                raise AssertionError("must not insert when the article is missing")
+
+            def commit(self) -> None:  # pragma: no cover — not reached
+                raise AssertionError("must not commit when the article is missing")
+
+        def _override_get_db() -> Iterator[_StubDb]:
+            yield _StubDb()
+
+        live_app.dependency_overrides[bookmarks_get_db] = _override_get_db
+        live_app.dependency_overrides[get_current_user] = lambda: fake_user
+        try:
+            resp = client.post("/api/v1/bookmarks/", json={"article_id": 99999})
+        finally:
+            live_app.dependency_overrides.pop(bookmarks_get_db, None)
+            live_app.dependency_overrides.pop(get_current_user, None)
+
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -208,3 +208,20 @@ class TestAnalyticsRouter:
         # days must be <= 365
         resp = client.get("/api/v1/analytics/trends?days=999")
         assert resp.status_code == 422
+
+    def test_enabled_but_failing_query_returns_503_not_empty(self, client):
+        """When BigQuery is enabled and a query genuinely fails, the endpoint
+        returns 503 — NOT a silent 200 [] that looks like 'no data'."""
+        from app.services.bigquery import BigQueryQueryError
+
+        # Enable BigQuery at the router's config check, then make the underlying
+        # query raise the failure sentinel. The dedicated handler → 503.
+        with patch("app.routers.analytics.config") as mock_cfg:
+            mock_cfg.bigquery.enable_bigquery = True
+            with patch(
+                "app.routers.analytics.get_sentiment_trends",
+                side_effect=BigQueryQueryError("boom"),
+            ):
+                resp = client.get("/api/v1/analytics/trends")
+        assert resp.status_code == 503
+        assert resp.json() != []


### PR DESCRIPTION
## Summary

The final cluster of low-severity audit findings: correct HTTP semantics, surfacing real analytics failures instead of masking them, and a handful of one-spot ORM consistency fixes. No happy-path behaviour change. Verified against real Postgres (full suite: 102 passed, 0 skipped).

## Bookmark FK violation → 404, not 409

`create_bookmark` mapped **every** `IntegrityError` to 409 "already exists", so POSTing a non-existent `article_id` (an FK violation) was mislabelled a duplicate. Now pre-checks the article exists (`db.get` → 404 if missing); the remaining `IntegrityError` can only be the duplicate trigger → 409. Tests cover both the 404 (missing article) and the still-correct 409 (real duplicate) paths.

## BigQuery failures surface as 503, not silent 200 [] 

The 7 read-query delegates wrapped each query in `except Exception: return []`, so an **enabled-but-failing** query (auth/quota/schema drift) was indistinguishable from "no rows" — the frontend just drew an empty chart. They now raise `BigQueryQueryError`, caught by a dedicated handler in `main.py` that returns **503**. The disabled-mode marker and legitimately-empty `[]` paths are unchanged; the write/flush path still degrades gracefully. Test asserts enabled+failing → 503.

## ORM / schema consistency (the safe subset)

- **(a)** `Base.type_annotation_map` maps every `Mapped[datetime]` to `DateTime(timezone=True)`. All migrations already create `timestamptz`, but the bare default mapped to `TIMESTAMP WITHOUT TIME ZONE`, so `alembic revision --autogenerate` would emit a spurious tz-stripping migration. **Verified against real Postgres**: autogenerate now shows no tz-stripping on the datetime columns. SQLite ignores the flag.
- **(c)** `User.bookmarks` cascade `'all, delete'` → `'all, delete-orphan'` to match `Article.bookmarks`.
- **(e)** `ingest_articles` replaced the per-row `article_exists` SELECT (an N+1 in the serial loop) with a single indexed `IN`-query that pre-loads the batch's existing URLs into a set; the savepoint still covers the insert-time race, so the dedup contract is unchanged. Removed the now-unused `article_exists` helper.
- **Deferred** (no current trigger, breakage risk): (b) `passive_deletes` on Article children (SQLite FK PRAGMA would need verifying against the cascade test), (d) re-crawl duplicate guard, (f) backfill partition filter.

## Testing
- Full suite against real Postgres: **102 passed, 0 skipped**.
- New/updated tests: bookmark 404 + 409, BigQuery enabled-failing → 503, existing savepoint/cascade tests still green.
- `ruff` + `mypy` clean. Autogenerate verified to no longer tz-strip.

> Note: while verifying (a) I noticed a separate, pre-existing cosmetic drift in `sources` (model uses `unique=True, index=True` + column comments; the DB has a `UniqueConstraint` and no comments). It's uniqueness-equivalent and metadata-only, but it adds autogenerate noise — handled in a follow-up reconcile migration, not here.
