### PR TITLE
fix(pipeline): crawl newest articles first so daily latest reach GCP NL

### DIFF
--- a/app/config/scheduler.py
+++ b/app/config/scheduler.py
@@ -21,7 +21,19 @@ class SchedulerConfig(BaseSettings):
 
     # Job parameters (optimized for API limits)
     batch_size: int = 50  # API requests per ingestion run
-    max_crawl_jobs: int = 100  # Articles to process per run
+    max_crawl_jobs: int = 50  # Crawl jobs to PROCESS per run (one GCP NL call each)
+    # Crawl jobs to CREATE per run, NEWEST articles first. Must keep pace with
+    # processing or a backlog of never-crawled articles accumulates and the
+    # latest articles never reach GCP NL (the bug this fixes: creation was capped
+    # at 20 and unordered, so new dailies were starved behind old backlog).
+    #
+    # Sized against the Cloud Natural Language free tier: each crawl makes one
+    # annotateText call, so 50/run × 3 runs/day × ~30 days ≈ 4,500/month, just
+    # under the 5,000-unit/month free tier. Newest-first ordering means today's
+    # articles are always enriched first; raise both knobs (accepting NL cost
+    # beyond the free tier, ~$1/1,000 units) to drain the historical backlog
+    # faster.
+    max_crawl_job_creation: int = 50
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -508,19 +508,28 @@ def get_pending_crawl_jobs(db: Session, limit: int = 10) -> List[CrawlJob]:
     Returns:
         List of pending CrawlJob instances
     """
+    # Newest jobs first: paired with newest-first job creation, this keeps the
+    # latest articles flowing through GCP NL rather than being starved behind a
+    # large historical backlog.
     jobs = (
         db.query(CrawlJob)
         .filter(CrawlJob.status == CrawlStatus.PENDING)  # type: ignore[arg-type]
-        .order_by(CrawlJob.created_at)
+        .order_by(CrawlJob.created_at.desc())
         .limit(limit)
         .all()
     )
     return list(jobs)
 
 
-def create_crawl_jobs_for_articles(db: Session, limit: int = 20) -> int:
+def create_crawl_jobs_for_articles(db: Session, limit: int = 100) -> int:
     """
     Create crawl jobs for articles that don't have them yet.
+
+    Newest articles first (``published_at DESC``): the daily ingestion should
+    push the latest articles through the crawl → GCP NL path promptly. Without
+    the ordering the query returned an arbitrary (effectively oldest) slice, so
+    freshly-ingested articles fell to the back of an ever-growing backlog and
+    never got entity/category analysis.
 
     Args:
         db: Database session
