### PR TITLE
feat(i18n): bilingual EN/DE news — feed, search, analytics + backfill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,10 @@ MEDIASTACK_BASE_URL=https://api.mediastack.com/v1/news
 MEDIASTACK_FETCH_LIMIT=25
 MEDIASTACK_SORT=published_desc
 MEDIASTACK_FETCH_CATEGORIES=general,business,health,science,technology,-sports,-entertainment
-MEDIASTACK_LANGUAGES=en
+# Comma-separated ISO 639-1 codes. "en,de" fetches both English and German
+# articles (the German national outlets in sources_list.py serve the DE feed).
+# Set to "en" to disable German ingestion.
+MEDIASTACK_LANGUAGES=en,de
 MEDIASTACK_TIMEOUT=10
 
 # Placeholder image used when none available

--- a/app/crud/analytics.py
+++ b/app/crud/analytics.py
@@ -24,8 +24,18 @@ _NON_ENTITY_TYPES = (
 )
 
 
+def _lang_clause(language: str | None, *, col: str = "language") -> str:
+    """Optional ``AND <col> = :language`` SQL fragment.
+
+    Returns an empty string when no language filter is requested, so the same
+    query text serves both the all-languages and per-language (EN/DE) cases.
+    The matching ``:language`` bind is only added to the params dict when set.
+    """
+    return f"\n                  AND {col} = :language" if language else ""
+
+
 def sentiment_rolling_average(
-    db: Session, *, days: int = 30, window: int = 7
+    db: Session, *, days: int = 30, window: int = 7, language: str | None = None
 ) -> list[dict[str, Any]]:
     """7-day rolling average sentiment using a window function.
 
@@ -33,8 +43,11 @@ def sentiment_rolling_average(
     sentiment fluctuations, revealing underlying trends.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    params: dict[str, Any] = {"cutoff": cutoff, "window_size": window - 1}
+    if language:
+        params["language"] = language
     result = db.execute(
-        text("""
+        text(f"""
             WITH daily AS (
                 SELECT
                     DATE(published_at) AS day,
@@ -42,7 +55,7 @@ def sentiment_rolling_average(
                     AVG(sentiment_score) AS avg_sentiment
                 FROM articles
                 WHERE sentiment_score IS NOT NULL
-                  AND published_at >= :cutoff
+                  AND published_at >= :cutoff{_lang_clause(language)}
                 GROUP BY DATE(published_at)
             )
             SELECT
@@ -58,20 +71,25 @@ def sentiment_rolling_average(
             FROM daily
             ORDER BY day
         """),
-        {"cutoff": cutoff, "window_size": window - 1},
+        params,
     )
     return [dict(row._mapping) for row in result]
 
 
-def source_sentiment_ranked(db: Session, *, days: int = 30) -> list[dict[str, Any]]:
+def source_sentiment_ranked(
+    db: Session, *, days: int = 30, language: str | None = None
+) -> list[dict[str, Any]]:
     """Rank sources by average sentiment using RANK() window function.
 
     Uses a CTE to compute per-source stats, then RANK() OVER to
     assign a rank by avg sentiment (highest = most positive source).
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    params: dict[str, Any] = {"cutoff": cutoff}
+    if language:
+        params["language"] = language
     result = db.execute(
-        text("""
+        text(f"""
             WITH source_stats AS (
                 SELECT
                     s.name          AS source_name,
@@ -81,7 +99,7 @@ def source_sentiment_ranked(db: Session, *, days: int = 30) -> list[dict[str, An
                 FROM sources s
                 JOIN articles a ON a.source_id = s.id
                 WHERE a.sentiment_score IS NOT NULL
-                  AND a.published_at >= :cutoff
+                  AND a.published_at >= :cutoff{_lang_clause(language, col="a.language")}
                 GROUP BY s.name
                 HAVING COUNT(a.id) >= 3
             )
@@ -94,12 +112,14 @@ def source_sentiment_ranked(db: Session, *, days: int = 30) -> list[dict[str, An
             FROM source_stats
             ORDER BY positivity_rank
         """),
-        {"cutoff": cutoff},
+        params,
     )
     return [dict(row._mapping) for row in result]
 
 
-def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, Any]]:
+def sentiment_grouping_sets(
+    db: Session, *, days: int = 30, language: str | None = None
+) -> list[dict[str, Any]]:
     """Multi-dimensional sentiment breakdown using GROUPING SETS.
 
     Returns article counts and avg sentiment grouped by:
@@ -109,8 +129,11 @@ def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, An
     - () — grand total
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    params: dict[str, Any] = {"cutoff": cutoff}
+    if language:
+        params["language"] = language
     result = db.execute(
-        text("""
+        text(f"""
             SELECT
                 COALESCE(category, '(all)')         AS category,
                 COALESCE(sentiment_label, '(all)')  AS sentiment_label,
@@ -120,7 +143,7 @@ def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, An
                 GROUPING(sentiment_label)            AS is_label_total
             FROM articles
             WHERE sentiment_score IS NOT NULL
-              AND published_at >= :cutoff
+              AND published_at >= :cutoff{_lang_clause(language)}
             GROUP BY GROUPING SETS (
                 (category, sentiment_label),
                 (category),
@@ -129,12 +152,14 @@ def sentiment_grouping_sets(db: Session, *, days: int = 30) -> list[dict[str, An
             )
             ORDER BY is_category_total, is_label_total, category, sentiment_label
         """),
-        {"cutoff": cutoff},
+        params,
     )
     return [dict(row._mapping) for row in result]
 
 
