### PR TITLE
feat(ui): dark-default theme, footer + privacy page, mobile responsiveness

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -23,8 +23,9 @@
   import Pagination from "./lib/Pagination.svelte";
   import ArticleCard from "./lib/ArticleCard.svelte";
   import BookmarksView from "./lib/BookmarksView.svelte";
+  import Privacy from "./lib/Privacy.svelte";
 
-  type Page = "articles" | "analytics" | "bookmarks";
+  type Page = "articles" | "analytics" | "bookmarks" | "privacy";
   let currentPage: Page = "articles";
 
   let articles: ArticleDto[] = [];
@@ -390,6 +391,8 @@
     <BookmarksView />
   {:else if currentPage === "analytics" && $userStore}
     <Dashboard />
+  {:else if currentPage === "privacy"}
+    <Privacy />
   {:else}
     <div class="empty-state">
       <div class="empty-icon" aria-hidden="true">◌</div>
@@ -399,12 +402,76 @@
   {/if}
 </main>
 
+<footer class="site-footer">
+  <div class="footer-inner">
+    <p class="footer-copy">
+      © 2026 aiFeelNews — a university project at
+      <a href="https://code.berlin" target="_blank" rel="noopener noreferrer">CODE University</a>.
+    </p>
+    <p class="footer-credits">
+      Sentiment by Google Cloud Natural Language · Articles via Mediastack ·
+      No tracking cookies.
+    </p>
+    <nav class="footer-nav" aria-label="Footer">
+      <button class="footer-link" on:click={() => (currentPage = "privacy")}>Privacy</button>
+      <a
+        class="footer-link"
+        href="https://github.com/cardox6/aifeelnews"
+        target="_blank"
+        rel="noopener noreferrer">Source on GitHub</a>
+    </nav>
+  </div>
+</footer>
+
 <style>
   .articles-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
     gap: var(--sp-5);
     margin-bottom: var(--sp-6);
+  }
+
+  .site-footer {
+    border-top: 1px solid var(--border);
+    margin-top: var(--sp-10);
+    padding: var(--sp-6) var(--sp-4);
+    background: var(--bg-panel);
+  }
+  .footer-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--sp-2) var(--sp-5);
+    font-size: 13px;
+    color: var(--text-ter);
+  }
+  .footer-copy { margin: 0; color: var(--text-sec); }
+  .footer-copy a { color: var(--text-sec); text-decoration: underline; }
+  .footer-credits { margin: 0; }
+  .footer-nav {
+    margin-left: auto;
+    display: flex;
+    gap: var(--sp-4);
+  }
+  .footer-link {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--text-sec);
+    font: inherit;
+    text-decoration: none;
+  }
+  .footer-link:hover { color: var(--text-pri); }
+  .footer-link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--r-sm);
+  }
+  @media (max-width: 640px) {
+    .footer-nav { margin-left: 0; }
   }
   .error-icon { font-size: 16px; flex-shrink: 0; }
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -360,3 +360,45 @@ select option {
   padding: 0; margin: -1px; overflow: hidden;
   clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
 }
+
+/* ─── MOBILE ──────────────────────────────────────────────────────────────
+   Phones/small tablets. Two goals: (1) the header must never force horizontal
+   scroll, and (2) interactive controls meet the 44px touch-target minimum and
+   use a >=16px font so iOS doesn't auto-zoom the page on focus. */
+@media (max-width: 768px) {
+  /* Header: let the row wrap instead of overflowing; the nav drops to its own
+     full-width line below the wordmark + account controls. */
+  .header-inner {
+    height: auto;
+    flex-wrap: wrap;
+    gap: var(--sp-3);
+    padding: var(--sp-3) var(--sp-4);
+  }
+  .nav {
+    order: 3;
+    width: 100%;
+    justify-content: flex-start;
+    gap: var(--sp-1);
+  }
+  .header-right { gap: var(--sp-2); }
+  .user-email { max-width: 40vw; }
+
+  /* Touch targets: nav, buttons, the theme toggle, and form controls. */
+  .nav-button,
+  .btn {
+    min-height: 44px;
+    padding: 8px 14px;
+  }
+  .theme-toggle {
+    width: 44px;
+    height: 44px;
+  }
+  select,
+  input[type="text"],
+  input[type="search"] {
+    min-height: 44px;
+    padding: 10px 12px;
+    font-size: 16px; /* >=16px stops iOS Safari from zooming on focus */
+  }
+  select { padding-right: 30px; }
+}

--- a/frontend/src/lib/ArticleCard.svelte
+++ b/frontend/src/lib/ArticleCard.svelte
@@ -423,6 +423,11 @@
     font-weight: 500;
     border: 1px solid;
     white-space: nowrap;
+    /* A long, unbroken entity name must not push past the card's right edge
+       (a horizontal-scroll nudge on narrow screens). Clip with an ellipsis. */
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .chip-topic {
     background: var(--accent-dim);
@@ -491,4 +496,17 @@
     transition: background var(--transition);
   }
   .bookmark-card-remove:hover { background: rgba(251, 113, 133, 0.28); }
