### PR TITLE
feat(search): pg_trgm trigram index + similarity ranking on title search

### DIFF
--- a/alembic/versions/a3f1c2d4e5b6_add_pg_trgm_title_search_index.py
+++ b/alembic/versions/a3f1c2d4e5b6_add_pg_trgm_title_search_index.py
@@ -1,0 +1,52 @@
+"""add pg_trgm trigram index on articles.title for indexed substring search
+
+Revision ID: a3f1c2d4e5b6
+Revises: 7c3e9a4f1b82
+Create Date: 2026-06-09 05:30:00.000000
+
+Background
+----------
+``GET /api/v1/articles/?search=`` filters with ``title ILIKE '%term%'``. The
+leading wildcard makes the match unindexable by a btree, so every search was a
+sequential scan over the whole ``articles`` table.
+
+The ``pg_trgm`` extension provides a GIN trigram index that *does* accelerate
+``ILIKE '%term%'`` (and ``similarity()`` ranking). After this migration the same
+query plans as a Bitmap Index Scan on ``ix_articles_title_trgm`` instead of a
+Seq Scan. This closes the long-standing TODO in ``app/routers/articles.py``.
+
+Postgres-only DDL (like every migration here — the SQLite test DB is built from
+``Base.metadata`` via ``create_all``, never migrated). The extension and index
+are no-ops on a non-Postgres engine, so this file is never executed there.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f1c2d4e5b6"
+down_revision: Union[str, None] = "7c3e9a4f1b82"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Enable trigram matching. IF NOT EXISTS keeps re-runs / shared databases
+    # safe. Requires the role to have CREATE on the database (the Cloud SQL
+    # app user does; pg_trgm ships with Postgres 14 — no superuser needed for
+    # CREATE EXTENSION on a trusted extension).
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    # GIN trigram index: accelerates ILIKE '%term%' substring search and
+    # similarity()/word_similarity() ranking on the title.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_articles_title_trgm "
+        "ON articles USING gin (title gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_articles_title_trgm")
+    # Intentionally NOT dropping the extension: other objects (future FTS work,
+    # other trigram indexes) may come to depend on it, and DROP EXTENSION would
+    # cascade. Leaving it installed is harmless and the safe default.

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -1,8 +1,10 @@
 from datetime import datetime
-from typing import List
+from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload, subqueryload
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.database import get_db
 from app.models.article import Article as ArticleModel
@@ -25,11 +27,13 @@ def _query_articles(
 ) -> list[ArticleModel]:
     """Build the article-list query with optional filters and pagination.
 
-    The filter columns (sentiment_label, category, source_id) are indexed in
     migration ``f2a3b4c5d6e7`` so filter+order is index-supported. The
     ``published_at`` range filter rides the existing ``ix_articles_published_at``
