### PR TITLE
chore(deploy): enable German ingestion in prod (MEDIASTACK_LANGUAGES=en,de)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,6 +197,7 @@ jobs:
           GCP_PROJECT_ID=${{ env.PROJECT_ID }}
           SENTIMENT_PROVIDER=GCP_NL
           BIGQUERY_ENABLE_BIGQUERY=true
+          MEDIASTACK_LANGUAGES=en,de
         secrets: |
           MEDIASTACK_API_KEY=mediastack-api-key:latest
           GCP_NLP_KEY_JSON=aifeelnews-gcp-nlp-key:latest


### PR DESCRIPTION
Sets `MEDIASTACK_LANGUAGES=en,de` on the Cloud Run service (deploy.yml env_vars) so production fetches both English and German articles.

The bilingual code (PR #170) keeps the config default at `en` for reversibility — German ingestion only activates once this env var is present in prod. This is a brand-new variable on the service, so it's a clean add with no env-var type-switch conflict.

**Required before the develop→main release** so the deploy actually starts ingesting + NLPing German content.