### PR TITLE
feat(search): UX — FTS wiring, highlight, URL sync, result count, focus key

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import { theme, toggleTheme } from "./lib/theme";
   import {
     fetchArticles,
+    searchArticles,
     fetchSources,
     createBookmark,
     deleteBookmark,
@@ -81,20 +82,68 @@
   // after onMount completes to avoid double-fetching on first render.
   let initialised = false;
 
+  // ── URL ⇄ filter-state sync ─────────────────────────────────────────
+  // Filters/search/date/page live in the querystring so a filtered view is
+  // shareable and survives reload. We use replaceState (not pushState) so each
+  // keystroke/filter change doesn't spam the browser history.
+  function readStateFromUrl() {
+    const p = new URLSearchParams(window.location.search);
+    sentiment = p.get("sentiment") ?? "";
+    category = p.get("category") ?? "";
+    const sid = p.get("source");
+    sourceId = sid ? Number(sid) : "";
+    search = p.get("search") ?? "";
+    publishedAfter = p.get("after") ?? "";
+    publishedBefore = p.get("before") ?? "";
+    const sk = Number(p.get("skip") ?? "0");
+    skip = Number.isFinite(sk) && sk > 0 ? sk : 0;
+  }
+
+  function syncStateToUrl() {
+    const p = new URLSearchParams();
+    if (sentiment) p.set("sentiment", sentiment);
+    if (category) p.set("category", category);
+    if (sourceId !== "") p.set("source", String(sourceId));
+    if (search.trim()) p.set("search", search.trim());
+    if (publishedAfter) p.set("after", publishedAfter);
+    if (publishedBefore) p.set("before", publishedBefore);
+    if (skip > 0) p.set("skip", String(skip));
+    const qs = p.toString();
+    const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    window.history.replaceState(null, "", url);
+  }
+
+  // The active search term (>= 2 chars after trim), or "" when not searching.
+  // Drives the FTS-vs-filter branch in loadArticles and the highlight/empty-state
+  // UI below.
+  $: activeQuery = search.trim().length >= 2 ? search.trim() : "";
+
   async function loadArticles() {
     try {
       loading = true;
       error = "";
-      articles = await fetchArticles({
-        skip,
-        limit,
-        sentiment_label: sentiment || undefined,
-        category: category || undefined,
-        source_id: sourceId === "" ? undefined : sourceId,
-        search: search.trim().length >= 2 ? search.trim() : undefined,
-        published_after: publishedAfter || undefined,
-        published_before: publishedBefore || undefined,
-      });
+      if (activeQuery) {
+        // A search term switches to the relevance-ranked full-text endpoint
+        // (title + description, phrase/boolean). It takes the date filter but
+        // not the sentiment/category/source dropdowns — search is its own mode.
+        articles = await searchArticles({
+          q: activeQuery,
+          skip,
+          limit,
+          published_after: publishedAfter || undefined,
+          published_before: publishedBefore || undefined,
+        });
+      } else {
+        articles = await fetchArticles({
+          skip,
+          limit,
+          sentiment_label: sentiment || undefined,
+          category: category || undefined,
+          source_id: sourceId === "" ? undefined : sourceId,
+          published_after: publishedAfter || undefined,
+          published_before: publishedBefore || undefined,
+        });
+      }
     } catch (e) {
       console.error("Failed to load articles:", e);
       error = e instanceof Error ? e.message : "Failed to load articles";
@@ -139,6 +188,7 @@
   // (Gated by `initialised` so we don't double-fetch on first render.)
   $: if (initialised) {
     void loadArticles();
+    syncStateToUrl();
     // Reading these makes the block reactive to all of them.
     void [
       sentiment,
@@ -163,6 +213,9 @@
   }
 
   onMount(async () => {
+    // Restore any shared/bookmarked filter state from the URL before the first
+    // fetch so a deep-linked search lands on the right results immediately.
+    readStateFromUrl();
     // ``allSettled`` so a slow/failing /sources/ request can't block the
     // articles fetch or prevent ``initialised`` from flipping. Both load
     // functions already swallow their own errors; this is belt-and-suspenders.
@@ -375,23 +428,38 @@
     {:else}
       <div class="page-head">
         <h1 class="page-title">
-          Latest Articles
+          {activeQuery ? "Search results" : "Latest Articles"}
           <span class="text-ter" style="font-weight:400">({articles.length})</span>
         </h1>
-        <p class="page-subtitle">Recent news with sentiment analysis</p>
+        <p class="page-subtitle">
+          {#if activeQuery}
+            Ranked by relevance for “{activeQuery}”
+          {:else}
+            Recent news with sentiment analysis
+          {/if}
+        </p>
       </div>
 
       {#if articles.length === 0}
         <div class="empty-state">
           <div class="empty-icon" aria-hidden="true">◳</div>
-          <p class="empty-title">No articles match these filters</p>
-          <p class="empty-sub">Try clearing a filter or broadening your search.</p>
+          {#if activeQuery}
+            <p class="empty-title">No results for “{activeQuery}”</p>
+            <p class="empty-sub">
+              Try a different term, or use quotes for a phrase and
+              <code>-word</code> to exclude.
+            </p>
+          {:else}
+            <p class="empty-title">No articles match these filters</p>
+            <p class="empty-sub">Try clearing a filter or broadening your search.</p>
+          {/if}
         </div>
       {:else}
         <div class="articles-grid">
           {#each articles as article (article.id)}
             <ArticleCard
               {article}
+              searchTerm={activeQuery}
               showBookmarkButton={!!$userStore}
               isBookmarked={$bookmarkStore.bookmarkedIds.has(article.id)}
               actionVariant="toggle"

--- a/frontend/src/lib/ArticleCard.svelte
+++ b/frontend/src/lib/ArticleCard.svelte
@@ -9,6 +9,11 @@
   import MoodBubble from "./MoodBubble.svelte";
 
   export let article: ArticleDto;
+  /**
+   * Active search term — when set, occurrences in the title are wrapped in
+   * <mark> so the user sees why a result matched. "" disables highlighting.
+   */
+  export let searchTerm: string = "";
   /** Whether to render the bookmark/remove control (signed-in only). */
   export let showBookmarkButton: boolean = false;
   /** Whether the article is currently bookmarked (drives icon fill / toggle). */
@@ -138,6 +143,36 @@
     return new Date(dateStr).toLocaleDateString();
   }
 
+  // ── Search-term highlighting ─────────────────────────────────────────
+  // Returns HTML with each query word wrapped in <mark>. We escape the source
+  // text FIRST (XSS-safe — the title is rendered via {@html}), then highlight,
+  // so a malicious title can never inject markup and the query can never break
+  // out of the <mark>. Tokens mirror the FTS query loosely: split on whitespace,
+  // strip the leading "-" (exclusion) and surrounding quotes, drop <2-char bits.
+  const escapeHtml = (s: string): string =>
+    s.replace(/[&<>"']/g, (c) => {
+      const map: Record<string, string> = {
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+      };
+      return map[c];
+    });
+
+  const escapeRegExp = (s: string): string =>
+    s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  function highlightHtml(text: string, term: string): string {
+    const safe = escapeHtml(text);
+    const tokens = term
+      .split(/\s+/)
+      .map((t) => t.replace(/^-/, "").replace(/^"|"$/g, ""))
+      .filter((t) => t.length >= 2);
+    if (tokens.length === 0) return safe;
+    const pattern = new RegExp(`(${tokens.map(escapeRegExp).join("|")})`, "gi");
+    return safe.replace(pattern, "<mark>$1</mark>");
+  }
+
+  $: titleHtml = searchTerm ? highlightHtml(article.title, searchTerm) : "";
+
   function handleBookmarkClick() {
     dispatch("bookmark", { article });
   }
@@ -187,8 +222,10 @@
   </div>
 
   <div class="card-body">
-    <!-- Title -->
-    <h3 class="card-title">{article.title}</h3>
+    <!-- Title (highlighted when searching; titleHtml is escaped-then-marked) -->
+    <h3 class="card-title">
+      {#if searchTerm}{@html titleHtml}{:else}{article.title}{/if}
+    </h3>
 
     <!-- Description -->
     {#if article.description}
@@ -452,6 +489,14 @@
     -webkit-line-clamp: 2;
     line-clamp: 2;
     overflow: hidden;
+  }
+  /* Search highlight — brand accent wash, not the browser's default yellow,
+     so it reads on the dark theme and matches the indigo accent. */
+  .card-title :global(mark) {
+    background: var(--accent-dim);
+    color: var(--accent);
+    border-radius: 2px;
+    padding: 0 1px;
   }
   .card-desc {
     font-size: 13px;

--- a/frontend/src/lib/FilterBar.svelte
+++ b/frontend/src/lib/FilterBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy } from "svelte";
+  import { createEventDispatcher, onDestroy, onMount } from "svelte";
   import type { SourceDto } from "./api";
 
   export let sentiment: string = "";
@@ -58,6 +58,33 @@
     mq.addEventListener("change", onChange);
     onDestroy(() => mq.removeEventListener("change", onChange));
   }
+
+  // ── Keyboard shortcut: "/" or Ctrl/Cmd+K focuses the search box ──────
+  // "/" alone is ignored while the user is already typing in a field, so it
+  // doesn't hijack a literal slash; Ctrl/Cmd+K always works.
+  let searchInput: HTMLInputElement;
+
+  function isTypingTarget(el: EventTarget | null): boolean {
+    const node = el as HTMLElement | null;
+    if (!node) return false;
+    const tag = node.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || node.isContentEditable;
+  }
+
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    const isSlash = e.key === "/" && !isTypingTarget(e.target);
+    const isCmdK = (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k";
+    if (isSlash || isCmdK) {
+      e.preventDefault();
+      searchInput?.focus();
+      searchInput?.select();
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener("keydown", handleGlobalKeydown);
+    onDestroy(() => window.removeEventListener("keydown", handleGlobalKeydown));
+  });
 
   const dispatch = createEventDispatcher<{
     change: {
@@ -174,13 +201,16 @@
   <div class="search-wrap">
     <span class="search-icon" aria-hidden="true">⌕</span>
     <input
+      bind:this={searchInput}
       type="search"
       class="search-input"
-      placeholder="Search titles…"
+      placeholder="Search news…"
       value={search}
       on:input={handleSearchInput}
-      aria-label="Search article titles"
+      aria-label="Search articles by title and description"
+      aria-keyshortcuts="/ Control+K Meta+K"
     />
+    <kbd class="search-kbd" aria-hidden="true">/</kbd>
   </div>
 
   {#if showCustomRange}
@@ -236,7 +266,7 @@
     max-width: 320px;
     margin-left: auto;
   }
-  .search-wrap .search-input { width: 100%; padding-left: 30px; }
+  .search-wrap .search-input { width: 100%; padding-left: 30px; padding-right: 28px; }
   .search-icon {
     position: absolute;
     left: 9px;
@@ -245,6 +275,27 @@
     color: var(--text-ter);
     font-size: 14px;
     pointer-events: none;
+  }
+  /* "/" shortcut hint, right-aligned inside the input. Hidden once the field has
+     focus (the hint is moot while typing) and on touch (no physical key). */
+  .search-kbd {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1;
+    color: var(--text-ter);
+    background: var(--bg-app);
+    border: 1px solid var(--border-med);
+    border-radius: var(--r-sm);
+    padding: 2px 5px;
+    pointer-events: none;
+  }
+  .search-wrap:focus-within .search-kbd { display: none; }
+  @media (hover: none) {
+    .search-kbd { display: none; }
   }
 
   /* Custom from/to range: revealed only when "Custom range…" is picked. Its own


### PR DESCRIPTION
## Summary

The final PR of the search pass: wires the search box to the relevance-ranked full-text endpoint (#168) and adds the demo-facing UX that makes the search work visible — highlighting, shareable URLs, a search-aware empty state, and a keyboard shortcut. Frontend-only (no migration, no backend changes).

## Search mode (`App.svelte`)
- A search term (≥ 2 chars) now routes through `searchArticles()` — the `/articles/search` **FTS endpoint** (title + description, `ts_rank`, phrase/boolean) — with the date filter applied. An empty box uses the regular `/articles/` list with the sentiment/category/source dropdowns.
- Search is its own focused mode: the dropdowns don't combine with it (the FTS endpoint takes `q` + dates only). The heading reflects the mode — **"Search results — Ranked by relevance for 'X'"** vs "Latest Articles".

## Highlight (`ArticleCard.svelte`)
- New `searchTerm` prop. Title matches are wrapped in `<mark>` via an **escaped-then-marked** helper: the title is HTML-escaped *first*, then regex-escaped query tokens are wrapped — **XSS-safe** under `{@html}`. `<mark>` uses the brand accent wash, not the browser's default yellow.

## URL sync (`App.svelte`)
- Filters/search/date/page are written to the querystring with `replaceState` (no history spam) and **restored on mount**, so a filtered/search view is shareable and survives reload. The FilterBar already seeds its date inputs from the restored bounds.

## Empty state + count (`App.svelte`)
- Zero results while searching shows **"No results for 'X'"** with a phrase/exclude hint.

## Focus shortcut (`FilterBar.svelte`)
- **`/`** (when not already typing) or **Ctrl/Cmd+K** focuses + selects the search box. A `/` hint badge sits in the field and hides on focus and on touch devices. Placeholder/aria updated to reflect title+description full-text search.

## Verification
- `svelte-check` 0 errors / 0 warnings; `vite build` OK.
- Confirmed **end-to-end against the rebuilt Postgres docker stack** (FTS migration applied): ranked results, boolean exclusion (`iran -israel`), title highlighting, URL sync + reload-restore, and the `/` shortcut all working in the browser.
