### PR TITLE
feat: richer sentiment description with expand-in-place detail panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ SQLite is **not** a supported substitute for Postgres at the migration layer —
 | **Tests** | SQLite (in-memory) | Created on the fly via `Base.metadata.create_all` — bypasses migrations |
 | **Production** | Cloud SQL | Managed via Terraform — see [Multi-Environment Strategy](docs/MULTI_ENVIRONMENT_STRATEGY.md) |
 
-Schema migrations are managed by Alembic (13 migration files; see [docs/DATABASE.md § 2](docs/DATABASE.md#2-migrations) for the inventory):
+Schema migrations are managed by Alembic (14 migration files; see [docs/DATABASE.md § 2](docs/DATABASE.md#2-migrations) for the inventory):
 ```bash
 alembic upgrade head              # Apply all pending migrations
 alembic downgrade -1              # Rollback last migration

--- a/alembic/versions/7c3e9a4f1b82_add_article_sentiment_magnitude.py
+++ b/alembic/versions/7c3e9a4f1b82_add_article_sentiment_magnitude.py
@@ -1,0 +1,44 @@
+"""add article sentiment_magnitude
+
+Denormalizes the GCP NL sentiment ``magnitude`` (emotional intensity, 0+) onto
+``articles`` as a new nullable ``sentiment_magnitude`` column, mirroring the
+existing ``sentiment_label`` / ``sentiment_score`` denormalization. The value
+already exists per-provider on ``sentiment_analyses.magnitude``; copying the
+primary provider's value onto the article lets the read path stay denormalized
+(the article router deliberately does not serialize the ``sentiment_analyses``
+relationship).
+
+Additive and reversible: the column is nullable with no default, so existing
+rows are unaffected (VADER-only articles legitimately stay NULL — VADER produces
+no magnitude). A one-off backfill script populates historical GCP-NL articles.
+
+Revision ID: 7c3e9a4f1b82
+Revises: 2d60fa48c9ba
+Create Date: 2026-06-09
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7c3e9a4f1b82"
+down_revision: Union[str, None] = "2d60fa48c9ba"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the nullable sentiment_magnitude column to articles."""
+    op.add_column(
+        "articles",
+        sa.Column("sentiment_magnitude", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the sentiment_magnitude column."""
+    op.drop_column("articles", "sentiment_magnitude")

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -374,6 +374,9 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
         # Update denormalized article fields
         article.sentiment_label = sentiment_label  # type: ignore[assignment]
         article.sentiment_score = sentiment_score  # type: ignore[assignment]
+        # magnitude is None for VADER (incl. the GCP-NL→VADER fallback above),
+        # set only when GCP NL annotateText succeeded.
+        article.sentiment_magnitude = magnitude  # type: ignore[assignment]
 
         # Step 7: Mark crawl job as successful
         crawl_job.status = CrawlStatus.SUCCESS  # type: ignore[assignment]

--- a/app/models/article.py
+++ b/app/models/article.py
@@ -37,6 +37,10 @@ class Article(Base):
         String(20), default=None, index=True
     )
     sentiment_score: Mapped[Optional[float]] = mapped_column(default=None)
+    # Denormalized GCP NL magnitude (emotional intensity, 0+), mirrored from the
+    # primary provider's SentimentAnalysis row like sentiment_label/score above.
+    # NULL for VADER-only articles (VADER produces no magnitude).
+    sentiment_magnitude: Mapped[Optional[float]] = mapped_column(default=None)
 
     source: Mapped["Source"] = relationship(back_populates="articles")
     bookmarks: Mapped[List["Bookmark"]] = relationship(

--- a/app/schemas/article.py
+++ b/app/schemas/article.py
@@ -98,6 +98,14 @@ class ArticleRead(ArticleBase):
     sentiment_score: Optional[float] = Field(
         None, ge=-1.0, le=1.0, description="Latest sentiment score (-1 to 1)"
     )
+    sentiment_magnitude: Optional[float] = Field(
+        None,
+        ge=0.0,
+        description=(
+            "GCP NL sentiment magnitude (emotional intensity, 0+). "
+            "NULL for VADER-only articles."
+        ),
+    )
 
     # Entity and category data (populated when GCP NL provider is used)
     article_entities: Optional[List[ArticleEntityRead]] = Field(
@@ -125,6 +133,7 @@ class ArticleRead(ArticleBase):
                 "category": "technology",
                 "sentiment_label": "positive",
                 "sentiment_score": 0.75,
+                "sentiment_magnitude": 2.4,
             }
         },
     }

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -57,7 +57,7 @@ The bare-metal path (Postgres on the host, `uvicorn` on the host) works the same
 
 ## 2. Migrations
 
-Ten migrations, applied in order. Run `alembic upgrade head` to apply, `alembic downgrade -1` to roll back the most recent one.
+Fourteen migrations, applied in order. Run `alembic upgrade head` to apply, `alembic downgrade -1` to roll back the most recent one.
 
 | # | Revision | Summary |
 |---|----------|---------|
@@ -71,6 +71,10 @@ Ten migrations, applied in order. Run `alembic upgrade head` to apply, `alembic 
 | 8 | `d8e9f0a1b2c3` | Add `mention_count` to `article_entities` |
 | 9 | `e1f2a3b4c5d6` | Bookmark FK indexes + views, stored functions, triggers |
 | 10 | `f2a3b4c5d6e7` | Article filter indexes — `sentiment_label`, `category`, `source_id` |
+| 11 | `a1b2c3d4e5f6` | Fix ambiguous column in `fn_sentiment_distribution` |
+| 12 | `54bff216cdb7` | Drop `NOT NULL` on `users.hashed_password` |
+| 13 | `2d60fa48c9ba` | Reconcile `sources` schema with model (unique index, comments) |
+| 14 | `7c3e9a4f1b82` | Add denormalized `articles.sentiment_magnitude` (GCP NL) |
 
 ---
 

--- a/docs/ER_Diagram.md
+++ b/docs/ER_Diagram.md
@@ -37,6 +37,7 @@ erDiagram
         varchar_50 category "nullable"
         varchar_20 sentiment_label "nullable, denormalized"
         float sentiment_score "nullable, denormalized"
+        float sentiment_magnitude "nullable, denormalized, GCP NL only"
     }
 
     bookmarks {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -433,6 +433,9 @@
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
     gap: var(--sp-5);
     margin-bottom: var(--sp-6);
+    /* Start-align so a card whose sentiment "Why?" panel is expanded grows on
+       its own rather than stretching every other card in its row to match. */
+    align-items: start;
   }
 
   .site-footer {

--- a/frontend/src/lib/ArticleCard.svelte
+++ b/frontend/src/lib/ArticleCard.svelte
@@ -5,6 +5,7 @@
     ArticleEntityDto,
     ArticleCategoryDto,
   } from "./api";
+  import { describeSentiment, magnitudeTier } from "./sentiment";
 
   export let article: ArticleDto;
   /** Whether to render the bookmark/remove control (signed-in only). */
@@ -50,21 +51,32 @@
     return Math.round(((score + 1) / 2) * 100);
   }
 
-  function getSentimentExplanation(
-    label?: string | null,
-    score?: number | null
-  ): string {
-    if (!label || score === null || score === undefined) return "";
-    const abs = Math.abs(score);
-    const intensity =
-      abs > 0.6 ? "strongly" : abs > 0.25 ? "moderately" : "slightly";
-    switch (label.toLowerCase()) {
-      case "positive": return `Overall tone is ${intensity} positive`;
-      case "negative": return `Overall tone is ${intensity} negative`;
-      case "neutral":  return "Balanced, neutral tone";
-      default:         return "";
-    }
-  }
+  // Per-card disclosure: the data-driven sentiment "Why?" detail panel.
+  let detailsOpen = false;
+
+  // The data-driven one-line description (label + intensity + magnitude +
+  // top entities) — logic lives in the pure, testable ./sentiment module.
+  $: sentimentDescription = describeSentiment({
+    label: article.sentiment_label,
+    score: article.sentiment_score,
+    magnitude: article.sentiment_magnitude,
+    topEntities: getTopEntities(article.article_entities, 2).map(
+      (ae) => ae.entity.name
+    ),
+  });
+
+  // null when magnitude is unavailable (VADER-only) → the meter is hidden.
+  $: magTier = magnitudeTier(article.sentiment_magnitude);
+  const MAG_TIER_LABEL: Record<"low" | "medium" | "high", string> = {
+    low: "Low — largely factual",
+    medium: "Moderate emotional intensity",
+    high: "High — emotionally charged",
+  };
+  const MAG_TIER_FILL: Record<"low" | "medium" | "high", number> = {
+    low: 25,
+    medium: 60,
+    high: 100,
+  };
 
   // ── Entity / category helpers ────────────────────────────────────
 
@@ -208,10 +220,73 @@
           ></div>
         </div>
 
-        {#if getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
-          <p class="sentiment-note">
-            {getSentimentExplanation(article.sentiment_label, article.sentiment_score)}
-          </p>
+        {#if sentimentDescription}
+          <p class="sentiment-note">{sentimentDescription}</p>
+        {/if}
+
+        <button
+          type="button"
+          class="sentiment-details-toggle"
+          on:click={() => (detailsOpen = !detailsOpen)}
+          aria-expanded={detailsOpen}
+          aria-controls={`sent-details-${article.id}`}
+        >
+          {detailsOpen ? "Hide details" : "Why?"}
+        </button>
+
+        {#if detailsOpen}
+          <div
+            id={`sent-details-${article.id}`}
+            class="sentiment-details"
+          >
+            <dl class="sentiment-metrics">
+              <div class="metric">
+                <dt>Score</dt>
+                <dd class="mono">
+                  {article.sentiment_score > 0 ? "+" : ""}{article.sentiment_score.toFixed(2)}
+                  <span class="metric-hint">on −1 … +1</span>
+                </dd>
+              </div>
+
+              {#if magTier}
+                <div class="metric">
+                  <dt>Emotional intensity</dt>
+                  <dd>
+                    <span class="mag-meter" aria-hidden="true">
+                      <span
+                        class="mag-meter-fill {magTier}"
+                        style="width: {MAG_TIER_FILL[magTier]}%"
+                      ></span>
+                    </span>
+                    <span class="metric-hint">
+                      {MAG_TIER_LABEL[magTier]}
+                      {#if article.sentiment_magnitude != null}
+                        ({article.sentiment_magnitude.toFixed(1)})
+                      {/if}
+                    </span>
+                  </dd>
+                </div>
+              {:else}
+                <div class="metric">
+                  <dt>Emotional intensity</dt>
+                  <dd class="metric-hint">
+                    Not available (lexicon-based analysis)
+                  </dd>
+                </div>
+              {/if}
+
+              {#if getTopEntities(article.article_entities, 3).length > 0}
+                <div class="metric">
+                  <dt>Focus</dt>
+                  <dd class="metric-hint">
+                    {getTopEntities(article.article_entities, 3)
+                      .map((ae) => ae.entity.name)
+                      .join(", ")}
+                  </dd>
+                </div>
+              {/if}
+            </dl>
+          </div>
         {/if}
       </div>
     {/if}
@@ -413,6 +488,74 @@
   }
   .score-bar-fill { position: absolute; top: 0; height: 100%; border-radius: 2px; }
   .sentiment-note { font-size: 11px; font-style: italic; color: var(--text-ter); line-height: 1.4; }
+
+  /* "Why?" disclosure toggle + expand-in-place detail panel */
+  .sentiment-details-toggle {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--accent);
+    cursor: pointer;
+    border-radius: var(--r-sm);
+  }
+  .sentiment-details-toggle:hover { text-decoration: underline; }
+  .sentiment-details-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .sentiment-details {
+    border-top: 1px solid var(--border);
+    padding-top: var(--sp-2);
+    overflow: hidden;
+    animation: sentiment-details-in 160ms ease-out;
+  }
+  @keyframes sentiment-details-in {
+    from { opacity: 0; transform: translateY(-2px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .sentiment-metrics { margin: 0; display: flex; flex-direction: column; gap: var(--sp-2); }
+  .metric { display: flex; flex-direction: column; gap: 2px; }
+  .metric dt {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-ter);
+  }
+  .metric dd {
+    margin: 0;
+    font-size: 12px;
+    color: var(--text-pri);
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    flex-wrap: wrap;
+  }
+  .metric-hint { font-size: 11px; color: var(--text-sec); font-weight: 400; }
+
+  /* Emotional-intensity meter (magnitude tier) */
+  .mag-meter {
+    position: relative;
+    flex: 0 0 64px;
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .mag-meter-fill { position: absolute; left: 0; top: 0; height: 100%; border-radius: 2px; }
+  .mag-meter-fill.low    { background: var(--neu); }
+  .mag-meter-fill.medium { background: var(--accent); }
+  .mag-meter-fill.high   { background: var(--neg); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sentiment-details { animation: none; }
+  }
 
   /* Chips */
   .chips-row { display: flex; flex-wrap: wrap; gap: 5px; }

--- a/frontend/src/lib/BookmarksView.svelte
+++ b/frontend/src/lib/BookmarksView.svelte
@@ -167,6 +167,9 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
     gap: var(--sp-5);
+    /* Start-align so an expanded sentiment "Why?" panel grows its own card
+       rather than stretching the rest of the row. */
+    align-items: start;
   }
   .error-icon { font-size: 16px; flex-shrink: 0; }
   @media (max-width: 768px) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -55,6 +55,7 @@ export type ArticleDto = {
   };
   sentiment_label?: string | null;
   sentiment_score?: number | null;
+  sentiment_magnitude?: number | null;
   language?: string | null;
   country?: string | null;
   category?: string | null;

--- a/frontend/src/lib/sentiment.ts
+++ b/frontend/src/lib/sentiment.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure sentiment-description logic, extracted from ArticleCard so it is
+ * unit-testable and free of Svelte concerns.
+ *
+ * The richer description consumes more of what the NLP pipeline computes than a
+ * label + |score| bucket can:
+ *  - `magnitude` (GCP NL "emotional intensity", 0..∞) disambiguates a
+ *    near-zero score: high magnitude = mixed / polarizing (strong feeling both
+ *    ways), low magnitude = factual / unemotional. A score alone can't tell
+ *    these apart.
+ *  - `topEntities` (already salience-sorted) names what the coverage centres on.
+ *
+ * `magnitude` is null for VADER-only articles; every branch degrades gracefully
+ * to the score-only description when it's absent.
+ */
+
+export type SentimentInput = {
+  label?: string | null;
+  score?: number | null; // -1..1
+  magnitude?: number | null; // 0..∞ (GCP NL); null when unavailable
+  topEntities?: string[]; // already salience-sorted names
+};
+
+// ⚠️ CALIBRATION REQUIRED — these are placeholders, not final values.
+// `magnitude` is unbounded and grows with document length, so the low/high
+// cut-points must come from quantiles of OUR corpus, not guessed. Run against
+// production Postgres (the local seed is VADER-only, so it has no magnitude):
+//
+//   SELECT percentile_cont(0.33) WITHIN GROUP (ORDER BY magnitude) AS p33,
+//          percentile_cont(0.66) WITHIN GROUP (ORDER BY magnitude) AS p66
+//   FROM sentiment_analyses WHERE magnitude IS NOT NULL;
+//
+// Then set MAG_LOW = p33 and MAG_HIGH = p66 and remove this notice.
+// TODO(calibrate-against-prod): replace 1.0 / 3.0 with the measured quantiles.
+const MAG_LOW = 1.0;
+const MAG_HIGH = 3.0;
+
+const cap = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+
+export function describeSentiment({
+  label,
+  score,
+  magnitude,
+  topEntities = [],
+}: SentimentInput): string {
+  if (!label || score === null || score === undefined) return "";
+  const l = label.toLowerCase();
+  const abs = Math.abs(score);
+  const intensity = abs > 0.6 ? "strongly" : abs > 0.25 ? "moderately" : "slightly";
+
+  if (l === "neutral") {
+    if (magnitude != null && magnitude >= MAG_HIGH)
+      return "Mixed tone — strong feeling on both sides, not truly neutral";
+    if (magnitude != null && magnitude < MAG_LOW)
+      return "Largely factual, with little emotional language";
+    return "Balanced, neutral tone";
+  }
+
+  const dir = l === "positive" ? "positive" : "negative";
+  const focus = topEntities.length
+    ? `, centred on ${topEntities.slice(0, 2).join(" and ")}`
+    : "";
+  let out = `${cap(intensity)} ${dir} (${score.toFixed(2)})${focus}`;
+  if (magnitude != null && magnitude >= MAG_HIGH) out += " — emotionally charged";
+  return out;
+}
+
+/**
+ * A coarse three-bucket label for the magnitude meter in the detail panel.
+ * Returns null when magnitude is unavailable (VADER-only) so the UI can hide
+ * the meter rather than show a misleading "low".
+ */
+export function magnitudeTier(
+  magnitude?: number | null,
+): "low" | "medium" | "high" | null {
+  if (magnitude == null) return null;
+  if (magnitude >= MAG_HIGH) return "high";
+  if (magnitude < MAG_LOW) return "low";
+  return "medium";
+}

--- a/scripts/dev/backfill_article_magnitude.py
+++ b/scripts/dev/backfill_article_magnitude.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Backfill ``articles.sentiment_magnitude`` from historical GCP-NL analyses.
+
+The new denormalized ``Article.sentiment_magnitude`` column is populated going
+forward by the crawl worker, but pre-existing articles have it NULL. This
+one-off operator script copies the magnitude from each article's most recent
+GCP-NL ``SentimentAnalysis`` row (the only provider that produces magnitude)
+onto the article.
+
+VADER-only articles have no magnitude row, so they are skipped and stay NULL —
+the frontend degrades gracefully on a null magnitude. This means the script is
+effectively a no-op against a VADER-only local seed; it only does real work
+against a database that has been through the GCP-NL pipeline (i.e. production).
+
+Usage:
+    python scripts/dev/backfill_article_magnitude.py            # apply
+    python scripts/dev/backfill_article_magnitude.py --dry-run  # report only
+    python scripts/dev/backfill_article_magnitude.py --batch 500
+
+Idempotent: re-running only re-touches articles whose magnitude differs from
+their latest GCP-NL row, so a second run after a clean first run updates nothing.
+Operator tool, not part of the test suite (the backfill logic is unit-tested in
+tests/test_backfill_magnitude.py against an in-memory DB).
+"""
+
+import argparse
+import os
+import sys
+
+# Add project root to path so we can import app modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.article import Article
+from app.models.sentiment_analysis import SentimentAnalysis
+
+
+def backfill_magnitudes(db: Session, *, dry_run: bool = False, batch: int = 500) -> int:
+    """Copy the latest GCP-NL magnitude onto each article. Returns rows updated.
+
+    Pure of any CLI/printing concerns so it can be unit-tested directly.
+    """
+    updated = 0
+    offset = 0
+    while True:
+        articles = (
+            db.query(Article).order_by(Article.id).offset(offset).limit(batch).all()
+        )
+        if not articles:
+            break
+        for article in articles:
+            latest = (
+                db.query(SentimentAnalysis)
+                .filter(SentimentAnalysis.article_id == article.id)
+                .filter(SentimentAnalysis.magnitude.isnot(None))
+                .order_by(SentimentAnalysis.analyzed_at.desc())
+                .first()
+            )
+            if latest is None:
+                continue  # VADER-only / no magnitude — leave NULL
+            if article.sentiment_magnitude != latest.magnitude:
+                if not dry_run:
+                    article.sentiment_magnitude = latest.magnitude
+                updated += 1
+        offset += batch
+    if not dry_run:
+        db.commit()
+    return updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill articles.sentiment_magnitude from GCP-NL analyses"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report how many rows would change without writing",
+    )
+    parser.add_argument(
+        "--batch",
+        type=int,
+        default=500,
+        help="Articles per query batch (default: 500)",
+    )
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        updated = backfill_magnitudes(db, dry_run=args.dry_run, batch=args.batch)
+        verb = "would update" if args.dry_run else "updated"
+        print(f"sentiment_magnitude backfill: {verb} {updated} article(s).")
+        if updated == 0:
+            print(
+                "No GCP-NL magnitude rows found to copy "
+                "(expected against a VADER-only seed)."
+            )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_articles_filters.py
+++ b/tests/test_articles_filters.py
@@ -209,3 +209,42 @@ def test_bad_stored_image_url_does_not_500_the_list(
     ]
     assert len(bad) == 1
     assert bad[0]["image_url"] is None  # coerced, page still served
+
+
+def test_sentiment_magnitude_passthrough(
+    seeded_db: Session, client: TestClient
+) -> None:
+    """The denormalized sentiment_magnitude serializes on ArticleRead:
+    a GCP-NL article exposes its value, a VADER-only article stays null."""
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    seeded_db.add_all(
+        [
+            Article(
+                source_id=1,
+                title="GCP NL analysed article",
+                url="https://example.com/articles/with-magnitude",
+                published_at=base,
+                sentiment_label="positive",
+                sentiment_score=0.8,
+                sentiment_magnitude=2.4,
+            ),
+            Article(
+                source_id=1,
+                title="VADER only article",
+                url="https://example.com/articles/no-magnitude",
+                published_at=base,
+                sentiment_label="neutral",
+                sentiment_score=0.0,
+                sentiment_magnitude=None,
+            ),
+        ]
+    )
+    seeded_db.commit()
+
+    data = {a["url"]: a for a in client.get("/api/v1/articles/?limit=50").json()}
+
+    with_mag = data["https://example.com/articles/with-magnitude"]
+    assert with_mag["sentiment_magnitude"] == 2.4
+
+    without_mag = data["https://example.com/articles/no-magnitude"]
+    assert without_mag["sentiment_magnitude"] is None

--- a/tests/test_backfill_magnitude.py
+++ b/tests/test_backfill_magnitude.py
@@ -1,0 +1,113 @@
+"""Unit tests for the sentiment_magnitude backfill logic.
+
+Exercises the pure ``backfill_magnitudes`` helper from the operator script
+against the in-memory SQLite ``test_db`` fixture — no network, no real DB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.article import Article
+from app.models.sentiment_analysis import SentimentAnalysis
+from app.models.source import Source
+from scripts.dev.backfill_article_magnitude import backfill_magnitudes
+
+
+def _seed(db: Session) -> None:
+    db.add(Source(id=1, name="bbc"))
+    db.flush()
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+    # Article 1: has two GCP-NL analyses — newest (by analyzed_at) wins.
+    db.add(
+        Article(
+            id=1,
+            source_id=1,
+            title="GCP analysed",
+            url="https://example.com/1",
+            published_at=base,
+            sentiment_label="positive",
+            sentiment_score=0.8,
+        )
+    )
+    db.add_all(
+        [
+            SentimentAnalysis(
+                article_id=1,
+                provider="GCP_NL",
+                model_name="gcp_nl_v1",
+                score=0.7,
+                magnitude=1.1,  # older
+                label="positive",
+                analyzed_at=base - timedelta(days=2),
+            ),
+            SentimentAnalysis(
+                article_id=1,
+                provider="GCP_NL",
+                model_name="gcp_nl_v1",
+                score=0.8,
+                magnitude=2.9,  # newer — this should win
+                label="positive",
+                analyzed_at=base,
+            ),
+        ]
+    )
+
+    # Article 2: VADER-only, no magnitude row → must stay NULL.
+    db.add(
+        Article(
+            id=2,
+            source_id=1,
+            title="VADER only",
+            url="https://example.com/2",
+            published_at=base,
+            sentiment_label="neutral",
+            sentiment_score=0.0,
+        )
+    )
+    db.add(
+        SentimentAnalysis(
+            article_id=2,
+            provider="VADER",
+            model_name=None,
+            score=0.0,
+            magnitude=None,
+            label="neutral",
+            analyzed_at=base,
+        )
+    )
+    db.commit()
+
+
+def test_backfill_copies_latest_gcp_magnitude(test_db: Session) -> None:
+    _seed(test_db)
+
+    updated = backfill_magnitudes(test_db, batch=10)
+
+    assert updated == 1  # only article 1 changes
+    a1 = test_db.get(Article, 1)
+    a2 = test_db.get(Article, 2)
+    assert a1 is not None and a1.sentiment_magnitude == 2.9  # newest GCP row
+    assert a2 is not None and a2.sentiment_magnitude is None  # VADER stays null
+
+
+def test_backfill_is_idempotent(test_db: Session) -> None:
+    _seed(test_db)
+    backfill_magnitudes(test_db, batch=10)
+
+    # Second run touches nothing — values already match.
+    updated = backfill_magnitudes(test_db, batch=10)
+    assert updated == 0
+
+
+def test_backfill_dry_run_writes_nothing(test_db: Session) -> None:
+    _seed(test_db)
+
+    updated = backfill_magnitudes(test_db, dry_run=True, batch=10)
+
+    assert updated == 1  # reports the change...
+    a1 = test_db.get(Article, 1)
+    assert a1 is not None and a1.sentiment_magnitude is None  # ...but doesn't write


### PR DESCRIPTION
## What

Replaces the generic three-bucket sentiment blurb on the article card with a data-driven description, and adds a **"Why?"** disclosure that expands the card **in place** to show the score, an emotional-intensity meter, and the entities the coverage centres on.

The headline signal is GCP NL **`magnitude`** (emotional intensity). It was already computed and stored on `SentimentAnalysis` but never reached the article read path — which is deliberately denormalized (the article router does not serialize the `sentiment_analyses` relationship, for performance). So this mirrors `magnitude` onto `Article` exactly like `sentiment_label`/`sentiment_score` already are. The value-add: a near-zero score with **high** magnitude is *mixed / polarizing*, not neutral — a distinction a score alone can't make.

## Backend

- `Article.sentiment_magnitude` column + migration `7c3e9a4f1b82` — nullable, additive, reversible. Round-tripped against Postgres (upgrade → downgrade → upgrade); `--autogenerate` shows no drift.
- `crawl_worker` denormalizes `magnitude` onto the article alongside label/score (`None` for VADER, including the GCP-NL → VADER fallback path).
- `ArticleRead` exposes `sentiment_magnitude`.
- One-off operator backfill `scripts/dev/backfill_article_magnitude.py` copies the latest GCP-NL magnitude onto historical articles — `--dry-run`, idempotent, batched.
- Tests: read passthrough (value + null), backfill copy / idempotent / dry-run.

## Frontend

- New **pure, testable** `lib/sentiment.ts` (`describeSentiment` + `magnitudeTier`) — description logic extracted out of the component.
- `ArticleCard`: the data-driven one-liner + a **"Why?" expand-in-place** panel (`aria-expanded`/`aria-controls`, `:focus-visible` ring, `prefers-reduced-motion` respected).
- Article + Bookmarks grids set `align-items: start` so an expanded card grows on its own instead of stretching its row-mates.
- Degrades gracefully when `magnitude` is null (VADER-only / demo mode shows "Emotional intensity: not available").

## ⚠️ Before / at release

- The magnitude tier thresholds in `sentiment.ts` (`MAG_LOW`/`MAG_HIGH`) are **placeholders flagged `TODO`** — magnitude is document-length-dependent, so they must be calibrated from **production** quantiles (the local seed is VADER-only and has none). The calibration SQL is in the file's comment.
- Run the backfill against prod after `alembic upgrade head` lands there.

## Verification

- `svelte-check`: 0 errors / 0 warnings; `vite build` clean.
- `pytest`: 99 passed, 11 skipped (Postgres-marked, run in CI).
- `ruff` + `mypy` clean on all changed files.
- Migration round-trip + no autogenerate drift verified against a throwaway Postgres DB.
- Visual: confirmed the "Why?" disclosure expands in place and the null-magnitude (demo) path renders correctly.

## Possible follow-ups (not in this PR)

- No frontend test runner exists yet; `sentiment.ts` is structured for Vitest if you later want unit tests for the description branches.
