### PR TITLE
fix(deploy): escape comma in MEDIASTACK_LANGUAGES so deploys keep en,de

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,7 +197,11 @@ jobs:
           GCP_PROJECT_ID=${{ env.PROJECT_ID }}
           SENTIMENT_PROVIDER=GCP_NL
           BIGQUERY_ENABLE_BIGQUERY=true
-          MEDIASTACK_LANGUAGES=en,de
+          # Comma in the value MUST be escaped: the deploy-cloudrun action treats
+          # a bare comma as a separator between env vars, so `en,de` would set
+          # MEDIASTACK_LANGUAGES=en (dropping `de`) and silently disable German
+          # ingestion on every deploy. `\,` keeps it a single value.
+          MEDIASTACK_LANGUAGES=en\,de
         secrets: |
           MEDIASTACK_API_KEY=mediastack-api-key:latest
           GCP_NLP_KEY_JSON=aifeelnews-gcp-nlp-key:latest


### PR DESCRIPTION
Every deploy was silently reverting `MEDIASTACK_LANGUAGES` to `en`, disabling German ingestion in prod even though deploy.yml said `en,de`.

**Root cause:** the `google-github-actions/deploy-cloudrun` action parses `env_vars:` as comma-OR-newline-separated KEY=VALUE pairs, so a bare comma in `en,de` is read as a separator → it sets `MEDIASTACK_LANGUAGES=en` and drops `de`. (Same comma-as-delimiter trap as gcloud's `--set-env-vars`.)

**Fix:** escape the comma as `en\,de` per the action's docs. The full value now survives every deploy, so German ingestion stays on without the out-of-band `gcloud run services update` workaround that was needed after the last two releases.

Verified the failure mode live: deploys produced `MEDIASTACK_LANGUAGES='en'` on the service each time despite the unescaped `en,de` in deploy.yml.