### PR TITLE
Release: deploy.yml comma-escape fix (develop → main)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,7 +197,11 @@ jobs:
           GCP_PROJECT_ID=${{ env.PROJECT_ID }}
           SENTIMENT_PROVIDER=GCP_NL
           BIGQUERY_ENABLE_BIGQUERY=true
-          MEDIASTACK_LANGUAGES=en,de
+          # Comma in the value MUST be escaped: the deploy-cloudrun action treats
+          # a bare comma as a separator between env vars, so `en,de` would set
+          # MEDIASTACK_LANGUAGES=en (dropping `de`) and silently disable German
+          # ingestion on every deploy. `\,` keeps it a single value.
+          MEDIASTACK_LANGUAGES=en\,de
         secrets: |
           MEDIASTACK_API_KEY=mediastack-api-key:latest
           GCP_NLP_KEY_JSON=aifeelnews-gcp-nlp-key:latest


### PR DESCRIPTION
## Release: deploy.yml comma-escape fix (develop → main)

Deploys PR #175 — makes German ingestion survive deploys without manual intervention.

### Included
- **#175** — escape the comma in `MEDIASTACK_LANGUAGES=en\,de`. The `deploy-cloudrun` action was parsing the bare comma in `en,de` as a separator, setting the var to just `en` and silently disabling German ingestion on every deploy. The last two releases each required an out-of-band `gcloud run services update` to re-enable it; this fix makes the full value stick.

### Migration
- **None** — deploy.yml-only change. Fast deploy, no table rewrite.

### Post-deploy verification
- Confirm the live value is now `en,de` and **stays** there from the pipeline (no out-of-band patch needed): `gcloud run services describe aifeelnews-web --region=europe-west1 --format=json | ...`.
- This is the test that the escape worked — if it's `en,de` after a clean deploy, the recurring revert is fixed for good.
