### PR TITLE
fix(dashboard): scoped entity-filter refresh + quality-gate entity charts

### DIFF
--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -661,6 +661,12 @@ def get_top_entities(
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND (@entity_type IS NULL OR entity_type = @entity_type)
       AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+      -- Quality gate: only Knowledge-Graph-resolved entities (those GCP NL gave
+      -- a wikipedia_url). This drops generic common-noun "entities" like
+      -- "investors", "CEO", "administration", "one", "two", "U.S." that the
+      -- model tags but that are not notable named entities — keeping the chart
+      -- to real people/orgs/places.
+      AND wikipedia_url IS NOT NULL
     GROUP BY entity_name, entity_type
     ORDER BY article_count DESC
     LIMIT @limit
@@ -705,6 +711,9 @@ def get_entity_sentiment(
     FROM {fqn}
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND (@entity_type IS NULL OR entity_type = @entity_type)
+      AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+      -- Same quality gate as get_top_entities: Knowledge-Graph-resolved only.
+      AND wikipedia_url IS NOT NULL
     GROUP BY entity_name, entity_type
     HAVING COUNT(DISTINCT article_id) >= 2
     ORDER BY avg_sentiment_score DESC
@@ -747,6 +756,8 @@ def get_entity_sentiment_timeline(
         WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
           AND (@entity_type IS NULL OR entity_type = @entity_type)
           AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+          -- Same quality gate: only Knowledge-Graph-resolved entities.
+          AND wikipedia_url IS NOT NULL
         GROUP BY entity_name, entity_type
         ORDER BY COUNT(DISTINCT article_id) DESC
         LIMIT @limit

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -30,6 +30,9 @@
   let days = 30;
   const ROLLING_WINDOW = 7;
   let loading = true;
+  // Scoped to the entity row only (the entity-type filter), so refiltering the
+  // entity charts never blanks/repaints the whole dashboard.
+  let entityLoading = false;
   let error = '';
 
   // ── Postgres-backed data (the always-on core) ──────────────────────────
@@ -201,6 +204,33 @@
       error = e instanceof Error ? e.message : 'Failed to load analytics';
     } finally {
       loading = false;
+    }
+  }
+
+  // Refetch + re-render ONLY the three entity charts that depend on entityType.
+  // No global `loading`, no full re-render → the page does not blank or scroll.
+  async function loadEntityCharts() {
+    if (!hasBigQuery) return; // entity charts only exist on the BigQuery path
+    entityLoading = true;
+    try {
+      [bqEntities, bqEntitySentiment, bqEntityTimeline] = await Promise.all([
+        fetchTopEntities(days, entityType || undefined, 12).catch(() => []),
+        fetchEntitySentiment(days, entityType || undefined, 12).catch(() => []),
+        fetchEntitySentimentTimeline(days, entityType || undefined, 8).catch(
+          () => []
+        ),
+      ]);
+      setTimeout(() => {
+        bqEntityChart?.destroy();
+        bqSentimentChart?.destroy();
+        bqTimelineChart?.destroy();
+        bqEntityChart = bqSentimentChart = bqTimelineChart = null;
+        renderBqEntities();
+        renderBqEntitySentiment();
+        renderBqTimeline();
+      }, 0);
+    } finally {
+      entityLoading = false;
     }
   }
 
@@ -558,7 +588,11 @@
 
   function handleEntityTypeChange(event: Event) {
     entityType = (event.target as HTMLSelectElement).value;
-    loadData();
+    // Only the three entity charts depend on entityType — refetch and re-render
+    // just those, WITHOUT toggling the global `loading` flag. That keeps the
+    // rest of the dashboard mounted so the page doesn't blank and scroll back
+    // to the top (the filter lives in the bottom "AI-Enriched Insights" row).
+    loadEntityCharts();
   }
 
   let mounted = false;
@@ -711,7 +745,13 @@
           </p>
         </div>
         <div class="bq-header-controls">
-          <select on:change={handleEntityTypeChange} value={entityType} aria-label="Entity type filter">
+          <select
+            on:change={handleEntityTypeChange}
+            value={entityType}
+            disabled={entityLoading}
+            aria-busy={entityLoading}
+            aria-label="Entity type filter"
+          >
             <option value="">All types</option>
             <option value="PERSON">People</option>
             <option value="ORGANIZATION">Organizations</option>


### PR DESCRIPTION
Two **AI-Enriched Insights** fixes (your dashboard items 1 & 2).

## 1. Entity-type filter no longer reloads the whole dashboard (scroll-to-top)
Changing the filter called `loadData()`, which flipped the global `loading` flag (unmounting the **entire** dashboard) and refetched **all 9 endpoints** — even the 5 Postgres charts that don't depend on entity type. The full re-render reset scroll to the top, so after picking "People" you had to scroll back down to the bottom row to see the result.

**Fix:** `loadEntityCharts()` refetches only the **3 entity endpoints** and re-renders only those 3 charts, behind a scoped `entityLoading` flag. The page stays mounted and in place; the select shows a brief busy/disabled state.

## 2. Entity charts now show only real named entities (generic/junk removed)
GCP NL tags generic common nouns as entities — "investors", "CEO", "administration", "U.S.", "one", "two" — cluttering *Most-Mentioned People & Organizations*.

**Verified against prod:** every one of those has `wikipedia_url = NULL`, while real entities (Trump, Joe Biden, Apple) have one. Perfect discrimination on the sample.

**Fix:** gate the three BigQuery entity queries on **`wikipedia_url IS NOT NULL`** (Knowledge-Graph-resolved entities only). Also adds the `NUMBER/OTHER/DATE/…` type exclusion that `get_entity_sentiment` was missing.

## Verification
svelte-check 0 errors, build OK, backend 99 passed + 20 BQ tests, ruff/mypy clean.

**Note:** the entity row only renders with BigQuery enabled, so these are not visible in local demo mode — verify on the deploy/prod environment after merge.