### PR TITLE
Release: trending-names + crawl pipeline + dashboard fixes (develop → main)

### DIFF
--- a/app/config/scheduler.py
+++ b/app/config/scheduler.py
@@ -21,7 +21,19 @@ class SchedulerConfig(BaseSettings):
 
     # Job parameters (optimized for API limits)
     batch_size: int = 50  # API requests per ingestion run
-    max_crawl_jobs: int = 100  # Articles to process per run
+    max_crawl_jobs: int = 50  # Crawl jobs to PROCESS per run (one GCP NL call each)
+    # Crawl jobs to CREATE per run, NEWEST articles first. Must keep pace with
+    # processing or a backlog of never-crawled articles accumulates and the
+    # latest articles never reach GCP NL (the bug this fixes: creation was capped
+    # at 20 and unordered, so new dailies were starved behind old backlog).
+    #
+    # Sized against the Cloud Natural Language free tier: each crawl makes one
+    # annotateText call, so 50/run × 3 runs/day × ~30 days ≈ 4,500/month, just
+    # under the 5,000-unit/month free tier. Newest-first ordering means today's
+    # articles are always enriched first; raise both knobs (accepting NL cost
+    # beyond the free tier, ~$1/1,000 units) to drain the historical backlog
+    # faster.
+    max_crawl_job_creation: int = 50
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/crud/analytics.py
+++ b/app/crud/analytics.py
@@ -123,10 +123,18 @@ def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, An
 
 
 def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
-    """Entity momentum: compare mention frequency this week vs last week.
+    """Entity momentum: compare mention frequency this window vs the previous one.
 
-    Uses two CTEs partitioned by week, then computes growth rate.
+    Uses two CTEs split at the window midpoint, then computes growth rate.
     Surfaces entities that are trending up or down.
+
+    The windows key off ``article_entities.analyzed_at`` (when the entity was
+    extracted in *our* pipeline), NOT ``articles.published_at``. Entity
+    enrichment lags publication by days-to-weeks (the crawl/GCP-NL worker drains
+    a backlog), so a ``published_at`` window over the last few days catches
+    freshly-ingested articles that have not been entity-analyzed yet — returning
+    empty. ``analyzed_at`` is also the semantically correct axis for "trending
+    names": it reflects when a name surged in our analyzed coverage.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     midpoint = datetime.now(timezone.utc) - timedelta(days=days // 2)
@@ -139,8 +147,7 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                     COUNT(ae.id)    AS mention_count
                 FROM entities e
                 JOIN article_entities ae ON ae.entity_id = e.id
-                JOIN articles a ON a.id = ae.article_id
-                WHERE a.published_at >= :midpoint
+                WHERE ae.analyzed_at >= :midpoint
                 GROUP BY e.name, e.type
             ),
             previous AS (
@@ -150,9 +157,8 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                     COUNT(ae.id)    AS mention_count
                 FROM entities e
                 JOIN article_entities ae ON ae.entity_id = e.id
-                JOIN articles a ON a.id = ae.article_id
-                WHERE a.published_at >= :cutoff
-                  AND a.published_at < :midpoint
+                WHERE ae.analyzed_at >= :cutoff
+                  AND ae.analyzed_at < :midpoint
                 GROUP BY e.name, e.type
             )
             SELECT

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -508,19 +508,28 @@ def get_pending_crawl_jobs(db: Session, limit: int = 10) -> List[CrawlJob]:
     Returns:
         List of pending CrawlJob instances
     """
+    # Newest jobs first: paired with newest-first job creation, this keeps the
+    # latest articles flowing through GCP NL rather than being starved behind a
+    # large historical backlog.
     jobs = (
         db.query(CrawlJob)
         .filter(CrawlJob.status == CrawlStatus.PENDING)  # type: ignore[arg-type]
-        .order_by(CrawlJob.created_at)
+        .order_by(CrawlJob.created_at.desc())
         .limit(limit)
         .all()
     )
     return list(jobs)
 
 
-def create_crawl_jobs_for_articles(db: Session, limit: int = 20) -> int:
+def create_crawl_jobs_for_articles(db: Session, limit: int = 100) -> int:
     """
     Create crawl jobs for articles that don't have them yet.
