### PR TITLE
docs: sync READMEs, personas, and demo guide with final shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ingests articles from Mediastack, crawls original content (respecting robots.txt
 
 | Layer | Technology |
 |-------|-----------|
-| **Backend** | FastAPI + SQLAlchemy + PostgreSQL 14 (Python 3.13) |
+| **Backend** | FastAPI + SQLAlchemy + PostgreSQL 14 (Python 3.14) |
 | **Frontend** | Svelte 5 + Vite + TypeScript |
 | **Cloud** | GCP Cloud Run, Cloud SQL, Secret Manager, Cloud NL API, Cloud Scheduler, BigQuery, Cloud Monitoring, Cloud Logging |
 | **Auth** | Firebase Auth (Google Sign-In) + server-side ID token verification |
@@ -29,7 +29,7 @@ Ingests articles from Mediastack, crawls original content (respecting robots.txt
 ### Prerequisites
 
 - Docker + Docker Compose (recommended — supported full-stack path)
-- Python 3.13+ (only if running the backend on the host instead of in Compose)
+- Python 3.14+ (only if running the backend on the host instead of in Compose)
 - Node.js 18+ (frontend dev server)
 
 ### Two run modes
@@ -111,7 +111,7 @@ SQLite is **not** a supported substitute for Postgres at the migration layer —
 | **Tests** | SQLite (in-memory) | Created on the fly via `Base.metadata.create_all` — bypasses migrations |
 | **Production** | Cloud SQL | Managed via Terraform — see [Multi-Environment Strategy](docs/MULTI_ENVIRONMENT_STRATEGY.md) |
 
-Schema migrations are managed by Alembic (10 migration files; see [docs/DATABASE.md § 2](docs/DATABASE.md#2-migrations) for the inventory):
+Schema migrations are managed by Alembic (13 migration files; see [docs/DATABASE.md § 2](docs/DATABASE.md#2-migrations) for the inventory):
 ```bash
 alembic upgrade head              # Apply all pending migrations
 alembic downgrade -1              # Rollback last migration
@@ -157,9 +157,9 @@ This is the recommended path for local development and demos — no Mediastack k
 | `GET /ready` | Readiness probe (DB-aware) |
 | `GET /version` | Build SHA + timestamp |
 | `GET /metrics` | Lightweight observability metrics |
-| `GET /articles/`, `GET /articles/{id}`, `GET /articles/latest` | Articles with sentiment data; list routes accept `skip`, `limit`, `sentiment_label`, `category`, `source_id`, `search` |
-| `GET /sources/`, `POST /sources/` | News sources |
-| `GET/POST/DELETE /bookmarks/...` | User bookmarks (auth required) |
+| `GET /api/v1/articles/`, `GET /api/v1/articles/{id}`, `GET /api/v1/articles/latest` | Articles with sentiment data; list routes accept `skip`, `limit`, `sentiment_label`, `category`, `source_id`, `search` |
+| `GET /api/v1/sources/`, `POST /api/v1/sources/` | News sources (`POST` is admin-only — see [Authorization](#authentication--authorization)) |
+| `GET/POST/DELETE /api/v1/bookmarks/...` | User bookmarks (auth required) |
 | `GET /api/v1/sentiment/info` | Active sentiment provider |
 | `GET /api/v1/entities/`, `GET /api/v1/entities/types`, `GET /api/v1/entities/{id}` | NLP entities (people, orgs, locations) |
 | `GET /api/v1/analytics/*` | BigQuery analytics (trends, sources, pipeline stats) |
@@ -167,7 +167,7 @@ This is the recommended path for local development and demos — no Mediastack k
 | `POST /api/v1/trigger-ingestion` | Cloud Scheduler: ingest pipeline (OIDC-protected) |
 | `POST /api/v1/cleanup` | Cloud Scheduler: TTL cleanup (OIDC-protected) |
 
-> Routers under `/articles`, `/sources`, `/bookmarks`, `/users` are not prefixed with `/api/v1`. The newer analytics + entities + sentiment routers are. This split is historical; standardising the prefix is tracked as a follow-up (`tech-debt: unify API path prefix`).
+> Every application router is mounted under a single `/api/v1` prefix. An earlier split (core CRUD routers unprefixed, newer routers under `/api/v1`) was unified in a coordinated backend + frontend cutover, so there is one versioned API surface and `/docs` shows it whole.
 
 **Production:** https://aifeelnews-web-813770885946.europe-west1.run.app
 
@@ -209,6 +209,7 @@ Detailed STRIDE analysis in [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md); the im
 - Firebase Auth (Google Sign-In) with server-side ID token verification (`app/deps/auth.py`)
 - Protected endpoints require `Authorization: Bearer <firebase-id-token>` header
 - User records created on first authenticated request, linked by Firebase UID
+- **Role-based access control via Firebase custom claims** — a `role` claim rides in the Google-signed ID token and is read server-side; `require_admin` gates admin-only routes (`POST /api/v1/sources/`). The role is verified end-to-end by Google's token signature, so it needs no `users` table column and no second source of truth (`app/deps/auth.py`)
 - Cloud Scheduler endpoints (`/api/v1/trigger-ingestion`, `/api/v1/cleanup`) require a Google-signed OIDC token verified server-side (`app/deps/oidc.py`)
 
 ### Secret Management
@@ -221,7 +222,7 @@ Detailed STRIDE analysis in [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md); the im
 - CORS restricted to specific origins (Firebase Hosting URLs + localhost) — no wildcard
 - Parameterized queries only — no f-string SQL anywhere (BigQuery uses `@param` + `QueryJobConfig`)
 - Input validation via Pydantic schemas on all request/response models
-- Per-IP rate limiting via `slowapi` — 30/min analytics, 60/min sentiment, 6/h scheduler endpoints
+- Per-IP rate limiting via `slowapi` — 30/min on the analytics + PostgreSQL `db-analytics` routes (the heaviest window-function/CTE queries), 60/min sentiment, 60/min `/metrics`, 6/h scheduler endpoints
 
 ### Data Protection
 - Article content truncated to 1024 chars with 7-day TTL expiry (data minimization)

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,3 +35,15 @@ docker-compose -f docker-compose.prod.yml up
 - **Scheduler Service**: Periodic ingestion from Mediastack API
 
 All services share the same codebase but run different entry points optimized for their specific roles.
+
+## Image hardening
+
+- **Base image:** `python:3.14-slim`, **pinned by digest** (`@sha256:…`) in every Dockerfile — the build is reproducible and can't drift when the `3.14-slim` tag is re-pushed.
+- **Non-root runtime:** each image creates and runs as a dedicated unprivileged user (`app` / `worker` / `scheduler`), never root.
+- **Slim build:** no `gcc` / `libpq-dev` / `curl` in the final image — `psycopg2-binary` ships prebuilt wheels, so no compiler toolchain is needed at runtime, shrinking the image and the attack surface.
+- **Healthchecks use the Python stdlib, not `curl`:** the web image probes `/health` with `urllib`; the worker and scheduler open a `SessionLocal()` DB connection. No extra binaries installed just to health-check.
+
+## Configuration files
+
+- **`docker-compose.yml`** — local full stack: Postgres + web + worker + scheduler. Demo-mode defaults from `.env.example` work as-is (web on host `:8002`, db on `:5433`).
+- **`docker-compose.prod.yml`** — production build target (web / worker / scheduler), used to validate the production image config locally; the live deploy builds these via Cloud Build → Artifact Registry → Cloud Run.

--- a/docs/PERSONAS_AND_USE_CASES.md
+++ b/docs/PERSONAS_AND_USE_CASES.md
@@ -17,8 +17,8 @@
 | Attribute | Detail |
 |-----------|--------|
 | **Goal** | Curate a personal reading list and track preferred topics |
-| **Behaviour** | Signs in (Google or Email/Password), bookmarks articles for later, revisits bookmarks page |
-| **Auth** | Required (Firebase Auth — Google Sign-In or Email/Password) |
+| **Behaviour** | Signs in with Google, bookmarks articles for later, revisits bookmarks page |
+| **Auth** | Required (Firebase Auth — Google Sign-In) |
 | **Key needs** | Persistent bookmarks, quick sign-in, bookmark management |
 | **Frequency** | Daily, 5–10 min sessions |
 
@@ -36,10 +36,10 @@
 
 | Attribute | Detail |
 |-----------|--------|
-| **Goal** | Ensure the ingestion pipeline runs reliably and data quality stays high |
-| **Behaviour** | Checks pipeline health metrics, triggers manual ingestion when needed, monitors crawl job success rates |
-| **Auth** | Required (OIDC-verified for scheduler endpoints) |
-| **Key needs** | Pipeline health dashboard, manual trigger capability, TTL cleanup controls |
+| **Goal** | Ensure the ingestion pipeline runs reliably, data quality stays high, and privileged writes stay locked down |
+| **Behaviour** | Checks pipeline health metrics, triggers manual ingestion when needed, monitors crawl job success rates, registers new news sources |
+| **Auth** | Required — automated jobs are OIDC-verified; human admin writes are gated by an `admin` role claim (Firebase custom claims, `require_admin`) |
+| **Key needs** | Pipeline health dashboard, manual trigger capability, TTL cleanup controls, admin-only source registration |
 | **Frequency** | Ad-hoc, during incidents or after deployment |
 
 ---
@@ -49,30 +49,31 @@
 Each use case has two status columns — backend (the API/data layer) and UI (what the SPA actually exposes to a user) — because the two can move at different speeds:
 
 - ✅ Implemented
-- 🔲 Not yet implemented
+- 🔲 Not yet implemented (on the backlog)
+- ⬚ Decided against — a deliberate non-goal, not a pending item
 - `n/a` Not user-facing (e.g. P4 admin scheduler triggers don't have a UI by design)
 
 ### Casual Reader (P1)
 
 | ID | Use Case | Backend | UI | Endpoint | Notes |
 |----|----------|---------|----|----------|-------|
-| UC-01 | Browse latest articles | ✅ | ✅ | `GET /articles/latest?limit=40` | |
-| UC-02 | View article detail with sentiment + entities | ✅ | 🔲 | `GET /articles/{id}` | Detail page deferred — feed cards already show sentiment badge |
-| UC-03 | Filter articles by sentiment label | ✅ | ✅ | `GET /articles/?sentiment_label=...` | |
-| UC-04 | Filter articles by category | ✅ | ✅ | `GET /articles/?category=...` | UI uses static mediastack enum; categories endpoint deferred |
-| UC-05 | Filter articles by source | ✅ | ✅ | `GET /articles/?source_id=...` | UI populates dropdown from `GET /sources/` |
-| UC-06 | Paginate article feed | ✅ | ✅ | `GET /articles/?skip=...&limit=...` | |
-| UC-07 | Search articles by keyword | ✅ | ✅ | `GET /articles/?search=...` | ILIKE substring on title; pg_trgm upgrade path documented in DATABASE.md |
+| UC-01 | Browse latest articles | ✅ | ✅ | `GET /api/v1/articles/latest?limit=40` | |
+| UC-02 | View article detail with sentiment + entities | ✅ | 🔲 | `GET /api/v1/articles/{id}` | Detail page deferred — feed cards already show sentiment badge |
+| UC-03 | Filter articles by sentiment label | ✅ | ✅ | `GET /api/v1/articles/?sentiment_label=...` | |
+| UC-04 | Filter articles by category | ✅ | ✅ | `GET /api/v1/articles/?category=...` | UI uses static mediastack enum; categories endpoint deferred |
+| UC-05 | Filter articles by source | ✅ | ✅ | `GET /api/v1/articles/?source_id=...` | UI populates dropdown from `GET /api/v1/sources/` |
+| UC-06 | Paginate article feed | ✅ | ✅ | `GET /api/v1/articles/?skip=...&limit=...` | |
+| UC-07 | Search articles by keyword | ✅ | ✅ | `GET /api/v1/articles/?search=...` | ILIKE substring on title; pg_trgm upgrade path documented in DATABASE.md |
 
 ### Registered Reader (P2)
 
 | ID | Use Case | Backend | UI | Endpoint | Notes |
 |----|----------|---------|----|----------|-------|
 | UC-08 | Sign in with Google | ✅ | ✅ | Firebase Auth (Google provider) | |
-| UC-09 | Sign in with Email/Password | 🔲 | 🔲 | Firebase Auth (Email provider) | Phase D — risk of regressing working Google sign-in, deferred |
-| UC-10 | Bookmark an article | ✅ | ✅ | `POST /bookmarks/` | Optimistic UI; 409 treated as silent success |
-| UC-11 | View bookmarks list | ✅ | ✅ | `GET /bookmarks/` | Dedicated `/bookmarks` view in SPA |
-| UC-12 | Remove a bookmark | ✅ | ✅ | `DELETE /bookmarks/{id}` | Optimistic remove with revert-on-error |
+| UC-09 | Sign in with Email/Password | ⬚ | ⬚ | — | **Decided against** (not a backlog item). The access-control story is RBAC via Firebase custom claims, not a second credential flow; adding Email/Password would risk regressing the working Google flow for little return. See note below. |
+| UC-10 | Bookmark an article | ✅ | ✅ | `POST /api/v1/bookmarks/` | Optimistic UI; 409 treated as silent success |
+| UC-11 | View bookmarks list | ✅ | ✅ | `GET /api/v1/bookmarks/` | Dedicated `/bookmarks` view in SPA |
+| UC-12 | Remove a bookmark | ✅ | ✅ | `DELETE /api/v1/bookmarks/{id}` | Optimistic remove with revert-on-error |
 
 ### News Analyst (P3)
 
@@ -85,6 +86,7 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 | UC-17 | View NLP category breakdown | ✅ | ✅ | `GET /api/v1/analytics/categories/nlp` | Analytics dashboard, "GCP NL Categories" chart |
 | UC-18 | Browse entity directory | ✅ | 🔲 | `GET /api/v1/entities/?entity_type=...` | |
 | UC-19 | View entity detail | ✅ | 🔲 | `GET /api/v1/entities/{id}` | |
+| UC-24 | View advanced-SQL trend charts (rolling avg, source ranking, category breakdown) | ✅ | ✅ | `GET /api/v1/db-analytics/*` | Analytics dashboard — PostgreSQL window-function/CTE/GROUPING SETS charts. Backed by the operational DB, so these **populate in demo mode** (no BigQuery/GCP-NL needed), unlike the GCP-NL-backed UC-15/16/17 entity & category charts |
 
 ### System Administrator (P4)
 
@@ -93,31 +95,39 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 | UC-20 | Trigger manual ingestion | ✅ | n/a | `POST /api/v1/trigger-ingestion` | Cloud Scheduler-driven, OIDC-verified |
 | UC-21 | View pipeline health metrics | ✅ | n/a | `GET /api/v1/analytics/pipeline?days=7` | Available to operators via API + GCP console |
 | UC-22 | Run TTL content cleanup | ✅ | n/a | `POST /api/v1/cleanup` | Cloud Scheduler-driven, OIDC-verified |
+| UC-23 | Register a new news source (admin) | ✅ | n/a | `POST /api/v1/sources/` | Gated by `require_admin` — caller's Firebase ID token must carry an `admin` role claim (custom claims). Non-admins get 403, unauthenticated 401 |
 
 ---
 
 ## Use Case Summary
 
-| Persona | Backend ✅ | UI ✅ | UI 🔲 | UI n/a | Backend 🔲 |
+| Persona | Backend ✅ | UI ✅ | UI 🔲 | UI n/a | Backlog 🔲 |
 |---------|-----------|------|------|--------|-----------|
 | P1 Casual Reader | 7 / 7 | 6 / 7 | 1 (UC-02) | 0 | 0 |
-| P2 Registered Reader | 4 / 5 | 4 / 5 | 0 | 0 | 1 (UC-09) |
-| P3 News Analyst | 7 / 7 | 4 / 7 | 3 (UC-16, UC-18, UC-19) | 0 | 0 |
-| P4 System Administrator | 3 / 3 | n/a | n/a | 3 | 0 |
-| **Totals** | **21 / 22** | **14 / 19 user-facing** | **5** | **3** | **1** |
+| P2 Registered Reader | 4 / 4 | 4 / 4 | 0 | 0 | 0 |
+| P3 News Analyst | 8 / 8 | 5 / 8 | 3 (UC-16, UC-18, UC-19) | 0 | 0 |
+| P4 System Administrator | 4 / 4 | n/a | n/a | 4 | 0 |
+| **Totals** | **23 / 23** | **15 / 19 user-facing** | **4** | **4** | **0** |
 
-User-facing UC count excludes P4 (scheduler-driven, no UI by design).
+Every defined use case has its backend implemented. UC-09 (Email/Password sign-in) is excluded from these counts — it is a deliberate non-goal (⬚), not a backlog gap (see the note under the Registered Reader table and the Roadmap section). User-facing UI counts exclude P4 (scheduler/admin-driven, no UI by design).
 
 ---
 
 ## Roadmap for not-yet-implemented use cases
 
+These are UI-only gaps — the backend is implemented in every case; only the SPA surface is outstanding.
+
 | ID | Status | Plan |
 |----|--------|------|
 | UC-02 | UI 🔲 | Article detail page — Svelte route showing full content, entities, sentiment scores. Backend ready. |
-| UC-09 | Backend + UI 🔲 | Email/Password sign-in via Firebase Auth. Deferred because it touches the working Google flow. |
 | UC-16 | UI 🔲 | Entity sentiment-distribution chart. Backend ready; not yet on the dashboard. |
 | UC-18, UC-19 | UI 🔲 | Entity directory list + detail page. Backend ready. |
+
+### Deliberate non-goals
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| UC-09 | ⬚ Email/Password sign-in — **decided against** | The access-control story is **RBAC via Firebase custom claims** (an `admin` role claim read from the Google-signed token, gating `POST /api/v1/sources/` via `require_admin`), not a second credential flow. A separate Email/Password path would add surface area and risk regressing the working Google Sign-In for no proportional gain. The original Exposé listed it as planned; this is the considered decision not to pursue it. |
 
 ---
 
@@ -129,13 +139,13 @@ A traceability matrix connects requirements (use cases) to implementation (table
 
 | Table | Use Cases | Why This Table Exists |
 |-------|-----------|----------------------|
-| `sources` | UC-05, UC-14 | Filter by source, compare source sentiment bias |
-| `articles` | UC-01–07 | Core content — every Casual Reader use case hits this table |
+| `sources` | UC-05, UC-14, UC-23, UC-24 | Filter by source, compare/rank source sentiment bias, admin source registration |
+| `articles` | UC-01–07, UC-24 | Core content — every Casual Reader use case hits this table; also the basis of the db-analytics trend charts |
 | `bookmarks` | UC-10–12 | M2M join enabling Registered Reader's personal reading list |
-| `users` | UC-08–09, UC-10–12 | Auth identity; FK anchor for bookmarks |
+| `users` | UC-08, UC-10–12 | Auth identity; FK anchor for bookmarks. The `admin` authorization role rides in the Firebase ID token (custom claim), so it needs no column here |
 | `article_contents` | UC-02 | Crawled body text shown on article detail page |
-| `sentiment_analyses` | UC-02, UC-13–14 | Multi-provider scores drive sentiment badges and trend charts |
+| `sentiment_analyses` | UC-02, UC-13–14, UC-24 | Multi-provider scores drive sentiment badges, trend charts, and the rolling-average/ranking db-analytics queries |
 | `entities` | UC-15–16, UC-18–19 | Canonical entity lookup for News Analyst tracking |
-| `article_entities` | UC-15–16, UC-18 | M2M with payload — salience/mention_count power entity analytics |
-| `article_categories` | UC-04, UC-17 | NLP classification enables category filtering and heatmaps |
+| `article_entities` | UC-15–16, UC-18, UC-24 | M2M with payload — salience/mention_count power entity analytics + the entity-momentum query |
+| `article_categories` | UC-04, UC-17, UC-24 | NLP classification enables category filtering, heatmaps, and the daily-category breakdown |
 | `crawl_jobs` | UC-21 | Pipeline health metrics for System Admin |

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -90,7 +90,7 @@ LIMIT 20;
 -- ix_articles_source_id covers both the filter and the FK join
 ```
 
-`articles.title ILIKE '%term%'` (the `/articles/?search=` path) is **not** indexed — leading wildcard, B-tree can't help → Seq Scan. `pg_trgm` GIN is the documented upgrade path (`DATABASE.md § 4.4`); deferred (not the bottleneck; needs the extension; GIN overkill at 30k rows).
+`articles.title ILIKE '%term%'` (the `/api/v1/articles/?search=` path) is **not** indexed — leading wildcard, B-tree can't help → Seq Scan. `pg_trgm` GIN is the documented upgrade path (`DATABASE.md § 4.4`); deferred (not the bottleneck; needs the extension; GIN overkill at 30k rows).
 
 ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,6 +32,12 @@ See `.env.example` for required variables:
 - `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_AUTH_DOMAIN`, etc. — from your Firebase project
 - `VITE_API_BASE_URL` — backend API URL
 
+## 🎨 UI notes
+
+- **Dark-first theme.** The app ships dark by default (a first visit always sees the designed dark look — it deliberately does *not* follow the OS `prefers-color-scheme`). A header toggle switches to light and the choice persists in `localStorage` (`src/lib/theme.ts`).
+- **Privacy by design, no cookies.** Firebase stores its auth token in `localStorage`/IndexedDB, not cookies, and the app sets no tracking cookies — so there is no cookie banner. The footer states this and links to an in-app **Privacy** page (`src/lib/Privacy.svelte`) that describes what data the platform handles.
+- **3-page SPA.** A lightweight state machine (`articles | analytics | bookmarks`, plus the public privacy page) — no SvelteKit/router. The wordmark is a home link.
+
 ## 🛠️ Project Structure
 
 - `src/` — Svelte app source code
@@ -42,4 +48,4 @@ See `.env.example` for required variables:
 - See the root `README.md` and `docs/PROJECT_STRUCTURE.md` for backend and deployment details.
 
 ## 🚀 Production URL
-https://aifeelnews-front.firebaseapp.com
+https://aifeelnews-front.web.app/


### PR DESCRIPTION
Reconciles the project documentation with the final shipped state after the capstone-finalization pass (audit hardening, Python 3.14 uplift, frontend revamp). Docs-only — no code changes.

## What changed

**README.md**
- Python 3.13 → 3.14 (tech-stack table + host prerequisite).
- Migration count 10 → 13.
- API endpoints table now shows the unified `/api/v1` surface; replaced the "historical split / tech-debt" note (the split was removed in the coordinated cutover).
- Documented RBAC via Firebase custom claims (`require_admin` gates `POST /api/v1/sources/`).
- Rate-limit summary updated (db-analytics throttled, `/metrics` has its own limit).

**frontend/README.md**
- Production URL `firebaseapp.com` → `web.app`.
- Noted the dark-first theme, the no-cookie privacy posture + in-app Privacy page, and the 3-page state-machine SPA (no SvelteKit).

**docker/README.md**
- Documented image hardening: digest-pinned `python:3.14-slim`, non-root users, slim build, stdlib healthchecks.
- Described `docker-compose.yml` vs `docker-compose.prod.yml`.

**docs/PERSONAS_AND_USE_CASES.md**
- UC-09 (Email/Password) reframed from "deferred" to a deliberate non-goal, with rationale.
- Added UC-23 (admin-gated source registration) and UC-24 (PostgreSQL db-analytics dashboard charts, populated in demo mode).
- Updated personas, summary counts, roadmap, traceability matrix, and endpoint columns (`/api/v1`).

**docs/demo-guide.md**
- One legacy `/articles` reference → `/api/v1/articles`.

## Related

GitHub Milestones were updated alongside this: M10 (Frontend Overhaul) and M11 (Test Coverage) closed; M12 (Capstone Phase 2) trimmed to the genuinely-remaining items.
