### PR TITLE
fix: trending-names momentum window + calibrate magnitude thresholds

### DIFF
--- a/app/crud/analytics.py
+++ b/app/crud/analytics.py
@@ -123,10 +123,18 @@ def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, An
 
 
 def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
-    """Entity momentum: compare mention frequency this week vs last week.
+    """Entity momentum: compare mention frequency this window vs the previous one.
 
-    Uses two CTEs partitioned by week, then computes growth rate.
+    Uses two CTEs split at the window midpoint, then computes growth rate.
     Surfaces entities that are trending up or down.
+
+    The windows key off ``article_entities.analyzed_at`` (when the entity was
+    extracted in *our* pipeline), NOT ``articles.published_at``. Entity
+    enrichment lags publication by days-to-weeks (the crawl/GCP-NL worker drains
+    a backlog), so a ``published_at`` window over the last few days catches
+    freshly-ingested articles that have not been entity-analyzed yet — returning
+    empty. ``analyzed_at`` is also the semantically correct axis for "trending
+    names": it reflects when a name surged in our analyzed coverage.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     midpoint = datetime.now(timezone.utc) - timedelta(days=days // 2)
@@ -139,8 +147,7 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                     COUNT(ae.id)    AS mention_count
                 FROM entities e
                 JOIN article_entities ae ON ae.entity_id = e.id
-                JOIN articles a ON a.id = ae.article_id
-                WHERE a.published_at >= :midpoint
+                WHERE ae.analyzed_at >= :midpoint
                 GROUP BY e.name, e.type
             ),
             previous AS (
@@ -150,9 +157,8 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                     COUNT(ae.id)    AS mention_count
                 FROM entities e
                 JOIN article_entities ae ON ae.entity_id = e.id
-                JOIN articles a ON a.id = ae.article_id
-                WHERE a.published_at >= :cutoff
-                  AND a.published_at < :midpoint
+                WHERE ae.analyzed_at >= :cutoff
+                  AND ae.analyzed_at < :midpoint
                 GROUP BY e.name, e.type
             )
             SELECT

--- a/frontend/src/lib/sentiment.ts
+++ b/frontend/src/lib/sentiment.ts
@@ -21,19 +21,17 @@ export type SentimentInput = {
   topEntities?: string[]; // already salience-sorted names
 };
 
-// ⚠️ CALIBRATION REQUIRED — these are placeholders, not final values.
-// `magnitude` is unbounded and grows with document length, so the low/high
-// cut-points must come from quantiles of OUR corpus, not guessed. Run against
-// production Postgres (the local seed is VADER-only, so it has no magnitude):
+// Calibrated from the production corpus (2026-06-09) — `magnitude` is unbounded
+// and grows with document length, so the low/high cut-points are the 33rd/66th
+// percentiles of OUR data, not guessed values:
 //
-//   SELECT percentile_cont(0.33) WITHIN GROUP (ORDER BY magnitude) AS p33,
-//          percentile_cont(0.66) WITHIN GROUP (ORDER BY magnitude) AS p66
-//   FROM sentiment_analyses WHERE magnitude IS NOT NULL;
+//   SELECT percentile_cont(0.33) WITHIN GROUP (ORDER BY magnitude),  -- 7.8
+//          percentile_cont(0.66) WITHIN GROUP (ORDER BY magnitude)   -- 15.4
+//   FROM sentiment_analyses WHERE magnitude IS NOT NULL;  -- n=8786, min 0.2 max 196.1
 //
-// Then set MAG_LOW = p33 and MAG_HIGH = p66 and remove this notice.
-// TODO(calibrate-against-prod): replace 1.0 / 3.0 with the measured quantiles.
-const MAG_LOW = 1.0;
-const MAG_HIGH = 3.0;
+// Re-run and adjust if the corpus shifts substantially.
+const MAG_LOW = 7.8;
+const MAG_HIGH = 15.4;
 
 const cap = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
 

--- a/tests/test_db_analytics.py
+++ b/tests/test_db_analytics.py
@@ -18,6 +18,7 @@ from app.crud.analytics import (
     sentiment_rolling_average,
     source_sentiment_ranked,
 )