+
+  /* Mobile: bump the bookmark toggle and remove button to a 44px touch target
+     so they aren't mis-tapped (e.g. hitting "Read article" instead). */
+  @media (max-width: 768px) {
+    .bookmark-btn {
+      width: 44px;
+      height: 44px;
+    }
+    .bookmark-card-remove {
+      min-height: 44px;
+      padding: 8px 14px;
+    }
+  }
 </style>

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -754,4 +754,18 @@
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
   }
+
+  /* Small phones: the auto-fit minmax(150px) packs 2 cramped KPI tiles and
+     leaves the 5th stranded. Pin a clean 2-up grid with tighter padding, and
+     give the time-range select the full row so it isn't a sub-44px target. */
+  @media (max-width: 480px) {
+    .kpi-row {
+      grid-template-columns: 1fr 1fr;
+      gap: var(--sp-2);
+    }
+    .kpi-tile { padding: var(--sp-3) var(--sp-4); }
+    .kpi-value { font-size: 1.375rem; }
+    .controls { flex-direction: column; align-items: stretch; }
+    .controls select { width: 100%; }
+  }
 </style>

--- a/frontend/src/lib/FilterBar.svelte
+++ b/frontend/src/lib/FilterBar.svelte
@@ -137,4 +137,16 @@
     font-size: 14px;
     pointer-events: none;
   }
+
+  /* Narrow phones: stack each control full-width instead of wrapping the
+     8rem-min selects into a cramped, uneven grid with an auto-margin gap. */
+  @media (max-width: 600px) {
+    .filter-select,
+    .search-wrap {
+      flex: 1 1 100%;
+      min-width: 0;
+      max-width: none;
+      margin-left: 0;
+    }
+  }
 </style>