+
+    Newest articles first (``published_at DESC``): the daily ingestion should
+    push the latest articles through the crawl → GCP NL path promptly. Without
+    the ordering the query returned an arbitrary (effectively oldest) slice, so
+    freshly-ingested articles fell to the back of an ever-growing backlog and
+    never got entity/category analysis.
 
     Args:
         db: Database session
@@ -529,10 +538,11 @@ def create_crawl_jobs_for_articles(db: Session, limit: int = 20) -> int:
     Returns:
         Number of crawl jobs created
     """
-    # Find articles without crawl jobs
+    # Find articles without crawl jobs, newest first.
     articles_without_jobs = (
         db.query(Article)
         .filter(~Article.id.in_(db.query(CrawlJob.article_id).distinct()))  # type: ignore
+        .order_by(Article.published_at.desc())
         .limit(limit)
         .all()
     )
@@ -568,10 +578,16 @@ def run_crawl_worker(max_jobs: int = 5) -> Dict[str, Any]:
     db = SessionLocal()
 
     try:
+        from app.config import config
+
         start_time = time.time()
 
-        # Create crawl jobs for articles that don't have them
-        new_jobs = create_crawl_jobs_for_articles(db)
+        # Create crawl jobs for articles that don't have them. Enqueue up to the
+        # configured creation limit (newest first) so creation keeps pace with
+        # processing instead of leaving the latest articles un-crawled.
+        new_jobs = create_crawl_jobs_for_articles(
+            db, limit=config.scheduler.max_crawl_job_creation
+        )
 
         # Get pending crawl jobs
         pending_jobs = get_pending_crawl_jobs(db, max_jobs)

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -661,6 +661,12 @@ def get_top_entities(
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND (@entity_type IS NULL OR entity_type = @entity_type)
       AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+      -- Quality gate: only Knowledge-Graph-resolved entities (those GCP NL gave
+      -- a wikipedia_url). This drops generic common-noun "entities" like
+      -- "investors", "CEO", "administration", "one", "two", "U.S." that the
+      -- model tags but that are not notable named entities — keeping the chart
+      -- to real people/orgs/places.
+      AND wikipedia_url IS NOT NULL
     GROUP BY entity_name, entity_type
     ORDER BY article_count DESC
     LIMIT @limit
@@ -705,6 +711,9 @@ def get_entity_sentiment(
     FROM {fqn}
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND (@entity_type IS NULL OR entity_type = @entity_type)
+      AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+      -- Same quality gate as get_top_entities: Knowledge-Graph-resolved only.
+      AND wikipedia_url IS NOT NULL
     GROUP BY entity_name, entity_type
     HAVING COUNT(DISTINCT article_id) >= 2
     ORDER BY avg_sentiment_score DESC
@@ -747,6 +756,8 @@ def get_entity_sentiment_timeline(
         WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
           AND (@entity_type IS NULL OR entity_type = @entity_type)
           AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
+          -- Same quality gate: only Knowledge-Graph-resolved entities.
+          AND wikipedia_url IS NOT NULL
         GROUP BY entity_name, entity_type
         ORDER BY COUNT(DISTINCT article_id) DESC
         LIMIT @limit

--- a/docs/COST_AND_SCALABILITY.md
+++ b/docs/COST_AND_SCALABILITY.md
@@ -8,7 +8,7 @@
 | Cloud SQL (PostgreSQL 14) | db-f1-micro, 10GB, ZONAL, daily backup | ~$7-9 | N/A (always-on instance) |
 | Cloud Scheduler | 2 jobs (every 8h + daily 2AM) | $0 | 3 free jobs/month |
 | Secret Manager | 6 secrets, low-frequency access | ~$0 | 6 active secret versions free |
-| Cloud Natural Language API | annotateText (~2,250 calls/month) | ~$2-4 | 5,000 units/month free |
+| Cloud Natural Language API | annotateText (~4,500 calls/month) | ~$0-2 | 5,000 units/month free |
 | BigQuery | <1GB storage, <1TB queries/month | $0 | 10GB storage + 1TB queries free |
 | Artifact Registry | 3 Docker images, ~500MB total | ~$0.05 | 500MB free storage |
 | Firebase Hosting | Static SPA, <10GB bandwidth | $0 | Generous free tier (10GB/month) |

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -30,6 +30,9 @@
   let days = 30;
   const ROLLING_WINDOW = 7;
   let loading = true;
+  // Scoped to the entity row only (the entity-type filter), so refiltering the
+  // entity charts never blanks/repaints the whole dashboard.
+  let entityLoading = false;
   let error = '';
 
   // ── Postgres-backed data (the always-on core) ──────────────────────────
@@ -201,6 +204,33 @@
       error = e instanceof Error ? e.message : 'Failed to load analytics';
     } finally {
       loading = false;
+    }
+  }
+
+  // Refetch + re-render ONLY the three entity charts that depend on entityType.
+  // No global `loading`, no full re-render → the page does not blank or scroll.
+  async function loadEntityCharts() {
+    if (!hasBigQuery) return; // entity charts only exist on the BigQuery path
+    entityLoading = true;
+    try {
+      [bqEntities, bqEntitySentiment, bqEntityTimeline] = await Promise.all([
+        fetchTopEntities(days, entityType || undefined, 12).catch(() => []),
+        fetchEntitySentiment(days, entityType || undefined, 12).catch(() => []),
+        fetchEntitySentimentTimeline(days, entityType || undefined, 8).catch(
+          () => []
+        ),
+      ]);
+      setTimeout(() => {
+        bqEntityChart?.destroy();
+        bqSentimentChart?.destroy();
+        bqTimelineChart?.destroy();
+        bqEntityChart = bqSentimentChart = bqTimelineChart = null;
+        renderBqEntities();
+        renderBqEntitySentiment();
+        renderBqTimeline();
+      }, 0);
+    } finally {
+      entityLoading = false;
     }
   }
 
@@ -558,7 +588,11 @@
 
   function handleEntityTypeChange(event: Event) {
     entityType = (event.target as HTMLSelectElement).value;
-    loadData();
+    // Only the three entity charts depend on entityType — refetch and re-render
+    // just those, WITHOUT toggling the global `loading` flag. That keeps the
+    // rest of the dashboard mounted so the page doesn't blank and scroll back
+    // to the top (the filter lives in the bottom "AI-Enriched Insights" row).
+    loadEntityCharts();
   }
 
   let mounted = false;
@@ -711,7 +745,13 @@
           </p>
         </div>
         <div class="bq-header-controls">
-          <select on:change={handleEntityTypeChange} value={entityType} aria-label="Entity type filter">
+          <select
+            on:change={handleEntityTypeChange}
+            value={entityType}
+            disabled={entityLoading}
+            aria-busy={entityLoading}
+            aria-label="Entity type filter"
+          >
             <option value="">All types</option>
             <option value="PERSON">People</option>
             <option value="ORGANIZATION">Organizations</option>

--- a/frontend/src/lib/sentiment.ts
+++ b/frontend/src/lib/sentiment.ts
@@ -21,19 +21,17 @@ export type SentimentInput = {
   topEntities?: string[]; // already salience-sorted names
 };
 
-// ⚠️ CALIBRATION REQUIRED — these are placeholders, not final values.
-// `magnitude` is unbounded and grows with document length, so the low/high
-// cut-points must come from quantiles of OUR corpus, not guessed. Run against
-// production Postgres (the local seed is VADER-only, so it has no magnitude):
+// Calibrated from the production corpus (2026-06-09) — `magnitude` is unbounded
+// and grows with document length, so the low/high cut-points are the 33rd/66th
+// percentiles of OUR data, not guessed values:
 //
-//   SELECT percentile_cont(0.33) WITHIN GROUP (ORDER BY magnitude) AS p33,
-//          percentile_cont(0.66) WITHIN GROUP (ORDER BY magnitude) AS p66
-//   FROM sentiment_analyses WHERE magnitude IS NOT NULL;
+//   SELECT percentile_cont(0.33) WITHIN GROUP (ORDER BY magnitude),  -- 7.8
+//          percentile_cont(0.66) WITHIN GROUP (ORDER BY magnitude)   -- 15.4
+//   FROM sentiment_analyses WHERE magnitude IS NOT NULL;  -- n=8786, min 0.2 max 196.1
 //
-// Then set MAG_LOW = p33 and MAG_HIGH = p66 and remove this notice.
-// TODO(calibrate-against-prod): replace 1.0 / 3.0 with the measured quantiles.
-const MAG_LOW = 1.0;
-const MAG_HIGH = 3.0;
+// Re-run and adjust if the corpus shifts substantially.
+const MAG_LOW = 7.8;
+const MAG_HIGH = 15.4;
 
 const cap = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
 

--- a/tests/test_crawl_worker.py
+++ b/tests/test_crawl_worker.py
@@ -105,3 +105,46 @@ def test_rate_limited_parks_job_without_fetching(
     assert result is False
     assert job.status == CrawlStatus.RATE_LIMITED
     assert "rate limited" in job.error_message.lower()
+
+
+def test_create_crawl_jobs_picks_newest_articles_first(test_db: Any) -> None:
+    """Regression: create_crawl_jobs_for_articles must enqueue the NEWEST
+    un-crawled articles (published_at DESC). The bug was an unordered query +
+    a 20-job cap, which starved freshly-ingested articles behind old backlog so
+    the latest articles never reached GCP NL. Here 5 articles span 5 days and we
+    create only 3 jobs — they must be the 3 newest, not an arbitrary slice."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.article import Article
+    from app.models.crawl_job import CrawlJob
+    from app.models.source import Source
+
+    test_db.add(Source(id=1, name="bbc"))
+    test_db.flush()
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    # Insert oldest-first so insertion order is the OPPOSITE of published order —
+    # an unordered query would tend to return the oldest, failing this test.
+    for i in range(5):
+        test_db.add(
+            Article(
+                source_id=1,
+                title=f"Article {i}",
+                url=f"https://example.com/{i}",
+                published_at=base + timedelta(days=i),  # i=4 is newest
+            )
+        )
+    test_db.commit()
+
+    created = crawl_worker.create_crawl_jobs_for_articles(test_db, limit=3)
+    assert created == 3
+
+    # The 3 jobs must be for the 3 newest articles (published days 4, 3, 2).
+    job_article_ids = {cj.article_id for cj in test_db.query(CrawlJob).all()}
+    newest_three = {
+        a.id
+        for a in test_db.query(Article)
+        .order_by(Article.published_at.desc())
+        .limit(3)
+        .all()
+    }
+    assert job_article_ids == newest_three

