### PR TITLE
feat(filter): date-range filter on articles

### DIFF
--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -19,13 +20,16 @@ def _query_articles(
     category: str | None,
     source_id: int | None,
     search: str | None,
+    published_after: datetime | None,
+    published_before: datetime | None,
 ) -> list[ArticleModel]:
     """Build the article-list query with optional filters and pagination.
 
     The filter columns (sentiment_label, category, source_id) are indexed in
-    migration ``f2a3b4c5d6e7`` so filter+order is index-supported. Substring
-    search on title is unindexed; production-grade search would use pg_trgm
-    GIN.
+    migration ``f2a3b4c5d6e7`` so filter+order is index-supported. The
+    ``published_at`` range filter rides the existing ``ix_articles_published_at``
+    btree, which also serves the ORDER BY. Substring search on title is
+    unindexed; production-grade search would use pg_trgm GIN.
     """
     # sentiment is read from the denormalized sentiment_label/score columns on
     # ArticleModel, so the sentiment_analyses relationship is not serialized —
@@ -41,6 +45,10 @@ def _query_articles(
         query = query.filter(ArticleModel.category == category)
     if source_id is not None:
         query = query.filter(ArticleModel.source_id == source_id)
+    if published_after is not None:
+        query = query.filter(ArticleModel.published_at >= published_after)
+    if published_before is not None:
+        query = query.filter(ArticleModel.published_at <= published_before)
     if search is not None:
         query = query.filter(ArticleModel.title.ilike(f"%{search}%"))
     return list(
@@ -72,9 +80,25 @@ def get_articles(
         max_length=200,
         description="Case-insensitive substring match against article title",
     ),
+    published_after: datetime | None = Query(
+        None,
+        description="Only articles published at or after this ISO-8601 datetime",
+    ),
+    published_before: datetime | None = Query(
+        None,
+        description="Only articles published at or before this ISO-8601 datetime",
+    ),
 ) -> List[ArticleRead]:
     return _query_articles(  # type: ignore[return-value]
-        db, skip, limit, sentiment_label, category, source_id, search
+        db,
+        skip,
+        limit,
+        sentiment_label,
+        category,
+        source_id,
+        search,
+        published_after,
+        published_before,
     )
 
 
@@ -87,9 +111,19 @@ def get_latest_articles(
     category: str | None = Query(None, max_length=50),
     source_id: int | None = Query(None, ge=1),
     search: str | None = Query(None, min_length=2, max_length=200),
+    published_after: datetime | None = Query(None),
+    published_before: datetime | None = Query(None),
 ) -> List[ArticleRead]:
     return _query_articles(  # type: ignore[return-value]
-        db, skip, limit, sentiment_label, category, source_id, search
+        db,
+        skip,
+        limit,
+        sentiment_label,
+        category,
+        source_id,
+        search,
+        published_after,
+        published_before,
     )
 
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -51,6 +51,11 @@
   let category: string = "";
   let sourceId: number | "" = "";
   let search: string = "";
+  // ISO-8601 datetime strings (or "" when unset). The FilterBar owns the
+  // preset-vs-custom UI and emits already-resolved bounds; App only stores and
+  // forwards them.
+  let publishedAfter: string = "";
+  let publishedBefore: string = "";
   let skip: number = 0;
   const limit: number = 20;
 
@@ -87,6 +92,8 @@
         category: category || undefined,
         source_id: sourceId === "" ? undefined : sourceId,
         search: search.trim().length >= 2 ? search.trim() : undefined,
+        published_after: publishedAfter || undefined,
+        published_before: publishedBefore || undefined,
       });
     } catch (e) {
       console.error("Failed to load articles:", e);
@@ -133,7 +140,15 @@
   $: if (initialised) {
     void loadArticles();
     // Reading these makes the block reactive to all of them.
-    void [sentiment, category, sourceId, search, skip];
+    void [
+      sentiment,
+      category,
+      sourceId,
+      search,
+      publishedAfter,
+      publishedBefore,
+      skip,
+    ];
   }
 
   // React to auth-state changes: hydrate / reset the bookmark store, and
@@ -165,6 +180,8 @@
       category: string;
       sourceId: number | "";
       search: string;
+      publishedAfter: string;
+      publishedBefore: string;
     }>
   ) {
     const next = event.detail;
@@ -172,6 +189,8 @@
     category = next.category;
     sourceId = next.sourceId;
     search = next.search;
+    publishedAfter = next.publishedAfter;
+    publishedBefore = next.publishedBefore;
     // Filter changed → reset to first page.
     skip = 0;
   }