--- a/frontend/src/lib/Pagination.svelte
+++ b/frontend/src/lib/Pagination.svelte
@@ -51,7 +51,10 @@
     padding: var(--sp-4) 0;
   }
   .pagination-button {
-    padding: 6px 14px;
+    /* min-height keeps prev/next at the 44px touch-target minimum — these are
+       the only feed-paging controls, so a mis-fire is costly on mobile. */
+    min-height: 44px;
+    padding: 10px 16px;
     border-radius: var(--r-md);
     border: 1px solid var(--border-med);
     background: var(--bg-raised);

--- a/frontend/src/lib/Privacy.svelte
+++ b/frontend/src/lib/Privacy.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  // A short, honest privacy statement that reflects what the app actually does.
+  // This is NOT corporate boilerplate — every claim maps to the real
+  // architecture (data minimisation, TTL, EU region, no tracking).
+  const lastUpdated = "June 2026";
+</script>
+
+<section class="privacy" aria-labelledby="privacy-title">
+  <div class="page-head">
+    <h1 class="page-title" id="privacy-title">Privacy</h1>
+    <p class="page-subtitle">
+      What we collect, why, and what we deliberately don't do. Last updated {lastUpdated}.
+    </p>
+  </div>
+
+  <div class="prose">
+    <p>
+      aiFeelNews is a university project that analyses the sentiment of news
+      articles. This page describes how it handles data. It is written to be
+      accurate, not to cover a business we don't run.
+    </p>
+
+    <h2>What we collect</h2>
+    <ul>
+      <li>
+        <strong>Your email address</strong>, when you sign in. We use it only to
+        identify your account and attach your bookmarks to it.
+      </li>
+      <li>
+        <strong>Your bookmarks</strong> — the articles you save while signed in.
+      </li>
+    </ul>
+    <p>
+      We do <strong>not</strong> collect names, payment details, location, or
+      browsing history, and we do not build advertising or behavioural profiles.
+    </p>
+
+    <h2>Sign-in</h2>
+    <p>
+      Authentication is handled by <strong>Firebase Authentication</strong>
+      (Google sign-in). Your session token is stored locally in your browser
+      (IndexedDB / local storage), <strong>not</strong> in cookies, and is sent
+      to our API only to authorise your own requests.
+    </p>
+
+    <h2>Cookies &amp; tracking</h2>
+    <p>
+      This site sets <strong>no cookies</strong> and uses <strong>no
+      third-party analytics, advertising, or tracking</strong>. That's why you
+      won't see a cookie-consent banner — there's nothing to consent to.
+    </p>
+
+    <h2>Article content &amp; data minimisation</h2>
+    <p>
+      We ingest article metadata from <strong>Mediastack</strong> and, where
+      permitted by a site's <code>robots.txt</code>, crawl the original article
+      to analyse it. We <strong>do not keep full article bodies</strong>:
+      extracted text is truncated to 1,024 characters and automatically deleted
+      after 7 days by a time-to-live (TTL) cleanup job. Sentiment, entities and
+      categories are produced by <strong>Google Cloud Natural Language</strong>.
+    </p>
+
+    <h2>Where your data lives</h2>
+    <p>
+      Data is stored on Google Cloud in the <strong>europe-west1 (EU)</strong>
+      region.
+    </p>
+
+    <h2>Your choices</h2>
+    <ul>
+      <li>You can remove any bookmark at any time while signed in.</li>
+      <li>
+        To have your account email and bookmarks deleted, contact the project
+        maintainer via the
+        <a href="https://github.com/cardox6/aifeelnews" target="_blank" rel="noopener noreferrer">
+          project repository</a>.
+      </li>
+    </ul>
+
+    <p class="text-ter">
+      This is a student project and not a commercial service; this statement is
+      a good-faith description of its data handling, not a legal contract.
+    </p>
+  </div>
+</section>
+
+<style>
+  .privacy {
+    max-width: 760px;
+  }
+  .prose {
+    color: var(--text-sec);
+    line-height: 1.7;
+  }
+  .prose h2 {
+    color: var(--text-pri);
+    font-size: 1.1rem;
+    margin: var(--sp-6) 0 var(--sp-2);
+  }
+  .prose ul {
+    padding-left: 1.25rem;
+    margin: var(--sp-2) 0;
+  }
+  .prose li {
+    margin: 0.35rem 0;
+  }
+  .prose code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.1em 0.35em;
+    border-radius: var(--r-sm);
+    background: var(--bg-raised);
+  }
+  .prose a {
+    color: var(--accent);
+  }
+</style>

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -6,11 +6,12 @@ const STORAGE_KEY = "aifeelnews-theme";
 
 function readInitial(): Theme {
   if (typeof window === "undefined") return "dark";
+  // Dark-first by design: a first-time visitor always sees the intended dark
+  // theme (we deliberately do NOT follow the OS prefers-color-scheme, so the
+  // app's designed look is the first impression). Returning visitors keep
+  // whatever they explicitly toggled to, persisted in localStorage.
   const stored = window.localStorage.getItem(STORAGE_KEY);
-  if (stored === "dark" || stored === "light") return stored;
-  // Default to dark (the design is dark-first); honour an explicit OS light pref.
-  const prefersLight = window.matchMedia?.("(prefers-color-scheme: light)").matches;
-  return prefersLight ? "light" : "dark";
+  return stored === "light" ? "light" : "dark";
 }
 
 function applyTheme(theme: Theme): void {


### PR DESCRIPTION
## Summary

Three frontend UX improvements: a dark-default theme, an honest footer + privacy page, and a mobile-responsiveness pass (from a verified audit that found the app "not mobile-ready").

## Dark-default theme

`theme.ts` no longer follows the OS `prefers-color-scheme`. A first-time visitor always sees the **intended dark design**; returning visitors keep whatever they explicitly toggled (still persisted in `localStorage`). The design is dark-first, so the default should be the designed look, with the toggle as the opt-out.

## Footer + honest privacy page

- **Footer**: copyright + "university project" framing, data attributions (Google Cloud Natural Language + Mediastack), a "no tracking cookies" line, a Privacy link, and a source-repo link. Themed with the existing tokens, responsive.
- **Privacy page**: a 4th state-machine page reachable **publicly** from the footer (no routing). Content is accurate to the real architecture, not boilerplate — email + bookmarks collected for app function, Firebase sign-in with the token stored locally (**not cookies**), article bodies truncated to 1024 chars and **TTL-deleted after 7 days** (data minimisation), data in **europe-west1 (EU)**, and no analytics/ads/tracking.
- **No cookie-consent banner** — verified the app sets zero cookies, so there's nothing to consent to. Stated as a privacy-by-design point instead (good for the Cybersecurity module).

## Mobile responsiveness

A verified responsive audit found the app **"not mobile-ready"**. Fixes for all 10 confirmed issues:
- **Header overflow (the worst issue)**: `.header-inner` now wraps at ≤768px and the nav drops to its own full-width row, so phones no longer get horizontal scroll with the theme toggle / Logout pushed off-screen.
- **Touch targets → 44px** across the shell: nav buttons, `.btn`, theme toggle, pagination prev/next, the article bookmark + remove buttons.
- **Form controls**: `min-height: 44px` + `font-size: 16px` on mobile so iOS Safari stops auto-zooming the page on focus.
- **FilterBar**: selects + search stack full-width on narrow phones instead of a cramped, uneven wrap.
- **Dashboard**: KPI tiles pin to a clean 2-up grid on small phones; the time-range select goes full-width.
- **Entity chips**: clip with an ellipsis so a long unbroken name can't push past the card edge.

## Testing
- `svelte-check`: **0 errors** (166 files); `npm run build` succeeds.
- The mobile `@media` rules, footer, and privacy content are all present in the production build.

> Note: the footer copyright currently reads "© 2026 aiFeelNews — a university project at CODE University" (no personal name, since it isn't in the repo). Tell me the exact wording if you want your name added.