--- a/tests/test_db_analytics.py
+++ b/tests/test_db_analytics.py
@@ -18,6 +18,7 @@ from app.crud.analytics import (
     sentiment_rolling_average,
     source_sentiment_ranked,
 )
+from app.models.article import Article
 from app.seeds.seed_db import seed_database
 
 pytestmark = pytest.mark.postgres
@@ -92,6 +93,69 @@ def test_entity_momentum_runs_and_returns_expected_shape(seeded):
             "previous_mentions",
             "growth_pct",
         } <= set(r)
+
+
+def test_entity_momentum_keys_off_analyzed_at_not_published_at(seeded):
+    """Regression: the momentum windows must key off article_entities.analyzed_at,
+    not articles.published_at. Entity enrichment lags publication (the worker
+    drains a backlog), so an article published weeks ago can be entity-analyzed
+    today. Here every article is OLD by published_at but the entity mentions are
+    RECENT by analyzed_at — the chart must still surface them. Before the fix
+    this returned [] (empty 'trending names')."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.article_entity import ArticleEntity
+    from app.models.entity import Entity
+
+    now = datetime.now(timezone.utc)
+    # Pick three seeded articles (all published >30d ago).
+    article_ids = [a.id for a in seeded.query(Article).limit(3).all()]
+    assert len(article_ids) == 3, "seed should provide >=3 articles"
+
+    ent = Entity(name="Test Trending Name", type="PERSON")
+    seeded.add(ent)
+    seeded.flush()
+
+    # article_entities is UNIQUE(article_id, entity_id), so one row per article.
+    # Two distinct articles land in the recent window, one in the previous —
+    # recent=2 vs previous=1, a clear upward trend. analyzed_at is recent even
+    # though the underlying articles were published long ago.
+    seeded.add_all(
+        [
+            ArticleEntity(
+                article_id=article_ids[0],
+                entity_id=ent.id,
+                salience=0.5,
+                mention_count=1,
+                analyzed_at=now - timedelta(days=1),  # recent window
+            ),
+            ArticleEntity(
+                article_id=article_ids[1],
+                entity_id=ent.id,
+                salience=0.5,
+                mention_count=1,
+                analyzed_at=now - timedelta(days=2),  # recent window
+            ),
+            ArticleEntity(
+                article_id=article_ids[2],
+                entity_id=ent.id,
+                salience=0.5,
+                mention_count=1,
+                analyzed_at=now - timedelta(days=10),  # previous window
+            ),
+        ]
+    )
+    seeded.commit()
+
+    rows = entity_momentum(seeded, days=14)
+    names = {r["entity_name"] for r in rows}
+    assert "Test Trending Name" in names, (
+        "momentum must surface an entity with recent analyzed_at even when the "
+        "underlying articles were published long ago"
+    )
+    hit = next(r for r in rows if r["entity_name"] == "Test Trending Name")
+    assert hit["recent_mentions"] == 2
+    assert hit["previous_mentions"] == 1
 
 
 def test_daily_category_pivot_cumulative_is_monotonic(seeded):


### PR DESCRIPTION
## Release: `develop` → `main` (post-release bug fixes)

Three fixes for dashboard/pipeline issues found after the previous release. **Code-only — no new migrations.** Merging deploys to prod (Cloud Run rebuild + Firebase Hosting; the migration step finds nothing new to apply).

### #158 — Trending names + magnitude calibration
- `entity_momentum` keyed its windows off `articles.published_at`, but entity enrichment lags publication, so the "trending names" chart was empty. Re-keyed to `article_entities.analyzed_at` (verified: returns 12 entities vs `[]`).
- Magnitude tier thresholds calibrated from the prod corpus (p33=7.8, p66=15.4); the shipped placeholders (1.0/3.0) were an order of magnitude too low. (The 932-row prod magnitude backfill was already run separately.)

### #159 — Crawl newest articles first (pipeline)
- The crawl → GCP NL pipeline was backlogged: job creation was capped at 20/run, unordered, so the **latest articles never reached GCP NL** (newest crawled article was 3+ weeks stale; only 1.8% of articles ever entity-analyzed).
- Fix: newest-first ordering (`published_at DESC` creation, `created_at DESC` processing) + a `max_crawl_job_creation` knob (50, sized for the Cloud NL free tier). Self-healing — today's articles flow through on the next scheduled run; backlog drains top-down.

### #160 — Dashboard: entity filter + quality
- The entity-type filter reloaded the whole dashboard (all 9 endpoints + global loading) and reset scroll to top. Now a scoped refresh re-renders only the 3 entity charts in place.
- Generic non-entities ("investors", "CEO", "U.S.", "one", "two") cluttered the entity charts. Gated the 3 BigQuery entity queries on `wikipedia_url IS NOT NULL` (Knowledge-Graph-resolved entities only) — verified perfect discrimination against prod.

### Migrations
**None.** Prod DB is unchanged; `alembic upgrade head` is a no-op this release.

### Post-deploy effects to watch
- Trending-names chart populates (prod BigQuery data).
- Next scheduled ingestion (`0 */8 * * *`) starts crawling the newest articles → entities begin appearing on recent articles.
- Entity charts show only real named entities; filtering no longer jumps to top.

### Verification
develop CI green (ruff/mypy, Postgres migrations + full pytest on a real service container, frontend type-check). The `build-and-deploy` job is `main`-gated, so it runs on this merge.