+from app.models.article import Article
 from app.seeds.seed_db import seed_database
 
 pytestmark = pytest.mark.postgres
@@ -92,6 +93,69 @@ def test_entity_momentum_runs_and_returns_expected_shape(seeded):
             "previous_mentions",
             "growth_pct",
         } <= set(r)
+
+
+def test_entity_momentum_keys_off_analyzed_at_not_published_at(seeded):
+    """Regression: the momentum windows must key off article_entities.analyzed_at,
+    not articles.published_at. Entity enrichment lags publication (the worker
+    drains a backlog), so an article published weeks ago can be entity-analyzed
+    today. Here every article is OLD by published_at but the entity mentions are
+    RECENT by analyzed_at — the chart must still surface them. Before the fix
+    this returned [] (empty 'trending names')."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.article_entity import ArticleEntity
+    from app.models.entity import Entity
+
+    now = datetime.now(timezone.utc)
+    # Pick three seeded articles (all published >30d ago).
+    article_ids = [a.id for a in seeded.query(Article).limit(3).all()]
+    assert len(article_ids) == 3, "seed should provide >=3 articles"
+
+    ent = Entity(name="Test Trending Name", type="PERSON")
+    seeded.add(ent)
+    seeded.flush()
+
+    # article_entities is UNIQUE(article_id, entity_id), so one row per article.
+    # Two distinct articles land in the recent window, one in the previous —
+    # recent=2 vs previous=1, a clear upward trend. analyzed_at is recent even
+    # though the underlying articles were published long ago.
+    seeded.add_all(
+        [
+            ArticleEntity(
+                article_id=article_ids[0],
+                entity_id=ent.id,
+                salience=0.5,
+                mention_count=1,
+                analyzed_at=now - timedelta(days=1),  # recent window
+            ),
+            ArticleEntity(
+                article_id=article_ids[1],
+                entity_id=ent.id,
+                salience=0.5,
+                mention_count=1,
+                analyzed_at=now - timedelta(days=2),  # recent window
+            ),
+            ArticleEntity(
+                article_id=article_ids[2],
+                entity_id=ent.id,
+                salience=0.5,
+                mention_count=1,
+                analyzed_at=now - timedelta(days=10),  # previous window
+            ),
+        ]
+    )
+    seeded.commit()
+
+    rows = entity_momentum(seeded, days=14)
+    names = {r["entity_name"] for r in rows}
+    assert "Test Trending Name" in names, (
+        "momentum must surface an entity with recent analyzed_at even when the "
+        "underlying articles were published long ago"
+    )
+    hit = next(r for r in rows if r["entity_name"] == "Test Trending Name")
+    assert hit["recent_mentions"] == 2
+    assert hit["previous_mentions"] == 1
 
 
 def test_daily_category_pivot_cumulative_is_monotonic(seeded):


### PR DESCRIPTION
Two post-release fixes found while verifying prod after the #157 release.

## Trending names (entity momentum) — was empty
`entity_momentum` keyed its two comparison windows off `articles.published_at`. But entity enrichment **lags publication** (the crawl/GCP-NL worker drains a backlog), so the recent-`published_at` window caught freshly-ingested articles that haven't been entity-analyzed yet → empty chart, despite plenty of recent entity rows.

**Fix:** key the windows off `article_entities.analyzed_at` — when the name actually surged in our analyzed coverage, which is also the correct axis for "trending". Verified against prod: **returns 12 trending entities where the old query returned `[]`**.

Adds a Postgres regression test (entities with recent `analyzed_at` on long-ago-published articles must surface).

## Magnitude thresholds — calibrated
`frontend/src/lib/sentiment.ts` shipped `MAG_LOW`/`MAG_HIGH` as placeholders (1.0/3.0) flagged TODO. Calibrated from the prod corpus (2026-06-09): **p33=7.8, p66=15.4** over n=8786 magnitude rows (min 0.2, max 196.1). The placeholders were an order of magnitude too low — now 7.8 / 15.4.

## Verification
ruff/mypy clean; backend 99 passed + 19 Postgres analytics tests (incl. the new momentum regression test); svelte-check 0 errors; build OK. The 932-row prod magnitude backfill was already run separately and verified live.