### PR TITLE
feat(analytics): surface entity-sentiment charts + add BigQuery timeline query

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -14,6 +14,7 @@ from app.deps.ratelimit import limiter as _limiter
 from app.schemas.analytics import (
     CategoryBreakdown,
     EntitySentiment,
+    EntitySentimentTimelinePoint,
     NlpCategoryBreakdown,
     PipelineRun,
     SentimentTrendPoint,
@@ -23,6 +24,7 @@ from app.schemas.analytics import (
 from app.services.bigquery import (
     get_category_breakdown,
     get_entity_sentiment,
+    get_entity_sentiment_timeline,
     get_nlp_categories,
     get_pipeline_stats,
     get_sentiment_trends,
@@ -133,6 +135,26 @@ def entity_sentiment(
         return _disabled_response()
     return [
         EntitySentiment(**row) for row in get_entity_sentiment(days, entity_type, limit)
+    ]
+
+
+@router.get(
+    "/entities/sentiment-timeline",
+    response_model=Union[List[EntitySentimentTimelinePoint], Dict[str, str]],
+)
+@_limiter.limit(_RATE)
+def entity_sentiment_timeline(
+    request: Request,
+    days: int = Query(30, ge=1, le=365),
+    entity_type: Optional[str] = Query(None, description="Filter by entity type"),
+    limit: int = Query(8, ge=1, le=50),
+) -> Union[List[EntitySentimentTimelinePoint], Dict[str, str]]:
+    """Per-day average sentiment trend for the top-N most-mentioned entities."""
+    if not config.bigquery.enable_bigquery:
+        return _disabled_response()
+    return [
+        EntitySentimentTimelinePoint(**row)
+        for row in get_entity_sentiment_timeline(days, entity_type, limit)
     ]
 
 

--- a/app/schemas/analytics.py
+++ b/app/schemas/analytics.py
@@ -76,3 +76,13 @@ class NlpCategoryBreakdown(BaseModel):
     article_count: int
     avg_confidence: Optional[float] = None
     avg_sentiment_score: Optional[float] = None
+
+
+class EntitySentimentTimelinePoint(BaseModel):
+    """Per-day average sentiment for a single entity in the top-N set."""
+
+    date: date
+    entity_name: str
+    entity_type: str
+    article_count: int
+    avg_sentiment_score: Optional[float] = None

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -727,6 +727,62 @@ def get_entity_sentiment(
         raise BigQueryQueryError("Entity sentiment query failed") from e
 
 
+def get_entity_sentiment_timeline(
+    days: int = 30,
+    entity_type: Optional[str] = None,
+    limit: int = 8,
+) -> List[Dict[str, Any]]:
+    """Per-day average sentiment for the top-N most-mentioned entities."""
+    if not config.bigquery.enable_bigquery:
+        return []
+
+    from google.cloud import bigquery  # type: ignore[import-untyped,attr-defined]
+
+    fqn = _table_fqn(config.bigquery.entity_table)
+
+    query = f"""
+    WITH top_entities AS (
+        SELECT entity_name, entity_type
+        FROM {fqn}
+        WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+          AND (@entity_type IS NULL OR entity_type = @entity_type)
+          AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+        GROUP BY entity_name, entity_type
+        ORDER BY COUNT(DISTINCT article_id) DESC
+        LIMIT @limit
+    )
+    SELECT
+        DATE(e.ingested_at) AS date,
+        e.entity_name,
+        e.entity_type,
+        COUNT(DISTINCT e.article_id) AS article_count,
+        AVG(e.sentiment_score) AS avg_sentiment_score
+    FROM {fqn} AS e
+    JOIN top_entities AS t
+      ON e.entity_name = t.entity_name AND e.entity_type = t.entity_type
+    WHERE e.ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+      AND (@entity_type IS NULL OR e.entity_type = @entity_type)
+      AND e.entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+    GROUP BY date, e.entity_name, e.entity_type
+    ORDER BY date ASC, article_count DESC
+    """
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("days", "INT64", days),
+            bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
+            bigquery.ScalarQueryParameter("limit", "INT64", limit),
+        ]
+    )
+
+    try:
+        results = _get_client().query(query, job_config=job_config)
+        return [dict(row) for row in results]
+    except Exception as e:
+        logger.error("Entity sentiment timeline query failed: %s", e, exc_info=True)
+        raise BigQueryQueryError("Entity sentiment timeline query failed") from e
+
+
 def get_nlp_categories(
     days: int = 30,
     limit: int = 20,

--- a/docs/PERSONAS_AND_USE_CASES.md
+++ b/docs/PERSONAS_AND_USE_CASES.md
@@ -81,12 +81,13 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 |----|----------|---------|----|----------|-------|
 | UC-13 | View sentiment trends over time | ✅ | ✅ | `GET /api/v1/analytics/trends?days=30` | Analytics dashboard, "Sentiment Trends" chart |
 | UC-14 | Compare sources by sentiment | ✅ | ✅ | `GET /api/v1/analytics/sources?days=30` | Analytics dashboard, "Source Comparison" chart |
-| UC-15 | View top entities by mention count | ✅ | ✅ | `GET /api/v1/analytics/entities/top` | Analytics dashboard, "Top Entities" chart |
-| UC-16 | View entity sentiment distribution | ✅ | 🔲 | `GET /api/v1/analytics/entities/sentiment` | |
+| UC-15 | View top entities by mention count | ✅ | ✅ | `GET /api/v1/analytics/entities/top` | Analytics dashboard, "Most-Mentioned People & Organizations" chart; entity-type filter (PERSON/ORGANIZATION/…) |
+| UC-16 | View entity sentiment distribution | ✅ | ✅ | `GET /api/v1/analytics/entities/sentiment` | Analytics dashboard, "Most Positively & Negatively Covered Names" chart; entity-type filter (PERSON/ORGANIZATION/…) |
 | UC-17 | View NLP category breakdown | ✅ | ✅ | `GET /api/v1/analytics/categories/nlp` | Analytics dashboard, "GCP NL Categories" chart |
 | UC-18 | Browse entity directory | ✅ | 🔲 | `GET /api/v1/entities/?entity_type=...` | |
 | UC-19 | View entity detail | ✅ | 🔲 | `GET /api/v1/entities/{id}` | |
 | UC-24 | View advanced-SQL trend charts (rolling avg, source ranking, category breakdown) | ✅ | ✅ | `GET /api/v1/db-analytics/*` | Analytics dashboard — PostgreSQL window-function/CTE/GROUPING SETS charts. Backed by the operational DB, so these **populate in demo mode** (no BigQuery/GCP-NL needed), unlike the GCP-NL-backed UC-15/16/17 entity & category charts |
+| UC-25 | View per-entity sentiment trend over time | ✅ | ✅ | `GET /api/v1/analytics/entities/sentiment-timeline` | Analytics dashboard, "How Coverage Sentiment Shifts Over Time" — BigQuery-native daily timeline for the top-N entities; fulfils P3's "tracks entity sentiment over time" goal |
 
 ### System Administrator (P4)
 
@@ -105,9 +106,9 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 |---------|-----------|------|------|--------|-----------|
 | P1 Casual Reader | 7 / 7 | 6 / 7 | 1 (UC-02) | 0 | 0 |
 | P2 Registered Reader | 4 / 4 | 4 / 4 | 0 | 0 | 0 |
-| P3 News Analyst | 8 / 8 | 5 / 8 | 3 (UC-16, UC-18, UC-19) | 0 | 0 |
+| P3 News Analyst | 9 / 9 | 7 / 9 | 2 (UC-18, UC-19) | 0 | 0 |
 | P4 System Administrator | 4 / 4 | n/a | n/a | 4 | 0 |
-| **Totals** | **23 / 23** | **15 / 19 user-facing** | **4** | **4** | **0** |
+| **Totals** | **24 / 24** | **17 / 20 user-facing** | **3** | **4** | **0** |
 
 Every defined use case has its backend implemented. UC-09 (Email/Password sign-in) is excluded from these counts — it is a deliberate non-goal (⬚), not a backlog gap (see the note under the Registered Reader table and the Roadmap section). User-facing UI counts exclude P4 (scheduler/admin-driven, no UI by design).
 
@@ -120,7 +121,6 @@ These are UI-only gaps — the backend is implemented in every case; only the SP
 | ID | Status | Plan |
 |----|--------|------|
 | UC-02 | UI 🔲 | Article detail page — Svelte route showing full content, entities, sentiment scores. Backend ready. |
-| UC-16 | UI 🔲 | Entity sentiment-distribution chart. Backend ready; not yet on the dashboard. |
 | UC-18, UC-19 | UI 🔲 | Entity directory list + detail page. Backend ready. |
 
 ### Deliberate non-goals
@@ -145,7 +145,7 @@ A traceability matrix connects requirements (use cases) to implementation (table
 | `users` | UC-08, UC-10–12 | Auth identity; FK anchor for bookmarks. The `admin` authorization role rides in the Firebase ID token (custom claim), so it needs no column here |
 | `article_contents` | UC-02 | Crawled body text shown on article detail page |
 | `sentiment_analyses` | UC-02, UC-13–14, UC-24 | Multi-provider scores drive sentiment badges, trend charts, and the rolling-average/ranking db-analytics queries |
-| `entities` | UC-15–16, UC-18–19 | Canonical entity lookup for News Analyst tracking |
-| `article_entities` | UC-15–16, UC-18, UC-24 | M2M with payload — salience/mention_count power entity analytics + the entity-momentum query |
+| `entities` | UC-15–16, UC-18–19, UC-25 | Canonical entity lookup for News Analyst tracking + per-entity sentiment timeline |
+| `article_entities` | UC-15–16, UC-18, UC-24, UC-25 | M2M with payload — salience/mention_count power entity analytics + the entity-momentum and sentiment-timeline queries |
 | `article_categories` | UC-04, UC-17, UC-24 | NLP classification enables category filtering, heatmaps, and the daily-category breakdown |
 | `crawl_jobs` | UC-21 | Pipeline health metrics for System Admin |

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -10,6 +10,8 @@
     fetchCategoriesDaily,
     // BigQuery analytics (additive, only when enabled)
     fetchTopEntities,
+    fetchEntitySentiment,
+    fetchEntitySentimentTimeline,
     fetchNlpCategories,
     type RollingSentimentPoint,
     type SourceRanked,
@@ -17,6 +19,8 @@
     type EntityMomentum,
     type CategoryDailyPoint,
     type TopEntity,
+    type EntitySentiment,
+    type EntitySentimentTimelinePoint,
     type NlpCategoryBreakdown,
   } from './api';
   import { theme } from './theme';
@@ -37,8 +41,16 @@
 
   // ── BigQuery-backed data (additive bonus row when ENABLE_BIGQUERY) ──────
   let bqEntities: TopEntity[] = [];
+  let bqEntitySentiment: EntitySentiment[] = [];
+  let bqEntityTimeline: EntitySentimentTimelinePoint[] = [];
   let bqCategories: NlpCategoryBreakdown[] = [];
-  $: hasBigQuery = bqEntities.length > 0 || bqCategories.length > 0;
+  // Entity-type filter for the BQ entity charts ('' = all types).
+  let entityType = '';
+  $: hasBigQuery =
+    bqEntities.length > 0 ||
+    bqEntitySentiment.length > 0 ||
+    bqEntityTimeline.length > 0 ||
+    bqCategories.length > 0;
 
   // Sentiment palette — emerald / slate / rose, deliberately distinct from
   // the indigo brand accent so a sentiment colour can never read as "brand".
@@ -101,6 +113,8 @@
   let momentumChart: Chart | null = null;
   let catChart: Chart | null = null;
   let bqEntityChart: Chart | null = null;
+  let bqSentimentChart: Chart | null = null;
+  let bqTimelineChart: Chart | null = null;
   let bqCatChart: Chart | null = null;
 
   let rollingCanvas: HTMLCanvasElement;
@@ -109,6 +123,8 @@
   let momentumCanvas: HTMLCanvasElement;
   let catCanvas: HTMLCanvasElement;
   let bqEntityCanvas: HTMLCanvasElement;
+  let bqSentimentCanvas: HTMLCanvasElement;
+  let bqTimelineCanvas: HTMLCanvasElement;
   let bqCatCanvas: HTMLCanvasElement;
 
   // Resolve theme-aware chart colours from the live CSS custom properties so
@@ -170,9 +186,13 @@
       deriveKpis();
 
       // BigQuery analytics are best-effort: if BigQuery is disabled the
-      // endpoints return [] and the bonus row simply doesn't render.
-      [bqEntities, bqCategories] = await Promise.all([
-        fetchTopEntities(days, undefined, 12).catch(() => []),
+      // endpoints return [] and the bonus row simply doesn't render. The
+      // entity-type filter (entityType) narrows the three entity charts;
+      // '' means "all types" and is sent as undefined.
+      [bqEntities, bqEntitySentiment, bqEntityTimeline, bqCategories] = await Promise.all([
+        fetchTopEntities(days, entityType || undefined, 12).catch(() => []),
+        fetchEntitySentiment(days, entityType || undefined, 12).catch(() => []),
+        fetchEntitySentimentTimeline(days, entityType || undefined, 8).catch(() => []),
         fetchNlpCategories(days, 12).catch(() => []),
       ]);
 
@@ -186,13 +206,14 @@
 
   function destroyCharts() {
     for (const c of [
-      rollingChart, rankedChart, breakdownChart,
-      momentumChart, catChart, bqEntityChart, bqCatChart,
+      rollingChart, rankedChart, breakdownChart, momentumChart, catChart,
+      bqEntityChart, bqSentimentChart, bqTimelineChart, bqCatChart,
     ]) {
       c?.destroy();
     }
     rollingChart = rankedChart = breakdownChart = null;
-    momentumChart = catChart = bqEntityChart = bqCatChart = null;
+    momentumChart = catChart = null;
+    bqEntityChart = bqSentimentChart = bqTimelineChart = bqCatChart = null;
   }
 
   function renderCharts() {
@@ -204,6 +225,8 @@
     renderCatCumulative();
     if (hasBigQuery) {
       renderBqEntities();
+      renderBqEntitySentiment();
+      renderBqTimeline();
       renderBqCategories();
     }
   }
@@ -425,6 +448,86 @@
     });
   }
 
+  // 6c — Most positively / negatively covered names (BQ get_entity_sentiment).
+  //      Diverging horizontal bars: green = positive coverage, rose = negative.
+  function renderBqEntitySentiment() {
+    if (!bqSentimentCanvas || !bqEntitySentiment.length) return;
+    const sorted = [...bqEntitySentiment].sort(
+      (a, b) => (b.avg_sentiment_score ?? 0) - (a.avg_sentiment_score ?? 0),
+    );
+    const opts = baseOptions('y') as Record<string, any>;
+    opts.scales.y.grid = { display: false };
+    opts.scales.x.suggestedMin = -1;
+    opts.scales.x.suggestedMax = 1;
+    opts.plugins.tooltip.callbacks = {
+      label: (ctx: any) => {
+        const e = sorted[ctx.dataIndex];
+        return [
+          ` avg sentiment: ${(e.avg_sentiment_score ?? 0).toFixed(3)}`,
+          ` ${e.article_count} articles`,
+        ];
+      },
+    };
+    bqSentimentChart = new Chart(bqSentimentCanvas, {
+      type: 'bar',
+      data: {
+        labels: sorted.map((e) => `${e.entity_name} (${e.entity_type})`),
+        datasets: [
+          {
+            label: 'Avg sentiment',
+            data: sorted.map((e) => e.avg_sentiment_score ?? 0),
+            backgroundColor: sorted.map((e) => sentimentColor(e.avg_sentiment_score)),
+            borderRadius: 3,
+            borderSkipped: false,
+          },
+        ],
+      },
+      options: opts,
+    });
+  }
+
+  // 6d — Entity sentiment over time (BQ get_entity_sentiment_timeline).
+  //      One line per top-N entity; y = daily avg sentiment in [-1, 1].
+  function renderBqTimeline() {
+    if (!bqTimelineCanvas || !bqEntityTimeline.length) return;
+    const days_ = [...new Set(bqEntityTimeline.map((r) => r.date))].sort();
+    const entities = [...new Set(bqEntityTimeline.map((r) => r.entity_name))];
+    // Stable per-entity colour ramp around the accent hue (matches renderCatCumulative).
+    const ramp = ['#7C5CFC', '#34D399', '#FB7185', '#F59E0B', '#38BDF8', '#A78BFA', '#94A3B8', '#F472B6'];
+
+    const opts = baseOptions('x') as Record<string, any>;
+    opts.scales.y.suggestedMin = -1;
+    opts.scales.y.suggestedMax = 1;
+    opts.plugins.legend = { display: true, position: 'bottom', labels: { color: themeVars().tick, boxWidth: 10 } };
+    opts.plugins.tooltip.callbacks = {
+      label: (ctx: any) =>
+        ` ${ctx.dataset.label}: ${ctx.raw == null ? '—' : Number(ctx.raw).toFixed(3)}`,
+    };
+
+    bqTimelineChart = new Chart(bqTimelineCanvas, {
+      type: 'line',
+      data: {
+        labels: days_,
+        datasets: entities.map((name, i) => ({
+          label: name,
+          data: days_.map(
+            (d) =>
+              bqEntityTimeline.find((r) => r.date === d && r.entity_name === name)
+                ?.avg_sentiment_score ?? null,
+          ),
+          borderColor: ramp[i % ramp.length],
+          backgroundColor: ramp[i % ramp.length] + '20',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.3,
+          spanGaps: true,
+          fill: false,
+        })),
+      },
+      options: opts,
+    });
+  }
+
   function renderBqCategories() {
     if (!bqCatCanvas || !bqCategories.length) return;
     const opts = baseOptions('y') as Record<string, any>;
@@ -450,6 +553,11 @@
 
   function handleDaysChange(event: Event) {
     days = parseInt((event.target as HTMLSelectElement).value);
+    loadData();
+  }
+
+  function handleEntityTypeChange(event: Event) {
+    entityType = (event.target as HTMLSelectElement).value;
     loadData();
   }
 
@@ -602,7 +710,18 @@
             aggregated over the full history in the data warehouse.
           </p>
         </div>
-        <span class="bq-badge" title="Served from BigQuery — Google's analytics data warehouse">Data warehouse</span>
+        <div class="bq-header-controls">
+          <select on:change={handleEntityTypeChange} value={entityType} aria-label="Entity type filter">
+            <option value="">All types</option>
+            <option value="PERSON">People</option>
+            <option value="ORGANIZATION">Organizations</option>
+            <option value="LOCATION">Locations</option>
+            <option value="EVENT">Events</option>
+            <option value="WORK_OF_ART">Works of art</option>
+            <option value="CONSUMER_GOOD">Consumer goods</option>
+          </select>
+          <span class="bq-badge" title="Served from BigQuery — Google's analytics data warehouse">Data warehouse</span>
+        </div>
       </div>
       <div class="grid-2">
         <div class="card">
@@ -619,6 +738,30 @@
           {/if}
         </div>
         <div class="card">
+          <h3 class="chart-title">Most Positively &amp; Negatively Covered Names</h3>
+          <p class="chart-sub">
+            Entities ranked by the average sentiment of the articles mentioning
+            them. Green is favourable coverage, rose is unfavourable.
+          </p>
+          {#if bqEntitySentiment.length}
+            <div class="chart-wrap"><canvas bind:this={bqSentimentCanvas}></canvas></div>
+          {:else}
+            <p class="empty">No entity sentiment data</p>
+          {/if}
+        </div>
+        <div class="card card-wide">
+          <h3 class="chart-title">How Coverage Sentiment Shifts Over Time</h3>
+          <p class="chart-sub">
+            Daily average sentiment for the most-mentioned names, tracked across
+            the selected window. Each line is one entity.
+          </p>
+          {#if bqEntityTimeline.length}
+            <div class="chart-wrap"><canvas bind:this={bqTimelineCanvas}></canvas></div>
+          {:else}
+            <p class="empty">No entity timeline data</p>
+          {/if}
+        </div>
+        <div class="card card-wide">
           <h3 class="chart-title">What the News Is About</h3>
           <p class="chart-sub">
             Each article is classified into topics by Google's Natural Language
@@ -753,6 +896,12 @@
     border: 1px solid rgba(124, 92, 252, 0.25);
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
+  }
+  .bq-header-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    flex-wrap: wrap;
   }
 
   /* Small phones: the auto-fit minmax(150px) packs 2 cramped KPI tiles and

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -290,6 +290,14 @@ export type NlpCategoryBreakdown = {
   avg_sentiment_score: number | null;
 };
 
+export type EntitySentimentTimelinePoint = {
+  date: string;
+  entity_name: string;
+  entity_type: string;
+  article_count: number;
+  avg_sentiment_score: number | null;
+};
+
 async function fetchAnalytics<T>(path: string): Promise<T[]> {
   const res = await fetch(`${API_BASE}/api/v1/analytics${path}`);
   if (!res.ok) throw new Error(`Analytics request failed: ${res.status}`);
@@ -326,6 +334,12 @@ export function fetchEntitySentiment(days = 30, entityType?: string, limit = 20)
   let params = `?days=${days}&limit=${limit}`;
   if (entityType) params += `&entity_type=${entityType}`;
   return fetchAnalytics(`/entities/sentiment${params}`);
+}
+
+export function fetchEntitySentimentTimeline(days = 30, entityType?: string, limit = 8): Promise<EntitySentimentTimelinePoint[]> {
+  let params = `?days=${days}&limit=${limit}`;
+  if (entityType) params += `&entity_type=${entityType}`;
+  return fetchAnalytics(`/entities/sentiment-timeline${params}`);
 }
 
 export function fetchNlpCategories(days = 30, limit = 20): Promise<NlpCategoryBreakdown[]> {

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -162,6 +162,12 @@ class TestGracefulDegradation:
         result = get_pipeline_stats()
         assert result == []
 
+    def test_entity_sentiment_timeline_empty_when_disabled(self):
+        from app.services.bigquery import get_entity_sentiment_timeline
+
+        result = get_entity_sentiment_timeline()
+        assert result == []
+
     def test_flush_noop_when_disabled(self):
         from app.services.bigquery import flush
 
@@ -200,6 +206,25 @@ class TestAnalyticsRouter:
         resp = client.get("/api/v1/analytics/pipeline")
         assert resp.status_code == 200
 
+    def test_entity_sentiment_timeline_disabled(self, client):
+        resp = client.get("/api/v1/analytics/entities/sentiment-timeline")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("message") == "BigQuery analytics is not enabled"
+
+    def test_entity_sentiment_timeline_query_validation(self, client):
+        # days must be >= 1
+        resp = client.get("/api/v1/analytics/entities/sentiment-timeline?days=0")
+        assert resp.status_code == 422
+
+        # days must be <= 365
+        resp = client.get("/api/v1/analytics/entities/sentiment-timeline?days=999")
+        assert resp.status_code == 422
+
+        # limit must be <= 50
+        resp = client.get("/api/v1/analytics/entities/sentiment-timeline?limit=99")
+        assert resp.status_code == 422
+
     def test_trends_query_validation(self, client):
         # days must be >= 1
         resp = client.get("/api/v1/analytics/trends?days=0")
@@ -223,5 +248,20 @@ class TestAnalyticsRouter:
                 side_effect=BigQueryQueryError("boom"),
             ):
                 resp = client.get("/api/v1/analytics/trends")
+        assert resp.status_code == 503
+        assert resp.json() != []
+
+    def test_entity_sentiment_timeline_failing_query_returns_503(self, client):
+        """The new timeline endpoint follows the same raise-not-swallow contract:
+        a genuine query failure surfaces as 503, never a silent 200 []."""
+        from app.services.bigquery import BigQueryQueryError
+
+        with patch("app.routers.analytics.config") as mock_cfg:
+            mock_cfg.bigquery.enable_bigquery = True
+            with patch(
+                "app.routers.analytics.get_entity_sentiment_timeline",
+                side_effect=BigQueryQueryError("boom"),
+            ):
+                resp = client.get("/api/v1/analytics/entities/sentiment-timeline")
         assert resp.status_code == 503
         assert resp.json() != []


### PR DESCRIPTION
## Summary

A focused analytics pass on the P3 News Analyst dashboard: render two analytics that were already implemented in the backend but never wired to the UI, and add one new query that BigQuery is uniquely suited to. No change to the Postgres-vs-BigQuery split established in the dashboard work.

## Changes

**1. Surface entity-sentiment ranking (completes UC-16)**
"Most Positively & Negatively Covered Names" chart. The query, endpoint, schema, and `fetchEntitySentiment` wrapper already existed — only the dashboard chart was missing. Distinct from the existing Postgres "Trending Names" chart, which ranks by mention-*frequency growth*, not sentiment *polarity*.

**2. Entity-type filter on the BigQuery entity charts**
A PERSON / ORGANIZATION / LOCATION / … dropdown reusing the `entity_type` param both endpoints already accept. Lives in the AI-Enriched section header, so it never appears in demo / Postgres-only mode where it'd be meaningless.

**3. New query — per-entity sentiment over time (UC-25)**
`get_entity_sentiment_timeline` + `GET /api/v1/analytics/entities/sentiment-timeline`: per-day average sentiment for the top-N most-mentioned entities. Exploits `entity_events`' DAY partition on `ingested_at` + clustering on `(entity_type, entity_name)` — something the operational Postgres path can't cheaply do. Parameterized query; **raises `BigQueryQueryError` on failure** to match the service's raise-not-swallow (→ 503) contract introduced in the recent hardening pass. New `EntitySentimentTimelinePoint` schema + typed `api.ts` wrapper + multi-line chart.

### Deliberately NOT surfaced
`/trends`, `/sources`, `/categories` — they duplicate the Postgres rolling-avg / source-ranking / GROUPING-SETS charts. `/pipeline` — operational, not sentiment.

## Tests
- `test_entity_sentiment_timeline_empty_when_disabled` — disabled-state returns `[]`
- `test_entity_sentiment_timeline_disabled` / `..._query_validation` — 200 disabled-message + 422 on out-of-range `days`/`limit`
- `test_entity_sentiment_timeline_failing_query_returns_503` — failure surfaces as 503, never a silent `200 []`

Full suite: **95 passed, 11 skipped** (PG-only). `ruff` + `mypy` clean (pre-commit). Frontend `svelte-check`: **0 errors, 0 warnings**.

## Docs
`docs/PERSONAS_AND_USE_CASES.md` reconciled so the matrix stays consistent:
- UC-16 UI flipped 🔲 → ✅; removed from the Roadmap
- UC-25 added under P3
- Entity-type filter noted on UC-15 / UC-16 (not claimed as UC-18, which is a separate entity-directory page)
- Traceability matrix (`entities`, `article_entities`) + summary totals recomputed by hand (Backend 24/24, user-facing UI 17/20)

## Verify locally
```
ruff check app tests && pytest tests/test_bigquery.py -v
cd frontend && npm run check && npm run build
```
With `BIGQUERY_ENABLE_BIGQUERY=true` + creds (seed via `python -m app.jobs.backfill_bigquery`): the AI-Enriched section shows 4 charts + the entity-type dropdown; changing the dropdown reloads the three entity charts. With BigQuery off, the whole section stays hidden and the 5 Postgres charts are unchanged.