@@ -529,10 +538,11 @@ def create_crawl_jobs_for_articles(db: Session, limit: int = 20) -> int:
     Returns:
         Number of crawl jobs created
     """
-    # Find articles without crawl jobs
+    # Find articles without crawl jobs, newest first.
     articles_without_jobs = (
         db.query(Article)
         .filter(~Article.id.in_(db.query(CrawlJob.article_id).distinct()))  # type: ignore
+        .order_by(Article.published_at.desc())
         .limit(limit)
         .all()
     )
@@ -568,10 +578,16 @@ def run_crawl_worker(max_jobs: int = 5) -> Dict[str, Any]:
     db = SessionLocal()
 
     try:
+        from app.config import config
+
         start_time = time.time()
 
-        # Create crawl jobs for articles that don't have them
-        new_jobs = create_crawl_jobs_for_articles(db)
+        # Create crawl jobs for articles that don't have them. Enqueue up to the
+        # configured creation limit (newest first) so creation keeps pace with
+        # processing instead of leaving the latest articles un-crawled.
+        new_jobs = create_crawl_jobs_for_articles(
+            db, limit=config.scheduler.max_crawl_job_creation
+        )
 
         # Get pending crawl jobs
         pending_jobs = get_pending_crawl_jobs(db, max_jobs)

--- a/docs/COST_AND_SCALABILITY.md
+++ b/docs/COST_AND_SCALABILITY.md
@@ -8,7 +8,7 @@
 | Cloud SQL (PostgreSQL 14) | db-f1-micro, 10GB, ZONAL, daily backup | ~$7-9 | N/A (always-on instance) |
 | Cloud Scheduler | 2 jobs (every 8h + daily 2AM) | $0 | 3 free jobs/month |
 | Secret Manager | 6 secrets, low-frequency access | ~$0 | 6 active secret versions free |
-| Cloud Natural Language API | annotateText (~2,250 calls/month) | ~$2-4 | 5,000 units/month free |
+| Cloud Natural Language API | annotateText (~4,500 calls/month) | ~$0-2 | 5,000 units/month free |
 | BigQuery | <1GB storage, <1TB queries/month | $0 | 10GB storage + 1TB queries free |
 | Artifact Registry | 3 Docker images, ~500MB total | ~$0.05 | 500MB free storage |
 | Firebase Hosting | Static SPA, <10GB bandwidth | $0 | Generous free tier (10GB/month) |

--- a/tests/test_crawl_worker.py
+++ b/tests/test_crawl_worker.py
@@ -105,3 +105,46 @@ def test_rate_limited_parks_job_without_fetching(
     assert result is False
     assert job.status == CrawlStatus.RATE_LIMITED
     assert "rate limited" in job.error_message.lower()
+
+
+def test_create_crawl_jobs_picks_newest_articles_first(test_db: Any) -> None:
+    """Regression: create_crawl_jobs_for_articles must enqueue the NEWEST
+    un-crawled articles (published_at DESC). The bug was an unordered query +
+    a 20-job cap, which starved freshly-ingested articles behind old backlog so
+    the latest articles never reached GCP NL. Here 5 articles span 5 days and we
+    create only 3 jobs — they must be the 3 newest, not an arbitrary slice."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.article import Article
+    from app.models.crawl_job import CrawlJob
+    from app.models.source import Source
+
+    test_db.add(Source(id=1, name="bbc"))
+    test_db.flush()
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    # Insert oldest-first so insertion order is the OPPOSITE of published order —
+    # an unordered query would tend to return the oldest, failing this test.
+    for i in range(5):
+        test_db.add(
+            Article(
+                source_id=1,
+                title=f"Article {i}",
+                url=f"https://example.com/{i}",
+                published_at=base + timedelta(days=i),  # i=4 is newest
+            )
+        )
+    test_db.commit()
+
+    created = crawl_worker.create_crawl_jobs_for_articles(test_db, limit=3)
+    assert created == 3
+
+    # The 3 jobs must be for the 3 newest articles (published days 4, 3, 2).
+    job_article_ids = {cj.article_id for cj in test_db.query(CrawlJob).all()}
+    newest_three = {
+        a.id
+        for a in test_db.query(Article)
+        .order_by(Article.published_at.desc())
+        .limit(3)
+        .all()
+    }
+    assert job_article_ids == newest_three


### PR DESCRIPTION
## Problem

The crawl → GCP NL pipeline was **structurally backlogged** — the latest daily-ingested articles were never being entity/category-analyzed (your "is GCP NL gonna process the latest articles?" question: the answer was *no*).

**Prod evidence (2026-06-09):** 33,237 articles, but only **589 ever entity-analyzed** (1.8%); **32,511 never crawled at all**; the newest article ever crawled was published **2026-05-17** — 3+ weeks stale.

**Two causes:**
1. `create_crawl_jobs_for_articles` enqueued ≤20 articles/run (hardcoded default, never overridden) with **no ordering** → returned an arbitrary (effectively oldest) slice. New articles fell to the back of an ever-growing queue.
2. `get_pending_crawl_jobs` processed **oldest-first** (`created_at ASC`), compounding the starvation.

## Fix

- **Newest-first everywhere:** job creation ordered by `published_at DESC`, pending-job processing by `created_at DESC`. Today's articles now reach GCP NL on the next run; the backlog drains newest→oldest.
- **New `max_crawl_job_creation` knob** (default 50) so creation keeps pace with processing instead of the old 20 cap. Sized for the Cloud NL **free tier**: 50/run × 3 runs/day × ~30d ≈ **4,500/month**, under the 5,000-unit free tier. `max_crawl_jobs` aligned to 50.
- Regression test (newest-first creation) + COST doc updated (~2,250 → ~4,500 NL calls/month).

## Self-healing

No manual catch-up needed: with newest-first ordering the very next scheduled run grabs today's articles first, and the historical gap drains from the top down at ~150/day.

## Verification

100 backend tests pass (+1 new); ruff/mypy clean. Rebased onto develop after #158.