### PR TITLE
fix(backfill): set language on BigQuery entity + category events

### DIFF
--- a/app/jobs/backfill_bigquery.py
+++ b/app/jobs/backfill_bigquery.py
@@ -235,6 +235,7 @@ def backfill_entity_events(
                 Entity.wikipedia_url,
                 Article.sentiment_label,
                 Article.sentiment_score,
+                Article.language,
             )
             .join(Entity, ArticleEntity.entity_id == Entity.id)
             .join(Article, ArticleEntity.article_id == Article.id)
@@ -283,6 +284,7 @@ def backfill_entity_events(
                     "wikipedia_url": row.wikipedia_url,
                     "sentiment_label": row.sentiment_label,
                     "sentiment_score": row.sentiment_score,
+                    "language": row.language,
                 }
             )
 
@@ -333,6 +335,7 @@ def backfill_category_events(
                 ArticleCategory.confidence.label("category_confidence"),
                 Article.sentiment_label,
                 Article.sentiment_score,
+                Article.language,
             )
             .join(Article, ArticleCategory.article_id == Article.id)
             .join(Source, Article.source_id == Source.id)
@@ -377,6 +380,7 @@ def backfill_category_events(
                     "category_confidence": row.category_confidence,
                     "sentiment_label": row.sentiment_label,
                     "sentiment_score": row.sentiment_score,
+                    "language": row.language,
                 }
             )
 


### PR DESCRIPTION
Follow-up to #183 (the `_ensure_table` self-heal). `backfill_bigquery` only set the `language` field on *sentiment* events; the entity and category event rows omitted it, so backfilled German entity/category events landed with `language=NULL` and the dashboard's `language=de` filter returned nothing for those two BigQuery charts.

Both queries now select `Article.language` and include it in the row dicts, matching the sentiment-event path and the live `queue_*_event()` functions.

**Verified against prod end-to-end** (ran the backfill): `entity_events` now carry `language='de'` (8,037 rows) and `category_events` (326); `get_top_entities(language='de')` and `get_nlp_categories(language='de')` return 20 rows each; the live German dashboard charts populate with no BQ errors.

23 tests pass; ruff + mypy clean.