-    btree, which also serves the ORDER BY. Substring search on title is
-    unindexed; production-grade search would use pg_trgm GIN.
+    btree, which also serves the ORDER BY. The ``search`` substring match
+    (``title ILIKE '%term%'``) is accelerated by the pg_trgm GIN index
+    ``ix_articles_title_trgm`` (migration ``a3f1c2d4e5b6``); on Postgres we
+    additionally rank matches by trigram ``similarity`` so the closest title
+    surfaces first instead of merely the newest.
     """
     # sentiment is read from the denormalized sentiment_label/score columns on
     # ArticleModel, so the sentiment_analyses relationship is not serialized —
@@ -49,17 +53,25 @@ def _query_articles(
         query = query.filter(ArticleModel.published_at >= published_after)
     if published_before is not None:
         query = query.filter(ArticleModel.published_at <= published_before)
+
+    # The filter stays ILIKE on every dialect so the substring contract (and the
+    # SQLite-backed tests) is preserved byte-for-byte. Only the ORDER BY changes:
+    # on Postgres a searched query is ranked by trigram relevance first.
+    order_by: list[ColumnElement[Any]] = [
+        ArticleModel.published_at.desc(),
+        ArticleModel.id.desc(),
+    ]
     if search is not None:
         query = query.filter(ArticleModel.title.ilike(f"%{search}%"))
-    return list(
-        query.order_by(
-            ArticleModel.published_at.desc(),
-            ArticleModel.id.desc(),
-        )
-        .offset(skip)
-        .limit(limit)
-        .all()
-    )
+        # ``similarity()`` is a pg_trgm function — Postgres only. SQLite (tests)
+        # falls through to the date order, so no dialect shim is needed there.
+        if db.bind is not None and db.bind.dialect.name == "postgresql":
+            order_by = [
+                func.similarity(ArticleModel.title, search).desc(),
+                *order_by,
+            ]
+
+    return list(query.order_by(*order_by).offset(skip).limit(limit).all())
 
 
 @router.get("/", response_model=List[ArticleRead])

--- a/tests/test_articles_search_pg.py
+++ b/tests/test_articles_search_pg.py
@@ -1,0 +1,107 @@
+"""Postgres-only tests for trigram-accelerated title search (migration
+a3f1c2d4e5b6 + the similarity ranking in app/routers/articles.py).
+
+These need the real pg_trgm extension and GIN index, so they are
+@pytest.mark.postgres and skip when no TEST_POSTGRES_URL is set
+(see conftest.pytest_collection_modifyitems). The schema — including the
+trigram index — is built by the CI ``alembic upgrade head`` step before pytest
+runs, so ``postgres_db`` queries hit the migrated database.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.main import app
+from app.models.article import Article
+from app.models.source import Source
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.fixture()
+def seeded_pg(postgres_db: Session) -> Session:
+    """Seed titles with a clear trigram-similarity gradient for "quantum".
+
+    ``similarity(title, q)`` is the shared-trigram ratio over both strings, so a
+    title where the term is a *larger fraction* scores higher. The short
+    "Quantum leap…" therefore out-ranks the longer "Quantum computing…" even
+    though we publish the short one OLDEST — proving the ORDER BY is relevance,
+    not recency. (Verified directly against pg_trgm: 0.286 vs 0.195 vs 0.0.)
+    """
+    source = Source(name="testwire")
+    postgres_db.add(source)
+    postgres_db.flush()
+
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    # (title, hours_offset) — bigger offset = older. The strongest match is the
+    # oldest, so a pure published_at sort would bury it; similarity lifts it.
+    rows = [
+        ("Markets steady as earnings season opens", 0),  # newest, no match
+        ("Quantum computing breakthrough announced", 1),  # match, longer title
+        ("Quantum leap in chip design", 2),  # oldest, strongest (shorter) match
+    ]
+    for idx, (title, off) in enumerate(rows):
+        postgres_db.add(
+            Article(
+                source_id=source.id,
+                title=title,
+                url=f"https://example.com/pg/{idx}",
+                published_at=base - timedelta(hours=off),
+            )
+        )
+    postgres_db.commit()
+    return postgres_db
+
+
+@pytest.fixture()
+def client(seeded_pg: Session) -> TestClient:
+    def _override_get_db():
+        yield seeded_pg
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_title_search_uses_trigram_gin_index(seeded_pg: Session) -> None:
+    """The ILIKE '%term%' search plans as a bitmap scan on the trigram GIN
+    index, not a sequential scan. We force an index plan and assert the index
+    name appears in the EXPLAIN output."""
+    # enable_seqscan=off makes the planner prefer the index when it's eligible;
+    # if the trigram index were missing this would still seq-scan (GIN is the
+    # only way to satisfy a leading-wildcard ILIKE), so the assertion is real.
+    seeded_pg.execute(text("SET LOCAL enable_seqscan = off"))
+    plan = "\n".join(
+        row[0]
+        for row in seeded_pg.execute(
+            text("EXPLAIN SELECT id FROM articles WHERE title ILIKE :pat"),
+            {"pat": "%quantum%"},
+        ).fetchall()
+    )
+    assert "ix_articles_title_trgm" in plan, plan
+
+
+def test_search_ranks_by_trigram_similarity(client: TestClient) -> None:
+    """On Postgres a searched query orders by trigram similarity first, so the
+    strongest match leads even though it is the OLDEST row (a pure date sort
+    would put it last)."""
+    data = client.get("/api/v1/articles/?search=quantum").json()
+    titles = [a["title"] for a in data]
+    assert len(titles) == 2  # both "quantum" rows match; the markets row doesn't
+    assert titles[0] == "Quantum leap in chip design"
+
+
+def test_search_still_substring_filtered(client: TestClient) -> None:
+    """Ranking is additive — the ILIKE substring filter still bounds the set,
+    so a term present in no title returns nothing."""
+    data = client.get("/api/v1/articles/?search=zzzznomatch").json()
+    assert data == []


### PR DESCRIPTION
## Summary

Makes the article **title search indexed and relevance-ranked** instead of an unindexed sequential scan — the second PR of the search improvement pass (after #166's date filter, which this branch is rebased on top of).

## Migration (`alembic/versions/a3f1c2d4e5b6`)
- `CREATE EXTENSION IF NOT EXISTS pg_trgm`
- `CREATE INDEX ix_articles_title_trgm ON articles USING gin (title gin_trgm_ops)`
- This accelerates the existing `title ILIKE '%term%'`: a leading wildcard is unindexable by a btree, so the search was a **Seq Scan**; it now plans as a **Bitmap Index Scan** on the GIN trigram index. Closes the long-standing TODO in `app/routers/articles.py`.
- `downgrade()` drops the index but **intentionally keeps the extension** (other objects may come to depend on it; `DROP EXTENSION` would cascade).

## Router (`app/routers/articles.py`)
- `_query_articles()` keeps the `ILIKE` filter on **every** dialect, so the substring contract and the SQLite-backed tests are preserved byte-for-byte.
- Only the `ORDER BY` changes: on Postgres a searched query is ranked by `similarity(title, q) DESC` first, then the existing `published_at`/`id` order — so the closest title surfaces ahead of merely the newest. `similarity()` is a pg_trgm function, so it's **dialect-gated** to `postgresql`; SQLite falls through to the date order (no shim needed).

## Tests (`tests/test_articles_search_pg.py`, `@pytest.mark.postgres`)
- The `ILIKE` search plans onto `ix_articles_title_trgm` (EXPLAIN assertion).
- A searched query ranks the strongest trigram match first even when it's the **oldest** row (proves relevance, not recency).
- The substring filter still bounds the set (a no-match term returns `[]`).

## Verification
- Verified against a **real Postgres 14** (the docker-compose `db`): migration upgrade + downgrade round-trip; all 3 `@pytest.mark.postgres` tests pass with `TEST_POSTGRES_URL` set.
- SQLite suite: **104 passed / 16 skipped**. `ruff` + `mypy` clean.
- Rebased onto `develop` after #166 merged; both the date filter and the trigram ranking coexist in `_query_articles`.
