### PR TITLE
feat(search): full-text search endpoint (tsvector + ts_rank)

### DIFF
--- a/alembic/versions/b4e2d5c6f7a8_add_articles_fts_search_vector.py
+++ b/alembic/versions/b4e2d5c6f7a8_add_articles_fts_search_vector.py
@@ -1,0 +1,64 @@
+"""add full-text search_vector (tsvector) column + GIN index on articles
+
+Revision ID: b4e2d5c6f7a8
+Revises: a3f1c2d4e5b6
+Create Date: 2026-06-09 06:30:00.000000
+
+Background
+----------
+PR #167 added trigram (pg_trgm) substring search + ranking on ``title``. This
+adds a parallel **full-text** search path: a generated ``tsvector`` column over
+weighted ``title`` (weight A) + ``description`` (weight B), GIN-indexed, queried
+via ``websearch_to_tsquery`` and ranked with ``ts_rank``. This gives multi-field
+linguistic ranking (stemming, stop-words, phrase + boolean operators) that
+trigram matching can't, and powers the new ``GET /api/v1/articles/search`` route.
+
+Design notes
+------------
+* ``GENERATED ALWAYS AS (...) STORED`` (Postgres 12+) keeps the vector in sync
+  automatically — no trigger needed, unlike the classic tsvector pattern.
+* ``coalesce(..., '')`` so a NULL description doesn't null the whole vector.
+* The column is **deliberately NOT mapped on the ORM ``Article`` model**: it's a
+  Postgres-only DB object (like the views/functions in migration e1f2a3b4c5d6),
+  the SQLite test schema never needs it, and ``ArticleRead`` declares its fields
+  explicitly so the vector can never leak into an API response. The search CRUD
+  references it through raw ``text()`` SQL. (If you ever run
+  ``alembic revision --autogenerate``, it will propose DROPping this column
+  because it's absent from ``Base.metadata`` — keep it; this project hand-writes
+  migrations.)
+
+Postgres-only DDL (the SQLite test DB is built from ``Base.metadata`` via
+``create_all``, never migrated), consistent with every other migration here.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4e2d5c6f7a8"
+down_revision: Union[str, None] = "a3f1c2d4e5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE articles
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(description, '')), 'B')
+        ) STORED
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_articles_search_vector "
+        "ON articles USING gin (search_vector)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_articles_search_vector")
+    op.execute("ALTER TABLE articles DROP COLUMN IF EXISTS search_vector")

--- a/app/crud/search.py
+++ b/app/crud/search.py
@@ -1,0 +1,69 @@
+"""PostgreSQL full-text search over articles.
+
+A parallel, richer search path to the trigram substring search on ``/articles/``
+(migration a3f1c2d4e5b6): this queries the generated ``search_vector`` tsvector
+column (migration b4e2d5c6f7a8) with ``websearch_to_tsquery`` and ranks hits by
+``ts_rank``, giving stemming, stop-words and phrase/boolean operators across the
+weighted title (A) + description (B).
+
+Postgres-only — the ``@@`` operator, ``websearch_to_tsquery`` and ``ts_rank`` do
+not exist on SQLite. The caller (the ``/articles/search`` route) is reached only
+on the deployed Postgres stack; the SQLite test suite never hits this module
+(its tests are ``@pytest.mark.postgres``).
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session, joinedload, subqueryload
+
+from app.models.article import Article
+from app.models.article_entity import ArticleEntity
+
+
+def search_articles(
+    db: Session,
+    *,
+    q: str,
+    skip: int = 0,
+    limit: int = 20,
+    published_after: Optional[datetime] = None,
+    published_before: Optional[datetime] = None,
+) -> list[Article]:
+    """Full-text search articles by ``q``, ranked by ts_rank (desc), then recency.
+
+    ``q`` is parsed with ``websearch_to_tsquery`` — the user-facing grammar that
+    accepts quoted "phrases", ``or``, and leading ``-`` for exclusion, and never
+    raises on malformed input (unlike ``to_tsquery``). The same eager loads as
+    the list endpoint are applied so the response shape matches ``ArticleRead``.
+    """
+    # The FTS predicate and rank reference the Postgres-only search_vector column
+    # via text() (it is intentionally not an ORM attribute). The :q bind is set
+    # once with .params() and reused by both the filter and the ORDER BY rank.
+    query = (
+        db.query(Article)
+        .options(
+            joinedload(Article.source),
+            subqueryload(Article.article_entities).joinedload(ArticleEntity.entity),
+            subqueryload(Article.article_categories),
+        )
+        .filter(text("search_vector @@ websearch_to_tsquery('english', :q)"))
+    )
+
+    if published_after is not None:
+        query = query.filter(Article.published_at >= published_after)
+    if published_before is not None:
+        query = query.filter(Article.published_at <= published_before)
+
+    return list(
+        query.order_by(
+            text("ts_rank(search_vector, websearch_to_tsquery('english', :q)) DESC"),
+            Article.published_at.desc(),
+            Article.id.desc(),
+        )
+        .params(q=q)
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -6,6 +6,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload, subqueryload
 from sqlalchemy.sql.elements import ColumnElement
 
+from app.crud.search import search_articles
 from app.database import get_db
 from app.models.article import Article as ArticleModel
 from app.models.article_entity import ArticleEntity
@@ -27,6 +28,7 @@ def _query_articles(
 ) -> list[ArticleModel]:
     """Build the article-list query with optional filters and pagination.
 
+    The filter columns (sentiment_label, category, source_id) are indexed in
     migration ``f2a3b4c5d6e7`` so filter+order is index-supported. The
     ``published_at`` range filter rides the existing ``ix_articles_published_at``
     btree, which also serves the ORDER BY. The ``search`` substring match
@@ -136,6 +138,38 @@ def get_latest_articles(
         search,
         published_after,
         published_before,
+    )
+
+
+@router.get("/search", response_model=List[ArticleRead])
+def search_articles_fts(
+    db: Session = Depends(get_db),
+    q: str = Query(
+        ...,
+        min_length=2,
+        max_length=200,
+        description=(
+            'Full-text query (Postgres). Supports quoted "phrases", OR, and '
+            "leading - to exclude, via websearch_to_tsquery. Results are ranked "
+            "by ts_rank over the weighted title + description."
+        ),
+    ),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(20, ge=1, le=100),
+    published_after: datetime | None = Query(None),
+    published_before: datetime | None = Query(None),
+) -> List[ArticleRead]:
+    # Declared BEFORE /{article_id} so "search" isn't captured by the int path
+    # param. Postgres-only — the FTS operators don't exist on SQLite, so this
+    # route is exercised against the deployed/Postgres stack (tests are
+    # @pytest.mark.postgres).
+    return search_articles(  # type: ignore[return-value]
+        db,
+        q=q,
+        skip=skip,
+        limit=limit,
+        published_after=published_after,
+        published_before=published_before,
     )
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -114,6 +114,41 @@ export async function fetchArticles(
   return await res.json();
 }
 
+export type ArticleSearchParams = {
+  q: string;
+  skip?: number;
+  limit?: number;
+  published_after?: string;
+  published_before?: string;
+};
+
+/**
+ * Full-text search via `/api/v1/articles/search` (Postgres `ts_rank` ranking
+ * over the weighted title + description). Supports quoted "phrases", `or`, and
+ * leading `-` to exclude. Returns the same `ArticleDto` shape as the list
+ * endpoint, ordered by relevance then recency. Postgres-only on the backend.
+ */
+export async function searchArticles(
+  params: ArticleSearchParams
+): Promise<ArticleDto[]> {
+  const qs = new URLSearchParams();
+  qs.set("q", params.q);
+  if (params.skip !== undefined) qs.set("skip", String(params.skip));
+  if (params.limit !== undefined) qs.set("limit", String(params.limit));
+  if (params.published_after) qs.set("published_after", params.published_after);
+  if (params.published_before) qs.set("published_before", params.published_before);
+
+  const res = await fetch(`${API_BASE}/api/v1/articles/search?${qs.toString()}`);
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.error("API Error:", errorText);
+    throw new Error(`Failed to search articles: ${res.status} ${errorText}`);
+  }
+
+  return await res.json();
+}
+
 /**
  * Fetch a single article by ID. Used by BookmarksView to hydrate bookmarked
  * article details after listing the user's bookmarks.

--- a/tests/test_articles_search_fts.py
+++ b/tests/test_articles_search_fts.py
@@ -1,0 +1,130 @@
+"""Postgres-only tests for the full-text search endpoint /api/v1/articles/search
+(migration b4e2d5c6f7a8 + app/crud/search.py).
+
+These need the real generated tsvector column, the GIN index, and the
+websearch_to_tsquery/ts_rank functions, so they are @pytest.mark.postgres and
+skip when no TEST_POSTGRES_URL is set (see conftest.pytest_collection_modifyitems).
+The schema — including search_vector — is built by the CI ``alembic upgrade head``
+step before pytest runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.main import app
+from app.models.article import Article
+from app.models.source import Source
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.fixture()
+def seeded_pg(postgres_db: Session) -> Session:
+    """Seed articles whose titles/descriptions exercise FTS ranking + operators.
+
+    The generated search_vector column populates automatically on INSERT (it's
+    GENERATED ALWAYS ... STORED), so no extra step is needed.
+    """
+    source = Source(name="testwire")
+    postgres_db.add(source)
+    postgres_db.flush()
+
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    # (title, description, hours_offset)
+    rows = [
+        # Title hit (weight A) — should out-rank a description-only hit.
+        ("Central bank raises interest rates", "Policy update from the meeting", 2),
+        # Description-only hit (weight B) for "interest".
+        ("Quarterly markets wrap", "Investors weigh interest and inflation", 1),
+        # Phrase + boolean fixtures.
+        ("Global climate summit opens", "Leaders debate climate policy targets", 3),
+        ("Crypto market rally continues", "Bitcoin leads the climate of optimism", 4),
+        ("Sports roundup", "No relevant tokens here", 0),
+    ]
+    for idx, (title, desc, off) in enumerate(rows):
+        postgres_db.add(
+            Article(
+                source_id=source.id,
+                title=title,
+                description=desc,
+                url=f"https://example.com/fts/{idx}",
+                published_at=base - timedelta(hours=off),
+            )
+        )
+    postgres_db.commit()
+    return postgres_db
+
+
+@pytest.fixture()
+def client(seeded_pg: Session) -> TestClient:
+    def _override_get_db():
+        yield seeded_pg
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_search_endpoint_returns_matches(client: TestClient) -> None:
+    """A plain term matches both a title hit and a description hit."""
+    data = client.get("/api/v1/articles/search?q=interest").json()
+    titles = {a["title"] for a in data}
+    assert "Central bank raises interest rates" in titles  # title (weight A)
+    assert "Quarterly markets wrap" in titles  # description (weight B)
+    assert "Sports roundup" not in titles
+
+
+def test_title_weight_outranks_description(client: TestClient) -> None:
+    """ts_rank with setweight('A') on title means a title hit ranks above a
+    description-only hit for the same term."""
+    data = client.get("/api/v1/articles/search?q=interest").json()
+    assert data[0]["title"] == "Central bank raises interest rates"
+
+
+def test_phrase_query(client: TestClient) -> None:
+    """Quoted phrases are honored by websearch_to_tsquery: "climate policy"
+    matches the article whose description contains that phrase, not the one
+    that merely contains the word "climate" elsewhere."""
+    data = client.get('/api/v1/articles/search?q="climate policy"').json()
+    titles = {a["title"] for a in data}
+    assert "Global climate summit opens" in titles
+    assert "Crypto market rally continues" not in titles
+
+
+def test_boolean_exclusion(client: TestClient) -> None:
+    """Leading - excludes a term (websearch_to_tsquery grammar): climate without
+    crypto drops the crypto article."""
+    data = client.get("/api/v1/articles/search?q=climate -crypto").json()
+    titles = {a["title"] for a in data}
+    assert "Global climate summit opens" in titles
+    assert "Crypto market rally continues" not in titles
+
+
+def test_search_respects_date_bounds(client: TestClient) -> None:
+    """The date params compose with the FTS filter."""
+    # "climate" matches two rows (offsets 3 and 4 → 09:00 and 08:00). Bound to
+    # >= 08:30 keeps only the 09:00 one.
+    after = "2026-05-01T08:30:00Z"
+    data = client.get(
+        f"/api/v1/articles/search?q=climate&published_after={after}"
+    ).json()
+    titles = {a["title"] for a in data}
+    assert titles == {"Global climate summit opens"}
+
+
+def test_no_match_returns_empty(client: TestClient) -> None:
+    data = client.get("/api/v1/articles/search?q=zzzznomatch").json()
+    assert data == []
+
+
+def test_missing_q_is_422(client: TestClient) -> None:
+    """q is required."""
+    assert client.get("/api/v1/articles/search").status_code == 422


### PR DESCRIPTION
## Summary

Adds a Postgres **full-text search** path alongside the trigram substring search (#167), exposed as a new `GET /api/v1/articles/search?q=` endpoint. This gives multi-field **linguistic ranking** — stemming, stop-words, and phrase/boolean operators — over the weighted title + description, which trigram matching can't. Third PR of the search improvement pass.

## Migration (`alembic/versions/b4e2d5c6f7a8`)
- Adds a generated `search_vector tsvector` column:
  ```sql
  GENERATED ALWAYS AS (
    setweight(to_tsvector('english', coalesce(title,'')), 'A') ||
    setweight(to_tsvector('english', coalesce(description,'')), 'B')
  ) STORED
  ```
  `GENERATED … STORED` (PG12+) keeps it in sync with **no trigger**.
- `CREATE INDEX ix_articles_search_vector … USING gin (search_vector)`.
- The column is **deliberately not mapped on the ORM `Article` model** — it's a Postgres-only DB object (like the views/functions in `e1f2a3b4c5d6`), the SQLite test schema never needs it, and `ArticleRead` declares its fields explicitly so it can't leak into a response. `downgrade()` drops the index + column.

## CRUD (`app/crud/search.py`)
- `search_articles()` filters `search_vector @@ websearch_to_tsquery('english', :q)`, orders by `ts_rank DESC` then `published_at`/`id`, with optional date bounds + pagination. Parameterized via `text()` + `.params()` (no f-string SQL). Reuses the list endpoint's eager loads so the response shape matches `ArticleRead`.

## Router (`app/routers/articles.py`)
- New `GET /articles/search?q=` — declared **before** `/{article_id}` so `"search"` isn't captured by the int path param. `q` required (min 2). Accepts the same `published_after`/`published_before` bounds so search is date-scopable. The legacy `/articles/?search=` path is untouched.

## Frontend (`frontend/src/lib/api.ts`)
- `searchArticles(q, …)` client for the new endpoint. **Not yet wired into the UI** — the search box switches to FTS in the upcoming UX PR.

## Tests (`tests/test_articles_search_fts.py`, `@pytest.mark.postgres`)
- term matching, title-weight-outranks-description ranking, quoted **phrase**, **boolean** exclusion (`-term`), date-bound composition, empty result, required-`q` 422.

## Verification
- Verified against a **real Postgres 14** (the docker-compose `db`): both migrations upgrade; the FTS migration **downgrade → re-upgrade round-trips**; all **7** `@pytest.mark.postgres` tests pass with `TEST_POSTGRES_URL` set.
- SQLite suite: **104 passed / 23 skipped**. `ruff` + `mypy` clean. `svelte-check` 0/0 + `vite build` OK.
- Also restores a docstring sentence in `_query_articles` dropped in the #167 rebase merge.