@@ -333,6 +352,8 @@
       {category}
       {sourceId}
       {search}
+      {publishedAfter}
+      {publishedBefore}
       categories={CATEGORY_OPTIONS}
       {sources}
       on:change={handleFilterChange}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -261,7 +261,8 @@ a:hover { text-decoration: underline; }
 /* ─── FORM CONTROLS ──────────────────────────────────────────────────────── */
 select,
 input[type="text"],
-input[type="search"] {
+input[type="search"],
+input[type="date"] {
   background: var(--bg-raised);
   border: 1px solid var(--border-med);
   border-radius: var(--r-md);
@@ -273,6 +274,12 @@ input[type="search"] {
   appearance: none;
   -webkit-appearance: none;
 }
+/* Date inputs keep their native calendar popup, so hand the browser the active
+   theme: this themes the picker chrome AND the built-in calendar glyph so it's
+   visible on the dark control instead of a dark-on-dark icon. */
+input[type="date"] { cursor: pointer; }
+[data-theme="dark"] input[type="date"]  { color-scheme: dark; }
+[data-theme="light"] input[type="date"] { color-scheme: light; }
 select {
   padding-right: 28px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none' viewBox='0 0 10 6'%3E%3Cpath stroke='%2394A3B8' stroke-width='1.5' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
@@ -282,7 +289,8 @@ select {
 }
 select:focus,
 input[type="text"]:focus,
-input[type="search"]:focus {
+input[type="search"]:focus,
+input[type="date"]:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
@@ -423,7 +431,8 @@ select option {
   }
   select,
   input[type="text"],
-  input[type="search"] {
+  input[type="search"],
+  input[type="date"] {
     min-height: 44px;
     padding: 10px 12px;
     font-size: 16px; /* >=16px stops iOS Safari from zooming on focus */

--- a/frontend/src/lib/FilterBar.svelte
+++ b/frontend/src/lib/FilterBar.svelte
@@ -6,8 +6,45 @@
   export let category: string = "";
   export let sourceId: number | "" = "";
   export let search: string = "";
+  // ISO-8601 datetime strings (or "" when unset) — already-resolved bounds the
+  // parent forwards to the API. The UI below (preset dropdown + custom range)
+  // owns how they're produced.
+  export let publishedAfter: string = "";
+  export let publishedBefore: string = "";
   export let categories: string[] = [];
   export let sources: SourceDto[] = [];
+
+  // Date filtering is driven by a single dropdown:
+  //   • "" = any time
+  //   • "1" / "7" / "30" = rolling-day presets → published_after computed from
+  //     the current clock, published_before left open.
+  //   • "custom" = reveal a From/To pair of <input type="date">, normalised to
+  //     start-of-day / end-of-day so "to the 9th" includes all of the 9th.
+  // Seed from any incoming bounds so a range restored by the parent (e.g. from
+  // the URL in a later change) shows up; ISO datetime → its yyyy-mm-dd.
+  const isoToDateInput = (iso: string): string => (iso ? iso.slice(0, 10) : "");
+  let customFrom: string = isoToDateInput(publishedAfter); // yyyy-mm-dd
+  let customTo: string = isoToDateInput(publishedBefore); // yyyy-mm-dd
+  let datePreset: string = customFrom || customTo ? "custom" : "";
+
+  $: showCustomRange = datePreset === "custom";
+
+  function resolveDateBounds(): { after: string; before: string } {
+    if (datePreset === "custom") {
+      // Send local start/end-of-day so the inclusive backend bounds cover the
+      // whole picked day.
+      const after = customFrom ? new Date(`${customFrom}T00:00:00`).toISOString() : "";
+      const before = customTo ? new Date(`${customTo}T23:59:59.999`).toISOString() : "";
+      return { after, before };
+    }
+    if (datePreset) {
+      const days = Number(datePreset);
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - days);
+      return { after: cutoff.toISOString(), before: "" };
+    }
+    return { after: "", before: "" };
+  }
 
   // On narrow phones the three dropdowns sit 3-across, where the full
   // "All sentiments/categories/sources" labels would clip. Use short labels
@@ -28,6 +65,8 @@
       category: string;
       sourceId: number | "";
       search: string;
+      publishedAfter: string;
+      publishedBefore: string;
     };
   }>();
 
@@ -35,16 +74,33 @@
   let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
   function emitChange() {
+    const { after, before } = resolveDateBounds();
     dispatch("change", {
       sentiment,
       category,
       sourceId,
       search,
+      publishedAfter: after,
+      publishedBefore: before,
     });
   }
 
   function handleSelectChange() {
     // selects are non-debounced — change fires once per user pick.
+    emitChange();
+  }
+
+  function handlePresetChange() {
+    // Leaving "custom" discards the From/To values so a later re-select starts
+    // clean and a rolling preset never carries a stale range underneath it.
+    if (datePreset !== "custom") {
+      customFrom = "";
+      customTo = "";
+    }
+    emitChange();
+  }
+
+  function handleCustomDateChange() {
     emitChange();
   }
 
@@ -102,6 +158,19 @@
     {/each}
   </select>
 
+  <select
+    class="filter-select"
+    bind:value={datePreset}
+    on:change={handlePresetChange}
+    aria-label="Filter by date range"
+  >
+    <option value="">{isNarrow ? "Date" : "Any time"}</option>
+    <option value="1">Last 24 hours</option>
+    <option value="7">Last 7 days</option>
+    <option value="30">Last 30 days</option>
+    <option value="custom">Custom range…</option>
+  </select>
+
   <div class="search-wrap">
     <span class="search-icon" aria-hidden="true">⌕</span>
     <input
@@ -113,6 +182,33 @@
       aria-label="Search article titles"
     />
   </div>
+
+  {#if showCustomRange}
+    <div class="custom-range">
+      <label class="range-field">
+        <span class="range-label">From</span>
+        <input
+          type="date"
+          class="filter-select date-input"
+          bind:value={customFrom}
+          on:change={handleCustomDateChange}
+          max={customTo || undefined}
+          aria-label="Published from date"
+        />
+      </label>
+      <label class="range-field">
+        <span class="range-label">To</span>
+        <input
+          type="date"
+          class="filter-select date-input"
+          bind:value={customTo}
+          on:change={handleCustomDateChange}
+          min={customFrom || undefined}
+          aria-label="Published to date"
+        />
+      </label>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -151,6 +247,34 @@
     pointer-events: none;
   }
 
+  /* Custom from/to range: revealed only when "Custom range…" is picked. Its own
+     full-width row, set off from the controls above by a hairline + top padding
+     so it reads as a sub-panel rather than crowding the dropdowns. */
+  .custom-range {
+    flex: 1 1 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3) var(--sp-5);
+    flex-wrap: wrap;
+    padding-top: var(--sp-3);
+    border-top: 1px solid var(--border);
+  }
+  .range-field {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-2);
+  }
+  .range-label {
+    color: var(--text-sec);
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  /* Native date inputs collapse very narrow without a floor; keep them legible
+     and matched in width. */
+  .date-input {
+    min-width: 9.5rem;
+  }
+
   /* Narrow phones: lay the bar out as an explicit 2-row grid — the three short
      dropdowns share one row (3 columns), the search spans the full width below.
      This is half the height of four stacked controls and avoids the uneven
@@ -163,21 +287,31 @@
       padding: var(--sp-3);
     }
     /* 2 dropdowns per row gives each ~190px — enough for the short labels
-       plus the arrow without clipping. The 3rd select and the search each
-       span the full width below. Three compact rows, ~half the original
-       four-stack height. */
+       plus the arrow without clipping. Sentiment + category share row 1;
+       source + date-preset share row 2; the search and the custom range each
+       span the full width below. */
     .filter-select {
       min-width: 0;
       max-width: none;
-    }
-    .filter-select:nth-of-type(3) {
-      grid-column: 1 / -1;
     }
     .search-wrap {
       grid-column: 1 / -1;
       min-width: 0;
       max-width: none;
       margin-left: 0;
+    }
+    .custom-range {
+      grid-column: 1 / -1;
+    }
+    /* Each From/To field takes one grid column so the two date inputs sit
+       side-by-side instead of stacking. */
+    .range-field {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+    .date-input {
+      flex: 1 1 0;
+      width: 100%;
     }
   }
 </style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,6 +70,10 @@ export type ArticleFilterParams = {
   category?: string;
   source_id?: number;
   search?: string;
+  /** ISO-8601 datetime; inclusive lower bound on published_at. */
+  published_after?: string;
+  /** ISO-8601 datetime; inclusive upper bound on published_at. */
+  published_before?: string;
 };
 
 /**
@@ -91,6 +95,8 @@ export async function fetchArticles(
     qs.set("source_id", String(params.source_id));
   }
   if (params.search) qs.set("search", params.search);
+  if (params.published_after) qs.set("published_after", params.published_after);
+  if (params.published_before) qs.set("published_before", params.published_before);
 
   const queryString = qs.toString();
   const url = queryString

--- a/tests/test_articles_filters.py
+++ b/tests/test_articles_filters.py
@@ -130,6 +130,56 @@ class TestArticleFilters:
         assert len(data) == 1
         assert "Trump" in data[0]["title"]
 
+    def test_articles_filter_published_after(self, client: TestClient) -> None:
+        """published_after is an inclusive lower bound on published_at.
+
+        Seed times are ``2026-05-01 12:00`` (idx 0) down to ``03:00`` (idx 9),
+        one article per hour. A cutoff of ``10:00`` keeps the rows at
+        10:00/11:00/12:00 → 3 articles (>= is inclusive of the 10:00 row).
+        """
+        resp = client.get("/api/v1/articles/?published_after=2026-05-01T10:00:00Z")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+
+    def test_articles_filter_published_before(self, client: TestClient) -> None:
+        """published_before is an inclusive upper bound on published_at.
+
+        A cutoff of ``05:00`` keeps the rows at 03:00/04:00/05:00 → 3 articles
+        (<= is inclusive of the 05:00 row).
+        """
+        resp = client.get("/api/v1/articles/?published_before=2026-05-01T05:00:00Z")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+
+    def test_articles_filter_published_range(self, client: TestClient) -> None:
+        """after + before AND together into an inclusive window.
+
+        ``[08:00, 10:00]`` keeps 08:00/09:00/10:00 → 3 articles.
+        """
+        resp = client.get(
+            "/api/v1/articles/"
+            "?published_after=2026-05-01T08:00:00Z"
+            "&published_before=2026-05-01T10:00:00Z"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+
+    def test_articles_inverted_date_range_returns_empty(
+        self, client: TestClient
+    ) -> None:
+        """after > before is not an error — it just matches nothing (empty list),
+        consistent with how the other filters behave."""
+        resp = client.get(
+            "/api/v1/articles/"
+            "?published_after=2026-05-01T12:00:00Z"
+            "&published_before=2026-05-01T03:00:00Z"
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
     def test_articles_pagination(self, client: TestClient) -> None:
         """skip+limit yield disjoint id sets across consecutive pages."""
         page1 = client.get("/api/v1/articles/?skip=0&limit=5").json()


### PR DESCRIPTION
## Summary

Adds **date-range filtering** to the article feed — the first PR of the search/filter improvement pass. Users can now narrow articles by publication date via a quick preset (24h / 7d / 30d) or a custom From/To range.

## Backend (`app/routers/articles.py`)
- `_query_articles()` gains optional `published_after` / `published_before` datetime bounds, applied as **inclusive** `>=` / `<=` filters on `published_at`.
- These ride the **existing** `ix_articles_published_at` btree (which already serves the `ORDER BY`), so the filter is index-supported with **no new migration**. Works identically on SQLite and Postgres — no dialect gating.
- Both `GET /api/v1/articles/` and `/articles/latest` expose the two params.
- Inverted ranges (`after > before`) return an empty list rather than 422, matching how the other filters behave.

## Frontend
- **`FilterBar.svelte`**: a date dropdown (`Any time / Last 24 hours / 7 days / 30 days / Custom range…`). Picking *Custom range* reveals a From/To pair of date inputs on their own row. The component resolves the selection into ISO-8601 bounds, sending **start-of-day / end-of-day** for a custom day range so an inclusive "to" bound covers the whole picked day.
- **`App.svelte`**: threads `publishedAfter` / `publishedBefore` through filter state, the reactive re-fetch, and `handleFilterChange` (resets to page 1).
- **`api.ts`**: `published_after` / `published_before` added to `ArticleFilterParams`, serialized into the query string when set.

## Styling (`app.css`)
- Added `input[type="date"]` to the global form-control, `:focus`, and mobile touch-target rules so date inputs inherit the brand tokens (raised bg, border, text, accent focus ring) instead of native browser chrome.
- `color-scheme` keyed to `[data-theme]` so the calendar glyph/popup theme to dark/light correctly.

## Tests (`tests/test_articles_filters.py`)
- Inclusive lower bound, inclusive upper bound, AND-ed range, and the empty-result inverted-range case. All run on SQLite; existing contract tests unchanged.

## Verification
- Backend suite: **104 passed / 13 skipped** (skips = `@pytest.mark.postgres`, expected locally).
- `svelte-check`: 0 errors / 0 warnings · `vite build`: OK · `ruff` + `mypy`: clean.
- Confirmed end-to-end against the live dev backend (clean complementary split at a boundary date) and in the UI.