-def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
+def entity_momentum(
+    db: Session, *, days: int = 14, language: str | None = None
+) -> list[dict[str, Any]]:
     """Entity momentum: compare mention frequency this window vs the previous one.
 
     Uses two CTEs split at the window midpoint, then computes growth rate.
@@ -147,25 +172,37 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
     freshly-ingested articles that have not been entity-analyzed yet — returning
     empty. ``analyzed_at`` is also the semantically correct axis for "trending
     names": it reflects when a name surged in our analyzed coverage.
+
+    Unlike the other analytics queries, the CTEs here don't reference ``articles``
+    (they aggregate over ``entities`` + ``article_entities``). A ``language``
+    filter therefore requires an extra ``JOIN articles`` to reach
+    ``articles.language``; the join is added only when a language is requested,
+    so the all-languages query is unchanged.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     midpoint = datetime.now(timezone.utc) - timedelta(days=days // 2)
+    # Only reach into ``articles`` when filtering by language — keeps the default
+    # (all-languages) plan identical to before this feature.
+    lang_join = (
+        "\n                JOIN articles a ON a.id = ae.article_id" if language else ""
+    )
+    lang_filter = "\n                  AND a.language = :language" if language else ""
     # Quality gate (shared with the BigQuery entity charts): keep only
     # Knowledge-Graph-resolved entities (wikipedia_url set), drop non-entity
     # types, and exclude publisher / wire-service / image-credit names that are
     # self-referential page furniture rather than news subjects.
-    stmt = text("""
+    stmt = text(f"""
             WITH recent AS (
                 SELECT
                     e.name          AS entity_name,
                     e.type          AS entity_type,
                     COUNT(ae.id)    AS mention_count
                 FROM entities e
-                JOIN article_entities ae ON ae.entity_id = e.id
+                JOIN article_entities ae ON ae.entity_id = e.id{lang_join}
                 WHERE ae.analyzed_at >= :midpoint
                   AND e.wikipedia_url IS NOT NULL
                   AND e.type NOT IN :non_entity_types
-                  AND LOWER(e.name) NOT IN :publisher_denylist
+                  AND LOWER(e.name) NOT IN :publisher_denylist{lang_filter}
                 GROUP BY e.name, e.type
             ),
             previous AS (
@@ -174,12 +211,12 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
                     e.type          AS entity_type,
                     COUNT(ae.id)    AS mention_count
                 FROM entities e
-                JOIN article_entities ae ON ae.entity_id = e.id
+                JOIN article_entities ae ON ae.entity_id = e.id{lang_join}
                 WHERE ae.analyzed_at >= :cutoff
                   AND ae.analyzed_at < :midpoint
                   AND e.wikipedia_url IS NOT NULL
                   AND e.type NOT IN :non_entity_types
-                  AND LOWER(e.name) NOT IN :publisher_denylist
+                  AND LOWER(e.name) NOT IN :publisher_denylist{lang_filter}
                 GROUP BY e.name, e.type
             )
             SELECT
@@ -205,20 +242,20 @@ def entity_momentum(db: Session, *, days: int = 14) -> list[dict[str, Any]]:
         bindparam("non_entity_types", expanding=True),
         bindparam("publisher_denylist", expanding=True),
     )
-    result = db.execute(
-        stmt,
-        {
-            "cutoff": cutoff,
-            "midpoint": midpoint,
-            "non_entity_types": list(_NON_ENTITY_TYPES),
-            "publisher_denylist": publisher_denylist_lower(),
-        },
-    )
+    exec_params: dict[str, Any] = {
+        "cutoff": cutoff,
+        "midpoint": midpoint,
+        "non_entity_types": list(_NON_ENTITY_TYPES),
+        "publisher_denylist": publisher_denylist_lower(),
+    }
+    if language:
+        exec_params["language"] = language
+    result = db.execute(stmt, exec_params)
     return [dict(row._mapping) for row in result]
 
 
 def daily_category_sentiment_pivot(
-    db: Session, *, days: int = 14
+    db: Session, *, days: int = 14, language: str | None = None
 ) -> list[dict[str, Any]]:
     """Daily sentiment per category using window functions for running totals.
 
@@ -226,8 +263,11 @@ def daily_category_sentiment_pivot(
     per category via SUM() OVER (PARTITION BY ... ORDER BY).
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    params: dict[str, Any] = {"cutoff": cutoff}
+    if language:
+        params["language"] = language
     result = db.execute(
-        text("""
+        text(f"""
             WITH daily_cat AS (
                 SELECT
                     DATE(published_at)       AS day,
@@ -236,7 +276,7 @@ def daily_category_sentiment_pivot(
                     AVG(sentiment_score)     AS avg_sentiment
                 FROM articles
                 WHERE sentiment_score IS NOT NULL
-                  AND published_at >= :cutoff
+                  AND published_at >= :cutoff{_lang_clause(language)}
                 GROUP BY DATE(published_at), category
             )
             SELECT
@@ -250,6 +290,6 @@ def daily_category_sentiment_pivot(
             FROM daily_cat
             ORDER BY day, category
         """),
-        {"cutoff": cutoff},
+        params,
     )
     return [dict(row._mapping) for row in result]

--- a/app/crud/search.py
+++ b/app/crud/search.py
@@ -21,6 +21,11 @@ from sqlalchemy.orm import Session, joinedload, subqueryload
 from app.models.article import Article
 from app.models.article_entity import ArticleEntity
 
+# Postgres FTS text-search configurations, keyed by article language. Both ship
+# with Postgres by default. The value is interpolated into the tsquery SQL, so it
+# MUST come from this fixed allowlist — never from user input.
+_FTS_CONFIG = {"en": "english", "de": "german"}
+
 
 def search_articles(
     db: Session,
@@ -30,6 +35,7 @@ def search_articles(
     limit: int = 20,
     published_after: Optional[datetime] = None,
     published_before: Optional[datetime] = None,
+    language: Optional[str] = None,
 ) -> list[Article]:
     """Full-text search articles by ``q``, ranked by ts_rank (desc), then recency.
 
@@ -37,7 +43,17 @@ def search_articles(
     accepts quoted "phrases", ``or``, and leading ``-`` for exclusion, and never
     raises on malformed input (unlike ``to_tsquery``). The same eager loads as
     the list endpoint are applied so the response shape matches ``ArticleRead``.
+
+    ``language`` (ISO 639-1) both filters to that language and selects the FTS
+    text-search config (``german`` stemming/stop-words for ``de``), so a German
+    query stems correctly. It defaults to ``english`` for any unknown/absent code.
     """
+    # The text-search config name is a fixed literal chosen from the allowlist
+    # above — safe to interpolate into the SQL. ``:q`` stays a bind parameter.
+    cfg = _FTS_CONFIG.get(language or "en", "english")
+    predicate = f"search_vector @@ websearch_to_tsquery('{cfg}', :q)"
+    rank = f"ts_rank(search_vector, websearch_to_tsquery('{cfg}', :q)) DESC"
+
     # The FTS predicate and rank reference the Postgres-only search_vector column
     # via text() (it is intentionally not an ORM attribute). The :q bind is set
     # once with .params() and reused by both the filter and the ORDER BY rank.
@@ -48,9 +64,11 @@ def search_articles(
             subqueryload(Article.article_entities).joinedload(ArticleEntity.entity),
             subqueryload(Article.article_categories),
         )
-        .filter(text("search_vector @@ websearch_to_tsquery('english', :q)"))
+        .filter(text(predicate))
     )
 
+    if language is not None:
+        query = query.filter(Article.language == language)
     if published_after is not None:
         query = query.filter(Article.published_at >= published_after)
     if published_before is not None:
@@ -58,7 +76,7 @@ def search_articles(
 
     return list(
         query.order_by(
-            text("ts_rank(search_vector, websearch_to_tsquery('english', :q)) DESC"),
+            text(rank),
             Article.published_at.desc(),
             Article.id.desc(),
         )

--- a/app/jobs/backfill_german.py
+++ b/app/jobs/backfill_german.py
@@ -1,0 +1,156 @@
+"""Backfill German articles from Mediastack history into Postgres + NLP.
+
+Gives the German feed and the EN/DE dashboard ~30 days of history on day one,
+instead of a slowly-filling empty line. This is the *upstream* counterpart to
+``app/jobs/backfill_bigquery.py`` (which streams already-analyzed Postgres rows
+into BigQuery): here we fetch historical Mediastack articles, normalize + ingest
+them with ``language="de"``, and run the existing crawl worker so each gets full
+GCP NL analysis (sentiment + entities + V2-model categories).
+
+It reuses the live pipeline functions (``fetch_articles_from_source`` →
+``normalize_articles`` → ``ingest_articles`` → ``run_crawl_worker``) so there is
+no duplicated fetch/NLP logic and ingest's URL-unique dedup makes re-runs
+idempotent. Volume is bounded by a per-source/day cap to keep GCP NL spend
+predictable.
+
+Usage:
+    python -m app.jobs.backfill_german                 # 30 days, full NLP
+    python -m app.jobs.backfill_german --dry-run        # count only, no fetch
+    python -m app.jobs.backfill_german --days=7         # shorter window
+    python -m app.jobs.backfill_german --per-source-cap=5
+    python -m app.jobs.backfill_german --no-crawl       # ingest only, skip NLP crawl
+"""
+
+import logging
+import sys
+from datetime import date, timedelta
+
+from app.database import SessionLocal
+from app.jobs.crawl_worker import run_crawl_worker
+from app.jobs.fetch_from_mediastack import fetch_articles_from_source
+from app.jobs.ingest_articles import ingest_articles
+from app.jobs.normalize_articles import normalize_articles
+from app.jobs.sources_list import GERMAN_SOURCES
+from app.utils.logging import setup_logging
+
+setup_logging()
+logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+DEFAULT_DAYS = 30
+DEFAULT_PER_SOURCE_CAP = 8
+
+
+def _historical_days(days: int) -> list[str]:
+    """ISO ``YYYY-MM-DD`` strings for the last ``days`` days, oldest first."""
+    today = date.today()
+    return [(today - timedelta(days=n)).isoformat() for n in range(days, 0, -1)]
+
+
+def backfill_german(
+    *,
+    days: int = DEFAULT_DAYS,
+    per_source_cap: int = DEFAULT_PER_SOURCE_CAP,
+    include_crawling: bool = True,
+    dry_run: bool = False,
+) -> int:
+    """Backfill German articles over the last ``days`` days.
+
+    Returns the number of new articles ingested (0 on a dry run).
+    """
+    logger.info(
+        "=== German backfill: days=%d, per_source_cap=%d, crawl=%s, dry_run=%s ===",
+        days,
+        per_source_cap,
+        include_crawling,
+        dry_run,
+    )
+
+    raw: list[dict] = []
+    for day in _historical_days(days):
+        day_total = 0
+        for source in GERMAN_SOURCES:
+            if dry_run:
+                # Don't hit the API on a dry run — just show the plan.
+                continue
+            articles = fetch_articles_from_source(
+                source, languages="de", fetch_date=day
+            )
+            # Cap per source per day to bound GCP NL cost downstream. Log the
+            # drop so the trimmed volume is explicit (never a silent truncation).
+            if len(articles) > per_source_cap:
+                logger.info(
+                    "  %s %s: capping %d -> %d articles",
+                    day,
+                    source,
+                    len(articles),
+                    per_source_cap,
+                )
+                articles = articles[:per_source_cap]
+            raw.extend(articles)
+            day_total += len(articles)
+        logger.info(
+            "%s: %d articles across %d sources", day, day_total, len(GERMAN_SOURCES)
+        )
+
+    if dry_run:
+        planned = days * len(GERMAN_SOURCES) * per_source_cap
+        logger.info(
+            "DRY RUN — would fetch up to %d articles (%d days x %d sources x cap %d)",
+            planned,
+            days,
+            len(GERMAN_SOURCES),
+            per_source_cap,
+        )
+        return 0
+
+    logger.info("Fetched %d raw German articles; normalizing…", len(raw))
+    norm = normalize_articles(raw)
+    logger.info("Normalized to %d articles; ingesting…", len(norm))
+
+    db = SessionLocal()
+    try:
+        new = ingest_articles(db, norm)
+        logger.info("Ingested %d new German articles", new)
+    finally:
+        db.close()
+
+    if include_crawling and new > 0:
+        # Drain the crawl queue so the freshly-ingested German articles get full
+        # GCP NL analysis. Cap generously — one job per new article plus slack.
+        max_jobs = new + 10
+        logger.info("Running crawl worker (max_jobs=%d) for full NLP…", max_jobs)
+        result = run_crawl_worker(max_jobs=max_jobs)
+        logger.info(
+            "Crawl complete: %d successful, %d failed",
+            result["successful"],
+            result["failed"],
+        )
+    elif include_crawling:
+        logger.info("No new articles — skipping crawl.")
+
+    logger.info("=== German backfill complete: %d new articles ===", new)
+    return new
+
+
+def _parse_args(argv: list[str]) -> dict:
+    opts: dict = {
+        "days": DEFAULT_DAYS,
+        "per_source_cap": DEFAULT_PER_SOURCE_CAP,
+        "include_crawling": True,
+        "dry_run": False,
+    }
+    for arg in argv:
+        if arg == "--dry-run":
+            opts["dry_run"] = True
+        elif arg == "--no-crawl":
+            opts["include_crawling"] = False
+        elif arg.startswith("--days="):
+            opts["days"] = int(arg.split("=", 1)[1])
+        elif arg.startswith("--per-source-cap="):
+            opts["per_source_cap"] = int(arg.split("=", 1)[1])
+    return opts
+
+
+if __name__ == "__main__":
+    backfill_german(**_parse_args(sys.argv[1:]))

--- a/app/jobs/crawl_worker.py
+++ b/app/jobs/crawl_worker.py
@@ -259,9 +259,14 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
         entities_stored = 0
         categories_stored = 0
 
+        # The article's language (from Mediastack) drives the GCP NL model so
+        # German content is analyzed in German (sentiment + entities + V2-model
+        # categories), not forced through the English path.
+        article_language = article.language or "en"
+
         if provider == "GCP_NL":
             # Single annotateText call: sentiment + entities + categories
-            result = annotate_text_gcp_nl(article_text)
+            result = annotate_text_gcp_nl(article_text, language=article_language)
 
             if result is not None:
                 sentiment_label = result.sentiment_label
@@ -353,11 +358,16 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                     categories_stored += 1
             else:
                 # GCP NL failed — fall back to VADER for sentiment only
+                # (English text only; non-English returns explicit neutral).
                 logger.warning("GCP NL annotateText failed, falling back to VADER")
-                sentiment_label, sentiment_score = analyze_sentiment(article_text)
+                sentiment_label, sentiment_score = analyze_sentiment(
+                    article_text, language=article_language
+                )
         else:
             # VADER provider — sentiment only, no entities/categories
-            sentiment_label, sentiment_score = analyze_sentiment(article_text)
+            sentiment_label, sentiment_score = analyze_sentiment(
+                article_text, language=article_language
+            )
 
         # Store sentiment analysis record
         sentiment_analysis = SentimentAnalysis(
@@ -367,7 +377,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
             score=sentiment_score,
             magnitude=magnitude,
             label=sentiment_label,
-            language="en",
+            language=article_language,
         )
         db.add(sentiment_analysis)
 
@@ -424,6 +434,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                         sentiment_label=sentiment_label,
                         sentiment_score=sentiment_score,
                         wikipedia_url=ent.wikipedia_url,
+                        language=article_language,
                     )
 
                 # Stream category events (GCP_NL only)
@@ -436,6 +447,7 @@ def crawl_article(crawl_job: CrawlJob, db: Session) -> bool:
                         category_confidence=cat.confidence,
                         sentiment_label=sentiment_label,
                         sentiment_score=sentiment_score,
+                        language=article_language,
                     )
         except Exception as e:
             logger.warning("BigQuery streaming failed: %s", e, exc_info=True)

--- a/app/jobs/fetch_from_mediastack.py
+++ b/app/jobs/fetch_from_mediastack.py
@@ -25,7 +25,19 @@ class MediastackAPIError(Exception):
         super().__init__(f"Mediastack error {code} ({error_type}): {message}")
 
 
-def fetch_articles_from_source(source: str) -> list[dict]:
+def fetch_articles_from_source(
+    source: str,
+    *,
+    languages: str | None = None,
+    fetch_date: str | None = None,
+) -> list[dict]:
+    """Fetch one source's articles from Mediastack.
+
+    ``languages`` overrides ``settings.MEDIASTACK_LANGUAGES`` (e.g. ``"de"`` to
+    fetch a single language) and ``fetch_date`` overrides today's date with a
+    historical day (``"YYYY-MM-DD"``) — both used by the German backfill job to
+    pull a specific language across past days. Defaults preserve the live path.
+    """
     api_key = settings.MEDIASTACK_API_KEY
 
     if not api_key:
@@ -37,16 +49,18 @@ def fetch_articles_from_source(source: str) -> list[dict]:
             )
             return []
         logger.info("MEDIASTACK_API_KEY not set — using mock data for %s", source)
-        return fetch_mock_articles_from_source(source)
+        return fetch_mock_articles_from_source(
+            source, languages or settings.MEDIASTACK_LANGUAGES
+        )
 
     base_params = {
         "access_key": api_key,
         "sources": source,
-        "languages": settings.MEDIASTACK_LANGUAGES,
+        "languages": languages or settings.MEDIASTACK_LANGUAGES,
         "sort": settings.MEDIASTACK_SORT,
         "categories": settings.MEDIASTACK_FETCH_CATEGORIES,
         "limit": settings.MEDIASTACK_FETCH_LIMIT,
-        "date": date.today().isoformat(),
+        "date": fetch_date or date.today().isoformat(),
     }
 
     try:
@@ -95,7 +109,9 @@ def fetch_articles_from_source(source: str) -> list[dict]:
         logger.warning(
             "Mediastack request failed for %s: %s — using mock data", source, e
         )
-        return fetch_mock_articles_from_source(source)
+        return fetch_mock_articles_from_source(
+            source, languages or settings.MEDIASTACK_LANGUAGES
+        )
 
 
 def fetch_all_sources() -> list[dict]:

--- a/app/jobs/mock_mediastack.py
+++ b/app/jobs/mock_mediastack.py
@@ -1,6 +1,9 @@
 """Mock data for local development when Mediastack API is unavailable."""
 
+import logging
 from typing import Dict, List
+
+logger = logging.getLogger(__name__)
 
 # Sample mock articles matching Mediastack API response format
 MOCK_ARTICLES = [
@@ -60,13 +63,80 @@ MOCK_ARTICLES = [
         "country": "us",
         "category": "business",
     },
+    # German mock articles (language="de") so the EN/DE toggle, the
+    # ?language=de filter, and the German analytics can be exercised locally
+    # without a Mediastack API key.
+    {
+        "title": "Bundesregierung beschließt neues Klimaschutzgesetz",
+        "description": (
+            "Das Kabinett hat ein ambitioniertes Maßnahmenpaket zur Senkung "
+            "der CO2-Emissionen verabschiedet, das Industrie und Verkehr "
+            "gleichermaßen in die Pflicht nimmt."
+        ),
+        "url": "https://example.com/de/klimaschutzgesetz-2025",
+        "image": "https://picsum.photos/id/10/400/300",
+        "published_at": "2025-11-18T11:00:00Z",
+        "source": "Tagesschau",
+        "language": "de",
+        "country": "de",
+        "category": "general",
+    },
+    {
+        "title": "Deutsche Wirtschaft wächst trotz globaler Unsicherheit",
+        "description": (
+            "Führende Ökonomen melden ein überraschend robustes Wachstum, "
+            "getragen von starkem Export und stabiler Binnennachfrage."
+        ),
+        "url": "https://example.com/de/wirtschaft-wachstum-2025",
+        "image": "https://picsum.photos/id/11/400/300",
+        "published_at": "2025-11-18T10:15:00Z",
+        "source": "Handelsblatt",
+        "language": "de",
+        "country": "de",
+        "category": "business",
+    },
+    {
+        "title": "Durchbruch in der Quantenforschung an deutscher Universität",
+        "description": (
+            "Forscher präsentieren einen neuen Ansatz zur Fehlerkorrektur, "
+            "der praktische Quantencomputer ein gutes Stück näher rücken lässt."
+        ),
+        "url": "https://example.com/de/quantenforschung-2025",
+        "image": "https://picsum.photos/id/12/400/300",
+        "published_at": "2025-11-18T09:30:00Z",
+        "source": "Spiegel",
+        "language": "de",
+        "country": "de",
+        "category": "science",
+    },
 ]
 
 
-def get_mock_articles_for_source(source_name: str) -> List[Dict]:
-    """Return mock articles with the specified source name."""
+def _matches_languages(article: Dict, languages: str | None) -> bool:
+    """True if the article's language is in the requested comma-separated set.
+
+    Mirrors the real Mediastack ``languages`` param so a ``languages="de"``
+    request (e.g. from the German backfill) returns only German mocks locally.
+    ``None`` means no filter (return everything).
+    """
+    if not languages:
+        return True
+    wanted = {lang.strip() for lang in languages.split(",") if lang.strip()}
+    return article.get("language") in wanted
+
+
+def get_mock_articles_for_source(
+    source_name: str, languages: str | None = None
+) -> List[Dict]:
+    """Return mock articles with the specified source name.
+
+    ``languages`` filters by the article's language code to emulate the real
+    Mediastack ``languages`` query param.
+    """
     mock_articles = []
     for i, article in enumerate(MOCK_ARTICLES):
+        if not _matches_languages(article, languages):
+            continue
         mock_article = article.copy()
         mock_article["source_name"] = source_name
         # Modify URL to include source for uniqueness
@@ -76,7 +146,12 @@ def get_mock_articles_for_source(source_name: str) -> List[Dict]:
     return mock_articles
 
 
-def fetch_mock_articles_from_source(source: str) -> List[Dict]:
+def fetch_mock_articles_from_source(
+    source: str, languages: str | None = None
+) -> List[Dict]:
     """Mock version of fetch_articles_from_source for local development."""
-    print(f"→ Using MOCK data for {source} (Mediastack API unavailable)")
-    return get_mock_articles_for_source(source)
+    # Use the logger (not print) so this never crashes on a non-UTF-8 console
+    # (Windows cp1252 can't encode the arrow glyph) and matches the rest of the
+    # job logging.
+    logger.info("Using MOCK data for %s (Mediastack API unavailable)", source)
+    return get_mock_articles_for_source(source, languages)

--- a/app/jobs/normalize_articles.py
+++ b/app/jobs/normalize_articles.py
@@ -71,8 +71,11 @@ def normalize_articles(raw: List[Dict]) -> List[Dict]:
             logger.warning("Skipping article %s: title/url exceeds column limit", canon)
             continue
 
-        # sentiment
-        label, score = analyze_sentiment(f"{title} {desc}")
+        # sentiment — pass the article's own language so German text is scored
+        # by GCP NL's German model (and never silently routed through the
+        # English-only VADER fallback).
+        language = _clamp(item.get("language"), _LANGUAGE_MAX)
+        label, score = analyze_sentiment(f"{title} {desc}", language=language or "en")
 
         out.append(
             {
@@ -84,7 +87,7 @@ def normalize_articles(raw: List[Dict]) -> List[Dict]:
                     item.get("image") or item.get("image_url"), _IMAGE_URL_MAX
                 ),
                 "published_at": published,
-                "language": _clamp(item.get("language"), _LANGUAGE_MAX),
+                "language": language,
                 "country": _clamp(item.get("country"), _COUNTRY_MAX),
                 "category": _clamp(item.get("category"), _CATEGORY_MAX),
                 "sentiment_label": label,

--- a/app/jobs/sources_list.py
+++ b/app/jobs/sources_list.py
@@ -1,4 +1,9 @@
+# Mediastack source slugs. Fetched for every configured language
+# (MEDIASTACK_LANGUAGES, e.g. "en,de"), so an outlet only returns articles in
+# the languages it actually publishes — English outlets serve EN, the German
+# national outlets below serve DE.
 SOURCES = [
+    # English-language outlets
     "dw",
     "bbc",
     "cnn",
@@ -21,4 +26,34 @@ SOURCES = [
     "phys",
     "scienceandtechnologyresearchnews",
     "popsci",
+    # German national outlets (slugs verified live against the Mediastack
+    # /v1/sources + /v1/news endpoints — each returns lang=de articles). `dw`
+    # above also has a German feed and is reused. `die-welt` is the correct
+    # slug (not `welt`); `ard-tagesschau` duplicates `tagesschau`.
+    "spiegel",
+    "zeit",
+    "faz",
+    "sueddeutsche",
+    "die-welt",
+    "handelsblatt",
+    "tagesschau",
+    "stern",
+    "focus",
+]
+
+# German-language outlets only (incl. dw's German feed). Used by the German
+# backfill job to pull historical `languages=de` articles from just these
+# sources, rather than querying every English outlet for German content it
+# won't have.
+GERMAN_SOURCES = [
+    "dw",
+    "spiegel",
+    "zeit",
+    "faz",
+    "sueddeutsche",
+    "die-welt",
+    "handelsblatt",
+    "tagesschau",
+    "stern",
+    "focus",
 ]

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -36,6 +36,16 @@ router = APIRouter(tags=["Analytics"])
 
 _RATE = config.security.rate_limit_analytics
 
+# Optional ISO 639-1 language filter for the EN/DE dashboard toggle. Forward-only
+# on BigQuery: events streamed before the `language` column existed are NULL.
+_LANG_QUERY = Query(
+    None,
+    min_length=2,
+    max_length=2,
+    pattern="^[a-z]{2}$",
+    description="Filter by ISO 639-1 language code (e.g. 'en', 'de')",
+)
+
 
 def _disabled_response() -> Dict[str, str]:
     return {"message": "BigQuery analytics is not enabled"}
@@ -112,11 +122,14 @@ def top_entities(
     days: int = Query(30, ge=1, le=365),
     entity_type: Optional[str] = Query(None, description="Filter by entity type"),
     limit: int = Query(20, ge=1, le=100),
+    language: Optional[str] = _LANG_QUERY,
 ) -> Union[List[TopEntity], Dict[str, str]]:
     """Top entities by article mention count, with average sentiment."""
     if not config.bigquery.enable_bigquery:
         return _disabled_response()
-    return [TopEntity(**row) for row in get_top_entities(days, entity_type, limit)]
+    return [
+        TopEntity(**row) for row in get_top_entities(days, entity_type, limit, language)
+    ]
 
 
 @router.get(
@@ -167,8 +180,11 @@ def nlp_categories(
     request: Request,
     days: int = Query(30, ge=1, le=365),
     limit: int = Query(20, ge=1, le=100),
+    language: Optional[str] = _LANG_QUERY,
 ) -> Union[List[NlpCategoryBreakdown], Dict[str, str]]:
     """GCP NL content categories with sentiment aggregation."""
     if not config.bigquery.enable_bigquery:
         return _disabled_response()
-    return [NlpCategoryBreakdown(**row) for row in get_nlp_categories(days, limit)]
+    return [
+        NlpCategoryBreakdown(**row) for row in get_nlp_categories(days, limit, language)
+    ]

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -25,6 +25,7 @@ def _query_articles(
     search: str | None,
     published_after: datetime | None,
     published_before: datetime | None,
+    language: str | None,
 ) -> list[ArticleModel]:
     """Build the article-list query with optional filters and pagination.
 
@@ -51,6 +52,8 @@ def _query_articles(
         query = query.filter(ArticleModel.category == category)
     if source_id is not None:
         query = query.filter(ArticleModel.source_id == source_id)
+    if language is not None:
+        query = query.filter(ArticleModel.language == language)
     if published_after is not None:
         query = query.filter(ArticleModel.published_at >= published_after)
     if published_before is not None:
@@ -102,6 +105,13 @@ def get_articles(
         None,
         description="Only articles published at or before this ISO-8601 datetime",
     ),
+    language: str | None = Query(
+        None,
+        min_length=2,
+        max_length=2,
+        pattern="^[a-z]{2}$",
+        description="Filter by ISO 639-1 language code (e.g. 'en', 'de')",
+    ),
 ) -> List[ArticleRead]:
     return _query_articles(  # type: ignore[return-value]
         db,
@@ -113,6 +123,7 @@ def get_articles(
         search,
         published_after,
         published_before,
+        language,
     )
 
 
@@ -127,6 +138,9 @@ def get_latest_articles(
     search: str | None = Query(None, min_length=2, max_length=200),
     published_after: datetime | None = Query(None),
     published_before: datetime | None = Query(None),
+    language: str | None = Query(
+        None, min_length=2, max_length=2, pattern="^[a-z]{2}$"
+    ),
 ) -> List[ArticleRead]:
     return _query_articles(  # type: ignore[return-value]
         db,
@@ -138,6 +152,7 @@ def get_latest_articles(
         search,
         published_after,
         published_before,
+        language,
     )
 
 
@@ -158,6 +173,16 @@ def search_articles_fts(
     limit: int = Query(20, ge=1, le=100),
     published_after: datetime | None = Query(None),
     published_before: datetime | None = Query(None),
+    language: str | None = Query(
+        None,
+        min_length=2,
+        max_length=2,
+        pattern="^[a-z]{2}$",
+        description=(
+            "Filter by ISO 639-1 language code and select the FTS config "
+            "('de' uses German stemming/stop-words)"
+        ),
+    ),
 ) -> List[ArticleRead]:
     # Declared BEFORE /{article_id} so "search" isn't captured by the int path
     # param. Postgres-only — the FTS operators don't exist on SQLite, so this
@@ -170,6 +195,7 @@ def search_articles_fts(
         limit=limit,
         published_after=published_after,
         published_before=published_before,
+        language=language,
     )
 
 

--- a/app/routers/db_analytics.py
+++ b/app/routers/db_analytics.py
@@ -27,6 +27,16 @@ router = APIRouter(tags=["DB Analytics"])
 # Postgres, so they share the analytics rate-limit budget.
 _RATE = config.security.rate_limit_analytics
 
+# Shared optional ISO 639-1 language filter (e.g. "en", "de"). When set, the
+# chart aggregates over that language only — drives the EN/DE dashboard toggle.
+_LANG_QUERY = Query(
+    None,
+    min_length=2,
+    max_length=2,
+    pattern="^[a-z]{2}$",
+    description="Filter by ISO 639-1 language code (e.g. 'en', 'de')",
+)
+
 
 @router.get("/sentiment/rolling", response_model=List[Dict[str, Any]])
 @_limiter.limit(_RATE)
@@ -34,10 +44,11 @@ def get_sentiment_rolling(
     request: Request,
     days: int = Query(30, ge=7, le=365),
     window: int = Query(7, ge=3, le=30, description="Rolling window size in days"),
+    language: str | None = _LANG_QUERY,
     db: Session = Depends(get_db),
 ) -> List[Dict[str, Any]]:
     """7-day rolling average sentiment trend (window function)."""
-    return sentiment_rolling_average(db, days=days, window=window)
+    return sentiment_rolling_average(db, days=days, window=window, language=language)
 
 
 @router.get("/sources/ranked", response_model=List[Dict[str, Any]])
@@ -45,10 +56,11 @@ def get_sentiment_rolling(
 def get_sources_ranked(
     request: Request,
     days: int = Query(30, ge=1, le=365),
+    language: str | None = _LANG_QUERY,
     db: Session = Depends(get_db),
 ) -> List[Dict[str, Any]]:
     """Sources ranked by average sentiment (CTE + RANK window function)."""
-    return source_sentiment_ranked(db, days=days)
+    return source_sentiment_ranked(db, days=days, language=language)
 
 
 @router.get("/sentiment/breakdown", response_model=List[Dict[str, Any]])
@@ -56,10 +68,11 @@ def get_sources_ranked(
 def get_sentiment_breakdown(
     request: Request,
     days: int = Query(30, ge=1, le=365),
+    language: str | None = _LANG_QUERY,
     db: Session = Depends(get_db),
 ) -> List[Dict[str, Any]]:
     """Multi-dimensional sentiment breakdown (GROUPING SETS)."""
-    return sentiment_grouping_sets(db, days=days)
+    return sentiment_grouping_sets(db, days=days, language=language)
 
 
 @router.get("/entities/momentum", response_model=List[Dict[str, Any]])
@@ -67,10 +80,11 @@ def get_sentiment_breakdown(
 def get_entity_momentum(
     request: Request,
     days: int = Query(14, ge=4, le=60),
+    language: str | None = _LANG_QUERY,
     db: Session = Depends(get_db),
 ) -> List[Dict[str, Any]]:
     """Entity mention momentum: this period vs previous period."""
-    return entity_momentum(db, days=days)
+    return entity_momentum(db, days=days, language=language)
 
 
 @router.get("/categories/daily", response_model=List[Dict[str, Any]])
@@ -78,7 +92,8 @@ def get_entity_momentum(
 def get_categories_daily(
     request: Request,
     days: int = Query(14, ge=1, le=90),
+    language: str | None = _LANG_QUERY,
     db: Session = Depends(get_db),
 ) -> List[Dict[str, Any]]:
     """Daily sentiment per category with cumulative totals (window function)."""
-    return daily_category_sentiment_pivot(db, days=days)
+    return daily_category_sentiment_pivot(db, days=days, language=language)

--- a/app/services/bigquery.py
+++ b/app/services/bigquery.py
@@ -212,6 +212,9 @@ def _entity_schema() -> list:
         bigquery.SchemaField("wikipedia_url", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("sentiment_label", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("sentiment_score", "FLOAT", mode="NULLABLE"),
+        # Article language (ISO 639-1). NULLABLE: rows streamed before this
+        # field was added stay NULL, so a language filter is forward-only.
+        bigquery.SchemaField("language", "STRING", mode="NULLABLE"),
     ]
 
 
@@ -228,6 +231,8 @@ def _category_schema() -> list:
         bigquery.SchemaField("category_confidence", "FLOAT", mode="NULLABLE"),
         bigquery.SchemaField("sentiment_label", "STRING", mode="NULLABLE"),
         bigquery.SchemaField("sentiment_score", "FLOAT", mode="NULLABLE"),
+        # Article language (ISO 639-1). NULLABLE / forward-only (see entity schema).
+        bigquery.SchemaField("language", "STRING", mode="NULLABLE"),
     ]
 
 
@@ -329,6 +334,7 @@ def queue_entity_event(
     sentiment_label: str,
     sentiment_score: float,
     wikipedia_url: Optional[str] = None,
+    language: str = "en",
 ) -> None:
     """Buffer an entity event; auto-flushes at batch_size."""
     if not config.bigquery.enable_bigquery:
@@ -351,6 +357,7 @@ def queue_entity_event(
             "wikipedia_url": wikipedia_url,
             "sentiment_label": sentiment_label,
             "sentiment_score": sentiment_score,
+            "language": language,
         }
     )
 
@@ -366,6 +373,7 @@ def queue_category_event(
     category_confidence: float,
     sentiment_label: str,
     sentiment_score: float,
+    language: str = "en",
 ) -> None:
     """Buffer a category event; auto-flushes at batch_size."""
     if not config.bigquery.enable_bigquery:
@@ -383,6 +391,7 @@ def queue_category_event(
             "category_confidence": category_confidence,
             "sentiment_label": sentiment_label,
             "sentiment_score": sentiment_score,
+            "language": language,
         }
     )
 
@@ -642,8 +651,14 @@ def get_top_entities(
     days: int = 30,
     entity_type: Optional[str] = None,
     limit: int = 20,
+    language: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Top entities by article mention count."""
+    """Top entities by article mention count.
+
+    ``language`` (ISO 639-1) is forward-only: events streamed before the
+    ``language`` column was added have ``language = NULL`` and won't match a
+    filter until they age out of the ``days`` window (or are backfilled).
+    """
     if not config.bigquery.enable_bigquery:
         return []
 
@@ -661,6 +676,7 @@ def get_top_entities(
     FROM {fqn}
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND (@entity_type IS NULL OR entity_type = @entity_type)
+      AND (@language IS NULL OR language = @language)
       AND entity_type NOT IN ('NUMBER', 'OTHER', 'DATE', 'PRICE', 'ADDRESS', 'PHONE_NUMBER')
       -- Quality gate: only Knowledge-Graph-resolved entities (those GCP NL gave
       -- a wikipedia_url). This drops generic common-noun "entities" like
@@ -682,6 +698,7 @@ def get_top_entities(
             bigquery.ScalarQueryParameter("days", "INT64", days),
             bigquery.ScalarQueryParameter("entity_type", "STRING", entity_type),
             bigquery.ScalarQueryParameter("limit", "INT64", limit),
+            bigquery.ScalarQueryParameter("language", "STRING", language),
             bigquery.ArrayQueryParameter(
                 "publisher_denylist", "STRING", publisher_denylist_lower()
             ),
@@ -814,8 +831,12 @@ def get_entity_sentiment_timeline(
 def get_nlp_categories(
     days: int = 30,
     limit: int = 20,
+    language: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """GCP NL content categories with sentiment aggregation."""
+    """GCP NL content categories with sentiment aggregation.
+
+    ``language`` (ISO 639-1) is forward-only — see :func:`get_top_entities`.
+    """
     if not config.bigquery.enable_bigquery:
         return []
 
@@ -832,6 +853,7 @@ def get_nlp_categories(
     FROM {fqn}
     WHERE ingested_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
       AND category_name IS NOT NULL
+      AND (@language IS NULL OR language = @language)
     GROUP BY category_name
     ORDER BY article_count DESC
     LIMIT @limit
@@ -841,6 +863,7 @@ def get_nlp_categories(
         query_parameters=[
             bigquery.ScalarQueryParameter("days", "INT64", days),
             bigquery.ScalarQueryParameter("limit", "INT64", limit),
+            bigquery.ScalarQueryParameter("language", "STRING", language),
         ]
     )
 

--- a/app/utils/gcp_nlp.py
+++ b/app/utils/gcp_nlp.py
@@ -94,14 +94,17 @@ class GcpNlpClient:
                 raise
         return self._client
 
-    def analyze_sentiment(self, text: str) -> Tuple[str, float, Optional[float]]:
+    def analyze_sentiment(
+        self, text: str, language: str = "en"
+    ) -> Tuple[str, float, Optional[float]]:
         """
         Analyze sentiment using Google Cloud Natural Language API.
 
-        Optimized for English-only news articles (matches our ingestion pipeline).
-
         Args:
-            text: English text to analyze for sentiment
+            text: Text to analyze for sentiment
+            language: ISO 639-1 code of the text (e.g. "en", "de"). Passing it
+                explicitly skips the API's language-detection step. GCP NL
+                document sentiment supports German alongside English.
 
         Returns:
             Tuple of (label, score, magnitude) where:
@@ -123,12 +126,11 @@ class GcpNlpClient:
             text = text[: max_length // 4]  # Conservative truncation
 
         try:
-            # Create document object - hardcode English
-            # (we only ingest English articles)
+            # Declare the language explicitly so the API skips detection.
             document = language_v1.Document(
                 content=text,
                 type_=language_v1.Document.Type.PLAIN_TEXT,
-                language="en",  # Always English - saves language detection API calls
+                language=language,
             )
 
             # Call the API (following official GCP NL documentation)
@@ -181,7 +183,7 @@ class GcpNlpClient:
             # Don't fail the entire process for sentiment analysis errors
             return "neutral", 0.0, None
 
-    def annotate_text(self, text: str) -> AnnotateTextResult:
+    def annotate_text(self, text: str, language: str = "en") -> AnnotateTextResult:
         """
         Analyze text using GCP NL annotateText for sentiment + entities + categories.
 
@@ -189,7 +191,12 @@ class GcpNlpClient:
         classifyText calls, saving quota and cost.
 
         Args:
-            text: English text to analyze
+            text: Text to analyze
+            language: ISO 639-1 code of the text (e.g. "en", "de"). GCP NL
+                supports German for sentiment + entities. Content classification
+                (``classify_text``) is requested with the **V2** model, which —
+                unlike the default V1 (English-only) — covers German + 11 other
+                languages, so German articles get categories too.
 
         Returns:
             AnnotateTextResult with sentiment, entities, and categories
@@ -212,14 +219,25 @@ class GcpNlpClient:
             document = language_v1.Document(
                 content=text,
                 type_=language_v1.Document.Type.PLAIN_TEXT,
-                language="en",
+                language=language,
             )
 
-            # Request all three features in one call
+            # Request all three features in one call. classify_text uses the V2
+            # content-classification model: the V1 default is English-only, while
+            # V2 supports German (and 11 other languages) AND ships the newer 2022
+            # taxonomy for English. ``classification_model_options`` is only read
+            # when classify_text is true.
             features = language_v1.AnnotateTextRequest.Features(
                 extract_entities=True,
                 extract_document_sentiment=True,
                 classify_text=True,
+                classification_model_options=language_v1.ClassificationModelOptions(
+                    v2_model=language_v1.ClassificationModelOptions.V2Model(
+                        content_categories_version=(
+                            language_v1.ClassificationModelOptions.V2Model.ContentCategoriesVersion.V2
+                        )
+                    )
+                ),
             )
 
             response = self.client.annotate_text(

--- a/app/utils/sentiment.py
+++ b/app/utils/sentiment.py
@@ -19,7 +19,7 @@ vader_analyzer = SentimentIntensityAnalyzer()
 
 
 def analyze_sentiment_vader(text: str) -> Tuple[str, float]:
-    """Analyze sentiment using VADER sentiment analyzer."""
+    """Analyze sentiment using VADER sentiment analyzer (English lexicon only)."""
     if not text:
         return "neutral", 0.0
 
@@ -36,32 +36,56 @@ def analyze_sentiment_vader(text: str) -> Tuple[str, float]:
         return "neutral", score
 
 
-def analyze_sentiment_gcp_nl(text: str) -> Tuple[str, float, Optional[float]]:
-    """Analyze sentiment using Google Cloud Natural Language API (English only)."""
+def _vader_fallback(text: str, language: str) -> Tuple[str, float]:
+    """Fallback sentiment when GCP NL is unavailable.
+
+    VADER is an English-only lexicon: on non-English text it finds no lexicon
+    matches and collapses everything to ~0.0 / "neutral", which is silently
+    misleading. So we only run VADER for English; for any other language we
+    return an explicit neutral rather than a fake score.
+    """
+    if language != "en":
+        logger.debug(
+            "Skipping VADER fallback for language=%s (English-only lexicon); "
+            "returning explicit neutral",
+            language,
+        )
+        return "neutral", 0.0
+    return analyze_sentiment_vader(text)
+
+
+def analyze_sentiment_gcp_nl(
+    text: str, language: str = "en"
+) -> Tuple[str, float, Optional[float]]:
+    """Analyze sentiment using Google Cloud Natural Language API.
+
+    Supports German alongside English. On failure, falls back to VADER for
+    English only (see :func:`_vader_fallback`).
+    """
     try:
         from app.utils.gcp_nlp import gcp_nlp_client
 
-        return gcp_nlp_client.analyze_sentiment(text)
+        return gcp_nlp_client.analyze_sentiment(text, language)
     except ImportError as e:
         logger.warning(f"GCP NL client not available: {e}")
-        # Fall back to VADER
-        label, score = analyze_sentiment_vader(text)
+        label, score = _vader_fallback(text, language)
         return label, score, None
     except Exception as e:
         logger.warning(
-            "GCP NL analyzeSentiment failed: %s; falling back to VADER",
+            "GCP NL analyzeSentiment failed: %s; falling back",
             e,
             exc_info=True,
         )
-        # Fall back to VADER
         if config.sentiment.enable_fallback:
-            label, score = analyze_sentiment_vader(text)
+            label, score = _vader_fallback(text, language)
             return label, score, None
         else:
             return "neutral", 0.0, None
 
 
-def annotate_text_gcp_nl(text: str) -> Optional[AnnotateTextResult]:
+def annotate_text_gcp_nl(
+    text: str, language: str = "en"
+) -> Optional[AnnotateTextResult]:
     """
     Full annotateText using GCP NL (sentiment + entities + categories in one call).
 
@@ -71,7 +95,7 @@ def annotate_text_gcp_nl(text: str) -> Optional[AnnotateTextResult]:
     try:
         from app.utils.gcp_nlp import gcp_nlp_client
 
-        return gcp_nlp_client.annotate_text(text)
+        return gcp_nlp_client.annotate_text(text, language)
     except ImportError as e:
         logger.warning(f"GCP NL client not available: {e}")
         return None
@@ -84,14 +108,15 @@ def annotate_text_gcp_nl(text: str) -> Optional[AnnotateTextResult]:
         return None
 
 
-def analyze_sentiment(text: str) -> Tuple[str, float]:
+def analyze_sentiment(text: str, language: str = "en") -> Tuple[str, float]:
     """
-    Analyze sentiment using the configured provider (English only).
-
-    Optimized for English news articles matching our ingestion pipeline.
+    Analyze sentiment using the configured provider.
 
     Args:
-        text: English text to analyze
+        text: Text to analyze
+        language: ISO 639-1 code of the text (e.g. "en", "de"). GCP NL supports
+            German; the VADER fallback is English-only, so non-English text that
+            falls through to VADER returns an explicit neutral instead.
 
     Returns:
         Tuple of (sentiment_label, sentiment_score)
@@ -107,14 +132,14 @@ def analyze_sentiment(text: str) -> Tuple[str, float]:
 
     if provider == "GCP_NL":
         logger.debug("Using Google Cloud Natural Language for sentiment analysis")
-        label, score, magnitude = analyze_sentiment_gcp_nl(text)
+        label, score, magnitude = analyze_sentiment_gcp_nl(text, language)
         return label, score
     elif provider == "VADER":
         logger.debug("Using VADER for sentiment analysis")
-        return analyze_sentiment_vader(text)
+        return _vader_fallback(text, language)
     else:
         logger.warning(f"Unknown sentiment provider '{provider}', defaulting to VADER")
-        return analyze_sentiment_vader(text)
+        return _vader_fallback(text, language)
 
 
 def get_sentiment_provider_info() -> Dict[

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -25,6 +25,7 @@
   import ArticleCard from "./lib/ArticleCard.svelte";
   import BookmarksView from "./lib/BookmarksView.svelte";
   import Privacy from "./lib/Privacy.svelte";
+  import FlagToggle from "./lib/FlagToggle.svelte";
   import Logo from "./lib/Logo.svelte";
 
   type Page = "articles" | "analytics" | "bookmarks" | "privacy";
@@ -57,6 +58,10 @@
   // forwards them.
   let publishedAfter: string = "";
   let publishedBefore: string = "";
+  // Content language (ISO 639-1). The single source of truth for the EN/DE
+  // toggle — drives both the article feed and the Analytics dashboard. Always
+  // exactly one language; defaults to English.
+  let language: string = "en";
   let skip: number = 0;
   const limit: number = 20;
 
@@ -95,6 +100,7 @@
     search = p.get("search") ?? "";
     publishedAfter = p.get("after") ?? "";
     publishedBefore = p.get("before") ?? "";
+    language = p.get("lang") ?? "en";
     const sk = Number(p.get("skip") ?? "0");
     skip = Number.isFinite(sk) && sk > 0 ? sk : 0;
   }
@@ -107,6 +113,7 @@
     if (search.trim()) p.set("search", search.trim());
     if (publishedAfter) p.set("after", publishedAfter);
     if (publishedBefore) p.set("before", publishedBefore);
+    if (language && language !== "en") p.set("lang", language);
     if (skip > 0) p.set("skip", String(skip));
     const qs = p.toString();
     const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
@@ -132,6 +139,7 @@
           limit,
           published_after: publishedAfter || undefined,
           published_before: publishedBefore || undefined,
+          language: language || undefined,
         });
       } else {
         articles = await fetchArticles({
@@ -142,6 +150,7 @@
           source_id: sourceId === "" ? undefined : sourceId,
           published_after: publishedAfter || undefined,
           published_before: publishedBefore || undefined,
+          language: language || undefined,
         });
       }
     } catch (e) {
@@ -197,6 +206,7 @@
       search,
       publishedAfter,
       publishedBefore,
+      language,
       skip,
     ];
   }
@@ -245,6 +255,14 @@
     publishedAfter = next.publishedAfter;
     publishedBefore = next.publishedBefore;
     // Filter changed → reset to first page.
+    skip = 0;
+  }
+
+  // Switch the content language (EN/DE). Drives the feed + dashboard via the
+  // reactive block; resets pagination since the result set changes entirely.
+  function setLanguage(lang: string) {
+    if (lang === language) return;
+    language = lang;
     skip = 0;
   }
 
@@ -370,6 +388,13 @@
       {/if}
     </nav>
 
+    <!-- Content-language toggle: rounded SVG flags, dead-centered in the header
+         bar (absolutely positioned so it stays centered regardless of the
+         left/right group widths). Switches both the feed and the dashboard. -->
+    <div class="lang-center">
+      <FlagToggle {language} onchange={setLanguage} />
+    </div>
+
     <div class="header-right">
       {#if $userStore}
         <span class="user-email" title={$userStore.email ?? undefined}>{$userStore.email}</span>
@@ -480,7 +505,7 @@
   {:else if currentPage === "bookmarks" && $userStore}
     <BookmarksView />
   {:else if currentPage === "analytics" && $userStore}
-    <Dashboard />
+    <Dashboard {language} />
   {:else if currentPage === "privacy"}
     <Privacy />
   {:else}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -148,6 +148,21 @@ a:hover { text-decoration: underline; }
   display: flex;
   align-items: center;
   gap: var(--sp-6);
+  /* anchor for the dead-centered language toggle */
+  position: relative;
+}
+
+/* Language toggle pinned to the dead-center of the header bar, independent of
+   the left (logo/nav) and right (user/theme) group widths. It only spans its
+   own content width, so it doesn't overlay the side groups — no pointer-events
+   juggling needed (and :global() isn't valid in a plain global stylesheet). */
+.lang-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
 }
 .wordmark {
   font-size: 15px;

--- a/frontend/src/lib/Dashboard.svelte
+++ b/frontend/src/lib/Dashboard.svelte
@@ -27,6 +27,10 @@
 
   Chart.register(...registerables);
 
+  // Content language (ISO 639-1) from the global EN/DE toggle in the header.
+  // All charts aggregate over this language only.
+  export let language: string = "en";
+
   let days = 30;
   const ROLLING_WINDOW = 7;
   let loading = true;
@@ -180,23 +184,24 @@
       // (60 and 90 days). Clamp to those maxima so the wider ranges still
       // pull the most data the endpoint allows rather than 400-ing.
       [rolling, ranked, breakdown, momentum, catDaily] = await Promise.all([
-        fetchSentimentRolling(days, ROLLING_WINDOW),
-        fetchSourcesRanked(days),
-        fetchSentimentBreakdown(days),
-        fetchEntityMomentum(Math.min(days, 60)),
-        fetchCategoriesDaily(Math.min(days, 90)),
+        fetchSentimentRolling(days, ROLLING_WINDOW, language),
+        fetchSourcesRanked(days, language),
+        fetchSentimentBreakdown(days, language),
+        fetchEntityMomentum(Math.min(days, 60), language),
+        fetchCategoriesDaily(Math.min(days, 90), language),
       ]);
       deriveKpis();
 
       // BigQuery analytics are best-effort: if BigQuery is disabled the
       // endpoints return [] and the bonus row simply doesn't render. The
       // entity-type filter (entityType) narrows the three entity charts;
-      // '' means "all types" and is sent as undefined.
+      // '' means "all types" and is sent as undefined. The language filter is
+      // forward-only on BigQuery (events predating the column are NULL).
       [bqEntities, bqEntitySentiment, bqEntityTimeline, bqCategories] = await Promise.all([
-        fetchTopEntities(days, entityType || undefined, 12).catch(() => []),
+        fetchTopEntities(days, entityType || undefined, 12, language).catch(() => []),
         fetchEntitySentiment(days, entityType || undefined, 12).catch(() => []),
         fetchEntitySentimentTimeline(days, entityType || undefined, 8).catch(() => []),
-        fetchNlpCategories(days, 12).catch(() => []),
+        fetchNlpCategories(days, 12, language).catch(() => []),
       ]);
 
       setTimeout(renderCharts, 0);
@@ -214,7 +219,7 @@
     entityLoading = true;
     try {
       [bqEntities, bqEntitySentiment, bqEntityTimeline] = await Promise.all([
-        fetchTopEntities(days, entityType || undefined, 12).catch(() => []),
+        fetchTopEntities(days, entityType || undefined, 12, language).catch(() => []),
         fetchEntitySentiment(days, entityType || undefined, 12).catch(() => []),
         fetchEntitySentimentTimeline(days, entityType || undefined, 8).catch(
           () => []
@@ -604,6 +609,15 @@
     loadData();
   });
   onDestroy(() => destroyCharts());
+
+  // Reload every chart when the global language toggle changes (same effect as
+  // changing `days`). Guarded by `mounted` so it doesn't double-load on first
+  // render alongside onMount's initial loadData().
+  let lastLanguage = language;
+  $: if (mounted && language !== lastLanguage) {
+    lastLanguage = language;
+    loadData();
+  }
 
   // Re-render the charts when the theme flips so grid/tick/tooltip colours
   // follow the token system. Guarded by `mounted` + data presence so it never

--- a/frontend/src/lib/FlagToggle.svelte
+++ b/frontend/src/lib/FlagToggle.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  // EN/DE content-language toggle rendered as two rounded SVG flags.
+  // SVG (not flag emoji) is used because Windows browsers render the
+  // regional-indicator emoji as plain letters ("GB"/"DE") instead of flags.
+  // Inline SVG renders identically on every platform.
+  //
+  // Svelte 5 runes API (matches Logo.svelte): props via $props(), callback
+  // invoked through the `onchange?.(...)` accessor, native `onclick`.
+  interface Props {
+    language?: string;
+    onchange?: (lang: string) => void;
+  }
+  let { language = "en", onchange }: Props = $props();
+</script>
+
+<div class="flag-toggle" role="group" aria-label="Content language">
+  <button
+    type="button"
+    class="flag-btn"
+    class:flag-active={language === "en"}
+    onclick={() => onchange?.("en")}
+    aria-pressed={language === "en"}
+    aria-label="English news"
+    title="English"
+  >
+    <!-- Union Jack. Drawn in a 60x30 box, clipped to a circle. White diagonals
+         first, then the counterchanged red diagonals, then the white+red upright
+         cross on top. -->
+    <svg viewBox="0 0 60 30" aria-hidden="true">
+      <clipPath id="uk-round"><circle cx="30" cy="15" r="15" /></clipPath>
+      <g clip-path="url(#uk-round)">
+        <rect width="60" height="30" fill="#012169" />
+        <!-- white diagonals -->
+        <path d="M0,0 L60,30 M60,0 L0,30" stroke="#fff" stroke-width="6" />
+        <!-- red counterchanged diagonals (each half offset so they read as the
+             real Union Jack rather than a plain X) -->
+        <path d="M0,0 L30,15 M30,15 L60,30" stroke="#C8102E" stroke-width="2"
+          transform="translate(2,0)" />
+        <path d="M60,0 L30,15 M30,15 L0,30" stroke="#C8102E" stroke-width="2"
+          transform="translate(-2,0)" />
+        <!-- upright cross: white then red -->
+        <path d="M30,0 V30 M0,15 H60" stroke="#fff" stroke-width="10" />
+        <path d="M30,0 V30 M0,15 H60" stroke="#C8102E" stroke-width="6" />
+      </g>
+    </svg>
+  </button>
+
+  <button
+    type="button"
+    class="flag-btn"
+    class:flag-active={language === "de"}
+    onclick={() => onchange?.("de")}
+    aria-pressed={language === "de"}
+    aria-label="German news"
+    title="Deutsch"
+  >
+    <!-- Germany: black / red / gold horizontal bands -->
+    <svg viewBox="0 0 60 30" aria-hidden="true">
+      <clipPath id="de-round"><circle cx="30" cy="15" r="15" /></clipPath>
+      <g clip-path="url(#de-round)">
+        <rect width="60" height="10" y="0" fill="#000" />
+        <rect width="60" height="10" y="10" fill="#DD0000" />
+        <rect width="60" height="10" y="20" fill="#FFCE00" />
+      </g>
+    </svg>
+  </button>
+</div>
+
+<style>
+  .flag-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-2);
+  }
+  .flag-btn {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid var(--border-med);
+    border-radius: 50%;        /* round flags */
+    background: var(--bg-raised);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    cursor: pointer;
+    opacity: 0.5;              /* inactive flags read as "off" */
+    transition: all var(--transition);
+  }
+  .flag-btn svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    border-radius: 50%;
+  }
+  .flag-btn:hover { opacity: 0.85; border-color: var(--border-hi); }
+  .flag-active {
+    opacity: 1;                /* full-colour = selected */
+    border-color: var(--accent);
+    box-shadow: var(--accent-glow);
+  }
+</style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,6 +74,8 @@ export type ArticleFilterParams = {
   published_after?: string;
   /** ISO-8601 datetime; inclusive upper bound on published_at. */
   published_before?: string;
+  /** ISO 639-1 language code (e.g. "en", "de"). */
+  language?: string;
 };
 
 /**
@@ -97,6 +99,7 @@ export async function fetchArticles(
   if (params.search) qs.set("search", params.search);
   if (params.published_after) qs.set("published_after", params.published_after);
   if (params.published_before) qs.set("published_before", params.published_before);
+  if (params.language) qs.set("language", params.language);
 
   const queryString = qs.toString();
   const url = queryString
@@ -120,6 +123,8 @@ export type ArticleSearchParams = {
   limit?: number;
   published_after?: string;
   published_before?: string;
+  /** ISO 639-1 language code; also selects the FTS config ('de' → German). */
+  language?: string;
 };
 
 /**
@@ -137,6 +142,7 @@ export async function searchArticles(
   if (params.limit !== undefined) qs.set("limit", String(params.limit));
   if (params.published_after) qs.set("published_after", params.published_after);
   if (params.published_before) qs.set("published_before", params.published_before);
+  if (params.language) qs.set("language", params.language);
 
   const res = await fetch(`${API_BASE}/api/v1/articles/search?${qs.toString()}`);
 
@@ -366,9 +372,10 @@ export function fetchPipelineHealth(days = 7): Promise<PipelineRun[]> {
   return fetchAnalytics(`/pipeline?days=${days}`);
 }
 
-export function fetchTopEntities(days = 30, entityType?: string, limit = 20): Promise<TopEntity[]> {
+export function fetchTopEntities(days = 30, entityType?: string, limit = 20, language?: string): Promise<TopEntity[]> {
   let params = `?days=${days}&limit=${limit}`;
   if (entityType) params += `&entity_type=${entityType}`;
+  if (language) params += `&language=${language}`;
   return fetchAnalytics(`/entities/top${params}`);
 }
 
@@ -384,8 +391,9 @@ export function fetchEntitySentimentTimeline(days = 30, entityType?: string, lim
   return fetchAnalytics(`/entities/sentiment-timeline${params}`);
 }
 
-export function fetchNlpCategories(days = 30, limit = 20): Promise<NlpCategoryBreakdown[]> {
-  return fetchAnalytics(`/categories/nlp?days=${days}&limit=${limit}`);
+export function fetchNlpCategories(days = 30, limit = 20, language?: string): Promise<NlpCategoryBreakdown[]> {
+  const lang = language ? `&language=${language}` : "";
+  return fetchAnalytics(`/categories/nlp?days=${days}&limit=${limit}${lang}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -461,27 +469,33 @@ function coerceNumeric<T>(rows: Record<string, unknown>[], fields: string[]): T[
   });
 }
 
-export async function fetchSentimentRolling(days = 30, window = 7): Promise<RollingSentimentPoint[]> {
-  const rows = await fetchDbAnalyticsRaw(`/sentiment/rolling?days=${days}&window=${window}`);
+// Optional `&language=xx` suffix shared by the DB-analytics fetchers. Empty
+// when no language is selected, so the all-languages request is unchanged.
+function langSuffix(language?: string): string {
+  return language ? `&language=${language}` : "";
+}
+
+export async function fetchSentimentRolling(days = 30, window = 7, language?: string): Promise<RollingSentimentPoint[]> {
+  const rows = await fetchDbAnalyticsRaw(`/sentiment/rolling?days=${days}&window=${window}${langSuffix(language)}`);
   return coerceNumeric<RollingSentimentPoint>(rows, ['avg_sentiment', 'rolling_avg']);
 }
 
-export async function fetchSourcesRanked(days = 30): Promise<SourceRanked[]> {
-  const rows = await fetchDbAnalyticsRaw(`/sources/ranked?days=${days}`);
+export async function fetchSourcesRanked(days = 30, language?: string): Promise<SourceRanked[]> {
+  const rows = await fetchDbAnalyticsRaw(`/sources/ranked?days=${days}${langSuffix(language)}`);
   return coerceNumeric<SourceRanked>(rows, ['avg_sentiment', 'sentiment_stddev']);
 }
 
-export async function fetchSentimentBreakdown(days = 30): Promise<SentimentBreakdownRow[]> {
-  const rows = await fetchDbAnalyticsRaw(`/sentiment/breakdown?days=${days}`);
+export async function fetchSentimentBreakdown(days = 30, language?: string): Promise<SentimentBreakdownRow[]> {
+  const rows = await fetchDbAnalyticsRaw(`/sentiment/breakdown?days=${days}${langSuffix(language)}`);
   return coerceNumeric<SentimentBreakdownRow>(rows, ['avg_sentiment']);
 }
 
-export async function fetchEntityMomentum(days = 14): Promise<EntityMomentum[]> {
-  const rows = await fetchDbAnalyticsRaw(`/entities/momentum?days=${days}`);
+export async function fetchEntityMomentum(days = 14, language?: string): Promise<EntityMomentum[]> {
+  const rows = await fetchDbAnalyticsRaw(`/entities/momentum?days=${days}${langSuffix(language)}`);
   return coerceNumeric<EntityMomentum>(rows, ['growth_pct']);
 }
 
-export async function fetchCategoriesDaily(days = 14): Promise<CategoryDailyPoint[]> {
-  const rows = await fetchDbAnalyticsRaw(`/categories/daily?days=${days}`);
+export async function fetchCategoriesDaily(days = 14, language?: string): Promise<CategoryDailyPoint[]> {
+  const rows = await fetchDbAnalyticsRaw(`/categories/daily?days=${days}${langSuffix(language)}`);
   return coerceNumeric<CategoryDailyPoint>(rows, ['avg_sentiment']);
 }


### PR DESCRIPTION
## Bilingual EN/DE news — parallel English/German versions

Adds German news alongside English as toggleable, parallel versions of the whole app. A single **rounded-flag EN/DE toggle, dead-centered in the header**, drives both the article feed **and** the Analytics dashboard. The choice persists in the URL (`?lang=de`) so a German view is shareable and survives reload.

### What's included
- **NLP pipeline** — `language` threaded through `gcp_nlp` / `sentiment` / `normalize` / `crawl_worker`. `annotateText` now uses the **V2 content-classification model**, which (unlike the V1 default) supports German — so German articles get full sentiment + entities + categories, and English gains the newer 2022 taxonomy. VADER (English-only) is skipped for non-English.
- **Feed + search filter** — `?language=` on `/articles`, `/articles/latest`, and `/articles/search`. The FTS search additionally switches its text-search config `english`→`german` for DE stemming. The param is optional/`None`-default, so **every existing route is byte-identical when it's omitted**.
- **Analytics (EN/DE dashboard)** — all 5 Postgres charts filtered; `entity_momentum` adds a `JOIN articles` only when a language is requested (default plan unchanged). BigQuery entity/category events gain a `language` field + filtered queries (forward-only — pre-change rows are NULL).
- **Sources** — 9 German national outlets added (`spiegel`, `zeit`, `faz`, `sueddeutsche`, `die-welt`, `handelsblatt`, `tagesschau`, `stern`, `focus`); slugs verified live against the Mediastack API. `MEDIASTACK_LANGUAGES=en,de` (env; code default stays `en`, reversible).
- **Frontend** — new `FlagToggle.svelte` (inline-SVG flags — emoji flags render as "GB"/"DE" text on Windows). One shared `language` state drives feed + dashboard; `api.ts` threads it through all fetchers.
- **Backfill** — new `app/jobs/backfill_german.py`: Mediastack history → Postgres + full NLP, reusing the live pipeline. Per-source/day cap bounds GCP NL cost; URL-unique dedup makes re-runs idempotent (`--dry-run`, `--days`, `--per-source-cap`, `--no-crawl`).

### Notes
- **No DB migration** — `language`/`country` columns already existed.
- **Two bugs fixed during local testing** (would have shipped broken): a Svelte 5 callback mis-compile (`onchange()("en")`) and an invalid `:global()` selector in the global stylesheet that killed toggle clicks via a dropped `pointer-events` rule.
- Trade-offs: VADER skipped for non-English; `analyzeEntitySentiment` unused (EN/JA/ES-only); cross-language entities like "Google" dedupe together; BigQuery language filter is forward-only.

### Verification
- 104 tests pass / 23 Postgres-skip; `ruff` clean; frontend `svelte-check` + `vite build` clean.
- Verified end-to-end against the local Docker stack: toggle switches the feed, `?language=de` filters correctly, German FTS search works, analytics endpoints accept and apply `language`.

### Post-merge production step
After deploy: run `python -m app.jobs.backfill_german` against prod Cloud SQL, then `python -m app.jobs.backfill_bigquery --since=<30d ago>` — this populates the German feed + dashboard with real analyzed data (the one real GCP NL / Mediastack spend step, bounded by the cap).
