### PR TITLE
Release: German full-text search fix (develop → main)

### DIFF
--- a/alembic/versions/c5f3a6b7d8e9_add_german_search_vector.py
+++ b/alembic/versions/c5f3a6b7d8e9_add_german_search_vector.py
@@ -1,0 +1,66 @@
+"""add German full-text search_vector_de (tsvector) column + GIN index
+
+Revision ID: c5f3a6b7d8e9
+Revises: b4e2d5c6f7a8
+Create Date: 2026-06-09 08:30:00.000000
+
+Background
+----------
+Migration b4e2d5c6f7a8 added ``search_vector`` generated with the **English**
+text-search config. The bilingual EN/DE work queries German articles with
+``websearch_to_tsquery('german', ...)``, but matching a German query against an
+English-stemmed vector fails for any word German stems differently ("Fußball",
+"Wetter" miss; only identically-stemmed tokens like "Forschung" hit).
+
+A single generated column can't pick the config per row — Postgres requires the
+generation expression to be IMMUTABLE, and ``to_tsvector(<column>::regconfig, …)``
+is not (the regconfig is resolved at runtime). So we add a **second** generated
+column, ``search_vector_de``, stemmed with the ``german`` config. The search CRUD
+then queries ``search_vector_de`` for German and ``search_vector`` for English,
+giving full stemming + stop-words for both languages.
+
+Design notes
+------------
+* Same ``GENERATED ALWAYS AS (...) STORED`` + weighted title(A)/description(B)
+  shape as the English column, so it auto-syncs with no trigger.
+* Like ``search_vector``, this column is **deliberately NOT mapped on the ORM
+  ``Article`` model** — it's a Postgres-only object the SQLite test schema never
+  needs, referenced only via raw ``text()`` in ``app/crud/search.py``. (Autogenerate
+  would propose DROPping it because it's absent from ``Base.metadata`` — keep it.)
+* The ``german`` text-search config ships with Postgres by default.
+
+Postgres-only DDL (the SQLite test DB is built from ``Base.metadata`` via
+``create_all``, never migrated), consistent with the sibling FTS migration.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c5f3a6b7d8e9"
+down_revision: Union[str, None] = "b4e2d5c6f7a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE articles
+        ADD COLUMN search_vector_de tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('german', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('german', coalesce(description, '')), 'B')
+        ) STORED
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_articles_search_vector_de "
+        "ON articles USING gin (search_vector_de)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_articles_search_vector_de")
+    op.execute("ALTER TABLE articles DROP COLUMN IF EXISTS search_vector_de")

--- a/app/crud/search.py
+++ b/app/crud/search.py
@@ -1,10 +1,16 @@
 """PostgreSQL full-text search over articles.
 
 A parallel, richer search path to the trigram substring search on ``/articles/``
-(migration a3f1c2d4e5b6): this queries the generated ``search_vector`` tsvector
-column (migration b4e2d5c6f7a8) with ``websearch_to_tsquery`` and ranks hits by
-``ts_rank``, giving stemming, stop-words and phrase/boolean operators across the
-weighted title (A) + description (B).
+(migration a3f1c2d4e5b6): this queries a generated ``tsvector`` column with
+``websearch_to_tsquery`` and ranks hits by ``ts_rank``, giving stemming,
+stop-words and phrase/boolean operators across the weighted title (A) +
+description (B).
+
+There are TWO vector columns — ``search_vector`` (English config, migration
+b4e2d5c6f7a8) and ``search_vector_de`` (German config, migration c5f3a6b7d8e9) —
+because a single generated column can't pick its config per row (Postgres
+requires an immutable generation expression). German articles must be queried
+against the German-stemmed column or inflected words ("Fußball", "Wetter") miss.
 
 Postgres-only — the ``@@`` operator, ``websearch_to_tsquery`` and ``ts_rank`` do
 not exist on SQLite. The caller (the ``/articles/search`` route) is reached only
@@ -21,10 +27,15 @@ from sqlalchemy.orm import Session, joinedload, subqueryload
 from app.models.article import Article
 from app.models.article_entity import ArticleEntity
 
-# Postgres FTS text-search configurations, keyed by article language. Both ship
-# with Postgres by default. The value is interpolated into the tsquery SQL, so it
-# MUST come from this fixed allowlist — never from user input.
-_FTS_CONFIG = {"en": "english", "de": "german"}
+# Per-language FTS settings: the generated tsvector column to match against and
+# the text-search config to parse the query with. Both must agree (a German query
+# only matches the German-stemmed column). Keyed by ISO 639-1; defaults to English.
+# These are fixed literals interpolated into SQL — NEVER user input — so the
+# column name and config name are safe to format in.
+_FTS = {
+    "en": ("search_vector", "english"),
+    "de": ("search_vector_de", "german"),
+}
 
 
 def search_articles(
@@ -44,15 +55,16 @@ def search_articles(
     raises on malformed input (unlike ``to_tsquery``). The same eager loads as
     the list endpoint are applied so the response shape matches ``ArticleRead``.
 
-    ``language`` (ISO 639-1) both filters to that language and selects the FTS
-    text-search config (``german`` stemming/stop-words for ``de``), so a German
-    query stems correctly. It defaults to ``english`` for any unknown/absent code.
+    ``language`` (ISO 639-1) both filters to that language and selects the
+    matching FTS column + config (``search_vector_de`` / ``german`` for ``de``),
+    so a German query stems correctly. Defaults to the English pair for any
+    unknown/absent code.
     """
-    # The text-search config name is a fixed literal chosen from the allowlist
-    # above — safe to interpolate into the SQL. ``:q`` stays a bind parameter.
-    cfg = _FTS_CONFIG.get(language or "en", "english")
-    predicate = f"search_vector @@ websearch_to_tsquery('{cfg}', :q)"
-    rank = f"ts_rank(search_vector, websearch_to_tsquery('{cfg}', :q)) DESC"
+    # Column + config are fixed literals from the allowlist above (never user
+    # input), so they're safe to interpolate. ``:q`` stays a bind parameter.
+    column, cfg = _FTS.get(language or "en", _FTS["en"])
+    predicate = f"{column} @@ websearch_to_tsquery('{cfg}', :q)"
+    rank = f"ts_rank({column}, websearch_to_tsquery('{cfg}', :q)) DESC"
 
     # The FTS predicate and rank reference the Postgres-only search_vector column
     # via text() (it is intentionally not an ORM attribute). The :q bind is set


### PR DESCRIPTION
## Release: German full-text search fix (develop → main)

Deploys PR #173 — fixes German full-text search in prod.

### Included
- **#173** — German FTS via a dedicated German-stemmed `search_vector_de` column. The existing `search_vector` is English-config-only, so German queries missed any word German stems differently (`fußball`, `wetter` returned 0 in prod). A single generated column can't pick its config per row (Postgres immutability constraint), so a second column is added and the search CRUD queries the matching one per language.

### Migration running on prod
- `c5f3a6b7d8e9` (down_revision `b4e2d5c6f7a8` = current prod head) — adds `search_vector_de` + its GIN index. `GENERATED ... STORED`, so it backfills automatically for all existing rows; no data migration. Reversible (down/up verified locally).

### Post-deploy verification
- Confirm `MEDIASTACK_LANGUAGES` is still `en,de` on the live service (the GitHub deploy did NOT override the pinned value last release — verify, don't assume).
- Confirm German FTS now works: `/api/v1/articles/search?q=wirtschaft&language=de` returns hits.
