### PR TITLE
fix(analytics): quality-gate trending names + exclude publisher pollution

### DIFF
--- a/app/constants/entity_filters.py
+++ b/app/constants/entity_filters.py
@@ -1,0 +1,83 @@
+"""Quality filtering for extracted entities (shared by Postgres + BigQuery).
+
+GCP NL faithfully extracts every name it sees in an article — including the
+self-referential furniture of news pages: the publisher's own name, wire-service
+attributions ("according to Reuters"), and image-credit boilerplate ("Image:
+Getty Images"). Those dominate a naive most-mentioned ranking but are not what
+the news is *about*, so the entity charts exclude them.
+
+Two layers, applied together:
+
+1. ``wikipedia_url IS NOT NULL`` — keep only Knowledge-Graph-resolved entities,
+   dropping generic common nouns the model tags ("investors", "markets", "CEO",
+   "one", "two"). (Applied at the query site.)
+2. ``PUBLISHER_ENTITY_DENYLIST`` — drop news organisations, wire services, and
+   credit-line names. These ARE real orgs (they have a wikipedia_url), so layer
+   1 does not catch them; this explicit denylist does.
+
+Names are compared case-insensitively (``LOWER(entity_name)``), so every entry
+here is lowercase.
+"""
+
+from __future__ import annotations
+
+# News organisations / wire services / image-credit names that appear as
+# self-referential pollution rather than news subjects. Includes our own
+# ingestion sources and the common publishers/agencies they syndicate from,
+# with the spelling variants GCP NL emits (e.g. "Getty Images" and "Getty").
+PUBLISHER_ENTITY_DENYLIST: frozenset[str] = frozenset(
+    {
+        # Wire services / agencies
+        "reuters",
+        "associated press",
+        "ap",
+        "afp",
+        "agence france-presse",
+        "bloomberg",
+        "pa media",
+        "press association",
+        # Broadcasters / papers (our sources + common syndication partners)
+        "bbc",
+        "cnn",
+        "cnbc",
+        "the guardian",
+        "guardian",
+        "the new york times",
+        "new york times",
+        "nytimes",
+        "the independent",
+        "independent",
+        "sky news",
+        "politico",
+        "time",
+        "yahoo",
+        "yahoo news",
+        "dw",
+        "deutsche welle",
+        "financial post",
+        "foreign policy",
+        "businesstoday",
+        "business today",
+        "phys.org",
+        "popular science",
+        "scidev.net",
+        "scitechdaily",
+        "google news",
+        "google-news",
+        # Image-credit boilerplate
+        "getty",
+        "getty images",
+        "reuters/",
+        "shutterstock",
+        "associated press/",
+    }
+)
+
+
+def publisher_denylist_lower() -> list[str]:
+    """The denylist as a sorted list of lowercase strings, for SQL parameters.
+
+    Sorted so the bound parameter array is deterministic across calls (stable
+    query text / test fixtures).
+    """
+    return sorted(PUBLISHER_ENTITY_DENYLIST)

--- a/app/crud/analytics.py
+++ b/app/crud/analytics.py
@@ -8,8 +8,20 @@ by providing real-time queries against the operational database.
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 from sqlalchemy.orm import Session
+
+from app.constants.entity_filters import publisher_denylist_lower
+
+# Entity types that are never real named entities (numbers, dates, etc.).
+_NON_ENTITY_TYPES = (
+    "NUMBER",
+    "OTHER",
+    "DATE",
+    "PRICE",
+    "ADDRESS",
+    "PHONE_NUMBER",
+)
 
 
 def sentiment_rolling_average(
@@ -138,8 +150,11 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     midpoint = datetime.now(timezone.utc) - timedelta(days=days // 2)
-    result = db.execute(
-        text("""
+    # Quality gate (shared with the BigQuery entity charts): keep only
+    # Knowledge-Graph-resolved entities (wikipedia_url set), drop non-entity
+    # types, and exclude publisher / wire-service / image-credit names that are
+    # self-referential page furniture rather than news subjects.
+    stmt = text("""
             WITH recent AS (
                 SELECT
                     e.name          AS entity_name,
@@ -148,6 +163,9 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                 FROM entities e
                 JOIN article_entities ae ON ae.entity_id = e.id
                 WHERE ae.analyzed_at >= :midpoint
+                  AND e.wikipedia_url IS NOT NULL
+                  AND e.type NOT IN :non_entity_types
+                  AND LOWER(e.name) NOT IN :publisher_denylist
                 GROUP BY e.name, e.type
             ),
             previous AS (
@@ -159,6 +177,9 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                 JOIN article_entities ae ON ae.entity_id = e.id
                 WHERE ae.analyzed_at >= :cutoff
                   AND ae.analyzed_at < :midpoint
+                  AND e.wikipedia_url IS NOT NULL
+                  AND e.type NOT IN :non_entity_types
+                  AND LOWER(e.name) NOT IN :publisher_denylist
                 GROUP BY e.name, e.type
             )
             SELECT
@@ -180,8 +201,18 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                 ON r.entity_name = p.entity_name AND r.entity_type = p.entity_type
             WHERE COALESCE(r.mention_count, 0) + COALESCE(p.mention_count, 0) >= 3
             ORDER BY growth_pct DESC
-        """),
-        {"cutoff": cutoff, "midpoint": midpoint},
+        """).bindparams(
+        bindparam("non_entity_types", expanding=True),
+        bindparam("publisher_denylist", expanding=True),
+    )
+    result = db.execute(
+        stmt,
+        {
+            "cutoff": cutoff,
+            "midpoint": midpoint,
+            "non_entity_types": list(_NON_ENTITY_TYPES),
+            "publisher_denylist": publisher_denylist_lower(),
+        },
     )
     return [dict(row._mapping) for row in result]
 

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from app.config import config
+from app.constants.entity_filters import publisher_denylist_lower
 
 logger = logging.getLogger(__name__)
 
@@ -667,6 +668,10 @@ def get_top_entities(
       -- model tags but that are not notable named entities — keeping the chart
       -- to real people/orgs/places.
       AND wikipedia_url IS NOT NULL
+      -- And exclude publisher / wire-service / image-credit names (BBC, Getty,
+      -- Reuters, ...): real orgs, so the wiki gate keeps them, but they are
+      -- self-referential page furniture, not news subjects.
+      AND LOWER(entity_name) NOT IN UNNEST(@publisher_denylist)
     GROUP BY entity_name, entity_type
     ORDER BY article_count DESC
     LIMIT @limit
@@ -677,6 +682,9 @@ def get_top_entities(
             bigquery.ScalarQueryParameter("days", "INT64", days),
             bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
             bigquery.ScalarQueryParameter("limit", "INT64", limit),
+            bigquery.ArrayQueryParameter(
+                "publisher_denylist", "STRING", publisher_denylist_lower()
+            ),
         ]
     )
 
@@ -712,8 +720,10 @@ def get_entity_sentiment(
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND (@entity_type IS NULL OR entity_type = @entity_type)
       AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
-      -- Same quality gate as get_top_entities: Knowledge-Graph-resolved only.
+      -- Same quality gate as get_top_entities: Knowledge-Graph-resolved only,
+      -- and publisher / wire-service / credit names excluded.
       AND wikipedia_url IS NOT NULL
+      AND LOWER(entity_name) NOT IN UNNEST(@publisher_denylist)
     GROUP BY entity_name, entity_type
     HAVING COUNT(DISTINCT article_id) >= 2
     ORDER BY avg_sentiment_score DESC
@@ -725,6 +735,9 @@ def get_entity_sentiment(
             bigquery.ScalarQueryParameter("days", "INT64", days),
             bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
             bigquery.ScalarQueryParameter("limit", "INT64", limit),
+            bigquery.ArrayQueryParameter(
+                "publisher_denylist", "STRING", publisher_denylist_lower()
+            ),
         ]
     )
 
@@ -756,8 +769,9 @@ def get_entity_sentiment_timeline(
         WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
           AND (@entity_type IS NULL OR entity_type = @entity_type)
           AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
-          -- Same quality gate: only Knowledge-Graph-resolved entities.
+          -- Same quality gate: Knowledge-Graph-resolved only, publishers excluded.
           AND wikipedia_url IS NOT NULL
+          AND LOWER(entity_name) NOT IN UNNEST(@publisher_denylist)
         GROUP BY entity_name, entity_type
         ORDER BY COUNT(DISTINCT article_id) DESC
         LIMIT @limit
@@ -783,6 +797,9 @@ def get_entity_sentiment_timeline(
             bigquery.ScalarQueryParameter("days", "INT64", days),
             bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
             bigquery.ScalarQueryParameter("limit", "INT64", limit),
+            bigquery.ArrayQueryParameter(
+                "publisher_denylist", "STRING", publisher_denylist_lower()
+            ),
         ]
     )
 

--- a/tests/test_db_analytics.py
+++ b/tests/test_db_analytics.py
@@ -112,7 +112,13 @@ def test_entity_momentum_keys_off_analyzed_at_not_published_at(seeded):
     article_ids = [a.id for a in seeded.query(Article).limit(3).all()]
     assert len(article_ids) == 3, "seed should provide >=3 articles"
 
-    ent = Entity(name="Test Trending Name", type="PERSON")
+    # wikipedia_url is set so the entity passes the quality gate (only
+    # Knowledge-Graph-resolved entities are surfaced).
+    ent = Entity(
+        name="Test Trending Name",
+        type="PERSON",
+        wikipedia_url="https://en.wikipedia.org/wiki/Test",
+    )
     seeded.add(ent)
     seeded.flush()
 
@@ -156,6 +162,56 @@ def test_entity_momentum_keys_off_analyzed_at_not_published_at(seeded):
     hit = next(r for r in rows if r["entity_name"] == "Test Trending Name")
     assert hit["recent_mentions"] == 2
     assert hit["previous_mentions"] == 1
+
+
+def test_entity_momentum_excludes_low_quality_and_publishers(seeded):
+    """The momentum query applies the shared entity quality gate: drop entities
+    with no wikipedia_url (generic common nouns like 'markets') and publisher /
+    wire-service names (BBC, Getty) even though those are real orgs with a
+    wikipedia_url. Only the genuine subject entity should survive."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.article_entity import ArticleEntity
+    from app.models.entity import Entity
+
+    now = datetime.now(timezone.utc)
+    article_ids = [a.id for a in seeded.query(Article).limit(3).all()]
+    assert len(article_ids) == 3
+
+    real = Entity(
+        name="Real Subject",
+        type="PERSON",
+        wikipedia_url="https://en.wikipedia.org/wiki/Real",
+    )
+    # Generic common noun: GCP NL gives it no wikipedia_url → excluded by the gate.
+    generic = Entity(name="markets", type="OTHER", wikipedia_url=None)
+    # Publisher: a real org WITH a wikipedia_url → excluded only by the denylist.
+    publisher = Entity(
+        name="BBC",
+        type="ORGANIZATION",
+        wikipedia_url="https://en.wikipedia.org/wiki/BBC",
+    )
+    seeded.add_all([real, generic, publisher])
+    seeded.flush()
+
+    # Give all three plenty of recent mentions (well over the >=3 threshold).
+    for ent in (real, generic, publisher):
+        for art_id in article_ids:
+            seeded.add(
+                ArticleEntity(
+                    article_id=art_id,
+                    entity_id=ent.id,
+                    salience=0.5,
+                    mention_count=1,
+                    analyzed_at=now - timedelta(days=1),
+                )
+            )
+    seeded.commit()
+
+    names = {r["entity_name"] for r in entity_momentum(seeded, days=14)}
+    assert "Real Subject" in names
+    assert "markets" not in names  # no wikipedia_url
+    assert "BBC" not in names  # publisher denylist
 
 
 def test_daily_category_pivot_cumulative_is_monotonic(seeded):


### PR DESCRIPTION
Follow-up to the entity-quality work — closes two gaps you spotted.

## 1. "Trending names" had no quality gate
The Postgres `entity_momentum` query (behind the *trending names* chart) was the one entity surface that never got the quality gate, so it showed generic common nouns — "markets", "trading", "rates", "economy" (all `wikipedia_url = NULL`). Now gated like the others.

## 2. Self-referential publisher pollution (your observation)
The most-mentioned "entities" were the platform's **own sources and syndication partners**, not news subjects:

| Entity | Articles |
|---|---|
| Getty Images | 116 |
| Google | 108 |
| BBC | 85 |
| CNBC / AFP / AP / Reuters / Bloomberg | 57 / 42 / 38 / 37 / 32 |

These are real orgs (they have a `wikipedia_url`), so the wiki gate alone doesn't catch them — image-credit boilerplate ("Image: Getty"), wire-service bylines ("according to Reuters"), and our own source names.

## Fix — shared two-layer gate, applied to all 4 entity surfaces
- **New `app/constants/entity_filters.py`**: `PUBLISHER_ENTITY_DENYLIST` (news orgs, wire services, our ingestion sources, image-credit names) — single source of truth.
- **`entity_momentum` (Postgres):** `wikipedia_url IS NOT NULL` + non-entity-type exclusion + denylist (parameterized expanding binds).
- **3 BigQuery entity queries:** add the denylist (`LOWER(name) NOT IN UNNEST(@publisher_denylist)`) alongside the wiki gate they already had.

## Verified against prod
With both layers, top entities become **UK, US, Iran, Canada, Donald Trump, Europe, London, Ukraine, Bank of Canada, China, Russia** — actual news subjects, no publisher furniture.

## Tests
`entity_momentum` now asserts a no-wiki entity ("markets") and a publisher ("BBC", a real org *with* a wiki_url) are both excluded while a genuine subject survives. **7/7 Postgres analytics tests pass**; 100 backend tests; ruff/mypy clean.

> Note: only visible against BigQuery/prod (entity charts don't render in local demo mode).