### PR TITLE
chore(demo): reproducible credential-free demo + dev ergonomics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Normalize line endings so files behave the same on every clone (Windows,
+# macOS, Linux, CI). Without this, a Windows checkout can introduce CRLF into
+# files that MUST be LF — notably shell scripts, which fail inside Linux
+# containers with "bad interpreter" / "command not found" when they carry \r.
+
+# Default: let Git decide text vs binary, normalize text to LF in the repo.
+* text=auto eol=lf
+
+# Files that MUST be LF regardless of platform (executed in Linux containers
+# or parsed by tools sensitive to \r).
+*.sh            text eol=lf
+Makefile        text eol=lf
+Dockerfile*     text eol=lf
+*.dockerfile    text eol=lf
+docker/**       text eol=lf
+*.py            text eol=lf
+*.toml          text eol=lf
+*.cfg           text eol=lf
+*.ini           text eol=lf
+*.yml           text eol=lf
+*.yaml          text eol=lf
+*.json          text eol=lf
+*.ts            text eol=lf
+*.tsx           text eol=lf
+*.js            text eol=lf
+*.svelte        text eol=lf
+*.css           text eol=lf
+*.html          text eol=lf
+*.md            text eol=lf
+*.sql           text eol=lf
+*.tf            text eol=lf
+
+# Binary files — never touch their bytes (no EOL conversion, no diffing).
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.svg           binary
+*.pdf           binary
+*.woff          binary
+*.woff2         binary
+*.drawio        binary

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,79 @@
-.PHONY: reset-db ingest pipeline migrate env-init
+.PHONY: reset-db ingest pipeline migrate env-init \
+        demo demo-full frontend up down logs seed seed-reset pipeline-up
+
+# --------------------------------------------------------------------------- #
+# Docker demo (recommended for a clean, reproducible local run)
+# --------------------------------------------------------------------------- #
+# `make demo` brings up Postgres + the web API and loads the bundled enriched
+# seed — a deterministic 75-article (EN + DE) dataset with sentiment, entities
+# and categories, so every analytics chart populates offline. No API keys, no
+# GCP project. The worker + scheduler are NOT started (they live behind the
+# `pipeline` compose profile), so nothing pulls live data over the seed.
+#
+# `make demo` is backend-only and returns immediately (containers run detached),
+# which is what backend work / CI / "just the API" want. `make demo-full` adds
+# the Svelte frontend on top — it ends in `npm run dev`, a long-running
+# foreground process you watch and Ctrl-C. Two targets on purpose: only the
+# full-stack demo should pin the terminal.
+
+demo: up
+	@echo "⏳ Waiting for web to become healthy…"
+	@for i in $$(seq 1 30); do \
+		if [ "$$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8002/health 2>/dev/null)" = "200" ]; then \
+			echo "✅ web is up"; break; \
+		fi; sleep 3; \
+	done
+	@echo "🌱 Seeding the demo dataset…"
+	docker compose exec -T web python -m app.seeds.seed_db
+	@echo "🎉 Demo ready → http://localhost:8002/docs (API) · http://localhost:8002/metrics"
+
+# Full-stack demo: backend + seed (via `demo`), then the Svelte SPA. The
+# frontend setup is idempotent — .env is created only if missing and npm install
+# is a fast no-op once deps are cached. Ends in `npm run dev`, which BLOCKS in
+# the foreground (the dev server you watch); Ctrl-C stops the frontend, then
+# `make down` stops the backend. No credentials needed — the article feed and
+# the whole Analytics dashboard read only public endpoints.
+demo-full: demo frontend
+
+# Start just the Svelte dev server (assumes the backend is already up, e.g. via
+# `make demo`). api.ts auto-detects localhost → http://127.0.0.1:8002.
+frontend:
+	@echo "🎨 Preparing the frontend…"
+	cd frontend && { [ -f .env ] || cp .env.example .env; } && npm install
+	@echo "🚀 Starting the Svelte dev server → http://localhost:5173 (Ctrl-C to stop)"
+	cd frontend && npm run dev
+
+# Start only db + web (the default compose profile excludes worker/scheduler).
+up:
+	@echo "🐳 Starting db + web…"
+	docker compose up --build -d db web
+
+down:
+	@echo "🛑 Stopping the stack (keeps the postgres volume)…"
+	docker compose down
+
+logs:
+	docker compose logs -f web
+
+# Load the bundled seed into the running web container.
+seed:
+	@echo "🌱 Seeding the demo dataset…"
+	docker compose exec -T web python -m app.seeds.seed_db
+
+# Wipe seed-derived rows first, then reload (idempotent full refresh).
+seed-reset:
+	@echo "🌱 Reseeding (reset)…"
+	docker compose exec -T web python -m app.seeds.seed_db --reset
+
+# Opt in to the live crawl/ingest pipeline (adds worker + scheduler).
+# Requires a paid Mediastack key in .env to actually fetch new articles.
+pipeline-up:
+	@echo "🚀 Starting the full pipeline (db + web + worker + scheduler)…"
+	docker compose --profile pipeline up --build -d
+
+# --------------------------------------------------------------------------- #
+# Bare-metal helpers (host Python, no Docker)
+# --------------------------------------------------------------------------- #
 
 # Create a local .env from the tracked template (only the template ships in
 # the repo; there are no .env.local/.env.docker files to switch between).

--- a/README.md
+++ b/README.md
@@ -38,42 +38,61 @@ The project has two distinct local-run modes:
 
 | Mode | Sentiment | Articles | Credentials needed |
 |---|---|---|---|
-| **Demo** (default in `.env.example`) | VADER | Bundled seed dataset (50 articles) | None |
+| **Demo** (default in `.env.example`) | VADER | Bundled seed dataset (75 articles, English + German) | None |
 | **Production-equivalent** | GCP NL (entities + categories) | Live Mediastack ingestion | GCP service account JSON + paid Mediastack key |
 
-Demo mode is fully self-contained — no API keys, no GCP project. The bundled seed has sentiment pre-populated, and the seeder anchors the dates so the newest article lands ~1 day ago (the default *Last 30 days* dashboard range always has data). The six Analytics charts backed by the PostgreSQL `db-analytics` endpoints — mood-over-time (rolling average), source ranking, sentiment-by-category, trending names, and cumulative volume — populate out of the box, because they query the operational database directly rather than BigQuery. The "AI-Enriched Insights" row (Top Entities + topic classification) stays empty in demo mode: it is BigQuery/GCP-NL-backed, and VADER does not produce entity or category data. Running the worker with `--queue-crawl-jobs` (see below) populates `article_contents` and `sentiment_analyses` from the live article URLs.
+Demo mode is fully self-contained — no API keys, no GCP project. The bundled seed is a **fully enriched** production sample: 75 articles (50 English + 25 German) with sentiment, magnitude, GCP-NL entities, and topic categories pre-populated, spread across several days so the trend lines show a real tendency. The seeder anchors the dates so the newest article lands ~1 day ago (the default *Last 30 days* dashboard range always has data), and shifts the entity/category `analyzed_at` timestamps by the same offset so the trending-names window stays valid. The six Analytics charts backed by the PostgreSQL `db-analytics` endpoints — mood-over-time (rolling average), source ranking, sentiment-by-category, **trending names** (entity momentum), and cumulative volume — populate out of the box, because they query the operational database (which the seed enriches) directly rather than BigQuery. The "AI-Enriched Insights" row (Top Entities + topic classification) is **BigQuery**-backed and stays empty in demo mode, since BigQuery streaming requires a GCP project; the same entity/category data is present in Postgres, so the trending-names chart still renders. Running the worker with `--queue-crawl-jobs` (see below) populates `article_contents` and `sentiment_analyses` from the live article URLs.
 
 Production-equivalent mode requires real credentials: a GCP service account JSON with the Cloud Natural Language API enabled, and a paid Mediastack key — the free tier is HTTP-only and the project enforces HTTPS in [`app/config/ingestion.py:7`](app/config/ingestion.py#L7), so a free key will not authenticate. Both are project secrets and not shipped with the repo.
 
 ### Recommended: Docker Compose
 
-Compose brings up Postgres, the FastAPI service, the worker, and the scheduler in one shot. The Alembic migration chain uses Postgres-only DDL (views, PL/pgSQL functions, triggers), so a Postgres-backed setup is the path that mirrors production.
+The Alembic migration chain uses Postgres-only DDL (views, PL/pgSQL functions, triggers), so a Postgres-backed setup is the path that mirrors production. The fastest clean start is one command:
 
 ```bash
-cp .env.example .env                        # committed defaults run demo mode
-docker-compose up --build                   # first build ~2-3 min; subsequent boots are seconds
-docker-compose exec web python -m app.seeds.seed_db   # bundled 50-article snapshot
+cp .env.example .env   # committed defaults run demo mode — no API keys
+make demo              # build, start Postgres + web, wait healthy, load the seed
 ```
 
-To exercise the **full ingestion pipeline** (robots.txt check, body extraction, sentiment + entity analysis on real article URLs), pass `--queue-crawl-jobs`:
+`make demo` brings up **only** Postgres and the web API, then loads the bundled enriched bilingual seed — a deterministic 75-article (50 EN + 25 DE) dataset with sentiment, magnitude, entities, and categories, so every analytics chart populates offline. Open <http://localhost:8002/docs>. The worker and scheduler are **not** started by default, so nothing pulls live data over the seed and the dataset is reproducible run-to-run.
+
+> `make` shells out to `sh`; on Windows use Git Bash / WSL, or run the equivalent raw commands below. Other handy targets: `make seed` / `make seed-reset` (reload the seed), `make down`, `make logs`.
+
+Raw Compose, if you prefer not to use `make`:
 
 ```bash
-docker-compose exec web python -m app.seeds.seed_db --queue-crawl-jobs
-docker-compose logs -f worker      # watch the worker drain the queue
+docker compose up --build -d db web                  # db + web only (the default profile)
+docker compose exec web python -m app.seeds.seed_db  # load the bundled enriched seed
 ```
 
-The seed URLs are real public URLs (BBC, The Guardian, Reuters, etc., sampled from production). Some will not crawl successfully — they may have been moved or removed (`status=FAILED`), be denied by `robots.txt` (`status=FORBIDDEN_BY_ROBOTS`), or hit the per-host rate limit (`status=RATE_LIMITED`, retried later). That is the intended behavior of the worker; failures are surfaced in `crawl_jobs.status` and visible at `GET /metrics`.
+To exercise the **full ingestion pipeline** (live Mediastack fetch + robots.txt-respecting crawl + sentiment/entity analysis), opt in to the `pipeline` profile, which adds the worker and the hourly scheduler. This needs a paid Mediastack key in `.env` to fetch new articles:
 
-Frontend runs separately (the SPA is a Vite + Svelte 5 app, not part of Compose):
+```bash
+make pipeline-up                                     # or: docker compose --profile pipeline up --build -d
+docker compose logs -f worker                        # watch the worker drain the crawl queue
+```
+
+Alternatively, queue crawl jobs for the **seeded** article URLs without live ingestion, then start the worker:
+
+```bash
+docker compose exec web python -m app.seeds.seed_db --queue-crawl-jobs
+docker compose --profile pipeline up -d worker
+```
+
+The seed URLs are real public URLs (BBC, NYTimes, Spiegel, etc., sampled from production). Some will not crawl successfully — they may have been moved or removed (`status=FAILED`), be denied by `robots.txt` (`status=FORBIDDEN_BY_ROBOTS`), or hit the per-host rate limit (`status=RATE_LIMITED`, retried later). That is the intended behavior of the worker; failures are surfaced in `crawl_jobs.status` and visible at `GET /metrics`.
+
+Frontend runs separately (the SPA is a Vite + Svelte 5 app, not part of Compose). With the demo backend already up (`make demo`), this is all it takes:
 
 ```bash
 cd frontend
 cp .env.example .env
-# For docker-compose backend: no override needed — api.ts auto-detects
+# For the docker-compose backend: no override needed — api.ts auto-detects
 # localhost and uses DEFAULT_LOCAL_API_BASE (http://127.0.0.1:8002).
 # Set VITE_API_BASE_URL in .env.local only if you need a non-default host/port.
-npm install && npm run dev
+npm install && npm run dev   # → http://localhost:5173
 ```
+
+Both the **article feed** and the full **Analytics dashboard** (mood-over-time, source ranking, sentiment-by-category, trending names, cumulative volume) load **without signing in** — they read only public, unauthenticated endpoints. The Firebase keys in `.env.example` are placeholders; the app falls back to a no-auth demo mode (a harmless "Firebase not configured" console note). The **only** feature that needs real Firebase config is **Sign in with Google → Bookmarks** (per-user data). So an assessor can boot the entire project, browse the EN/DE feed, and explore every chart with **zero credentials**. The "AI-Enriched Insights" row (Top Entities / topic classification) is BigQuery-backed and stays empty offline — the same entity data drives the trending-names chart from Postgres.
 
 Backend services:
 
@@ -118,7 +137,7 @@ alembic downgrade -1              # Rollback last migration
 alembic history                   # View migration history
 ```
 
-**Loading sample data.** A static seed dataset of 50 articles across 10 sources (sampled from production with PII removed) is bundled at `app/seeds/seed_data.json`. Load it after running migrations:
+**Loading sample data.** A static, fully enriched seed dataset of 75 articles (50 English + 25 German) across 15 sources — with sentiment, magnitude, GCP-NL entities, and topic categories, sampled from production with PII removed — is bundled at `app/seeds/seed_data.json`. Load it after running migrations:
 
 ```bash
 python -m app.seeds.seed_db                       # idempotent: safe to re-run, skips existing URLs

--- a/app/main.py
+++ b/app/main.py
@@ -41,7 +41,26 @@ logger.info(
 )
 
 APP_VERSION = os.getenv("APP_VERSION", "1.0.1")
-app = FastAPI(title="aiFeelNews API", version=APP_VERSION)
+app = FastAPI(
+    title="aiFeelNews API",
+    version=APP_VERSION,
+    description=(
+        "News sentiment-analysis API. Ingests articles (English + German), "
+        "crawls original content (robots.txt-respecting), and annotates "
+        "sentiment, entities, and topic categories via Google Cloud Natural "
+        "Language.\n\n"
+        "- **Articles / Sources / Entities** — the read API behind the SPA "
+        "(search, filtering, full-text).\n"
+        "- **Analytics** — BigQuery-backed trends, entity, and pipeline-health "
+        "queries.\n"
+        "- **DB Analytics** — real-time PostgreSQL analytics (window functions, "
+        "CTEs, `GROUPING SETS`).\n"
+        "- **Bookmarks** — per-user, requires a Firebase ID token.\n\n"
+        "All data endpoints live under the single `/api/v1` namespace; "
+        "`/health`, `/ready`, `/version`, and `/metrics` are unversioned "
+        "infrastructure probes."
+    ),
+)
 
 # --- Rate limiting (slowapi) -------------------------------------------------
 # The shared limiter (app/deps/ratelimit.py) is registered on app.state so the
@@ -119,10 +138,13 @@ app.add_middleware(
 # API has one versioned namespace (no unprefixed legacy paths). Operational
 # endpoints (/health, /ready, /version, /metrics) stay unprefixed by design —
 # they're infrastructure probes, not part of the versioned data API.
-app.include_router(users.router, prefix="/api/v1/users", tags=["Users"])
-app.include_router(articles.router, prefix="/api/v1/articles", tags=["Articles"])
-app.include_router(bookmarks.router, prefix="/api/v1/bookmarks", tags=["Bookmarks"])
-app.include_router(sources.router, prefix="/api/v1/sources", tags=["Sources"])
+# Each router declares its own ``tags=`` (see app/routers/*.py); we do NOT
+# repeat the tag here or FastAPI concatenates them and Swagger shows a doubled
+# label ("Articles / Articles"). Prefix only.
+app.include_router(users.router, prefix="/api/v1/users")
+app.include_router(articles.router, prefix="/api/v1/articles")
+app.include_router(bookmarks.router, prefix="/api/v1/bookmarks")
+app.include_router(sources.router, prefix="/api/v1/sources")
 app.include_router(sentiment.router, prefix="/api/v1/sentiment")
 app.include_router(entities.router, prefix="/api/v1/entities")
 app.include_router(analytics.router, prefix="/api/v1/analytics")
@@ -130,12 +152,12 @@ app.include_router(analytics.router, prefix="/api/v1/analytics")
 app.include_router(db_analytics.router, prefix="/api/v1/db-analytics")
 
 
-@app.get("/")
+@app.get("/", tags=["Meta"])
 def root() -> dict[str, str]:
     return {"message": "aiFeelNews API is running"}
 
 
-@app.get("/health")
+@app.get("/health", tags=["Meta"])
 def health_check() -> dict[str, str]:
     """Health check endpoint for load balancers and monitoring."""
     try:
@@ -173,7 +195,7 @@ def get_version() -> dict[str, str]:
     }
 
 
-@app.get("/ready")
+@app.get("/ready", tags=["Meta"])
 def readiness_check() -> dict[str, str]:
     """Readiness probe — verifies DB connectivity before accepting traffic."""
     try:
@@ -265,7 +287,7 @@ def metrics(request: Request) -> dict[str, Any]:
         db.close()
 
 
-@app.post("/api/v1/trigger-ingestion")
+@app.post("/api/v1/trigger-ingestion", tags=["Operations"])
 @limiter.limit(_app_config.security.rate_limit_scheduler)
 def trigger_ingestion(
     request: Request,
@@ -304,7 +326,7 @@ def trigger_ingestion(
         )
 
 
-@app.post("/api/v1/cleanup")
+@app.post("/api/v1/cleanup", tags=["Operations"])
 @limiter.limit(_app_config.security.rate_limit_scheduler)
 def trigger_cleanup(
     request: Request,

--- a/app/routers/sentiment.py
+++ b/app/routers/sentiment.py
@@ -18,7 +18,7 @@ from app.utils.sentiment import get_sentiment_provider_info
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["sentiment"])
+router = APIRouter(tags=["Sentiment"])
 
 _RATE = config.security.rate_limit_sentiment
 

--- a/app/seeds/seed_data.json
+++ b/app/seeds/seed_data.json
@@ -1,714 +1,22499 @@
 {
   "_metadata": {
-    "generated_at": "2026-05-03T18:31:49.213927+00:00",
-    "source": "live production sample (50 rows from 10 sources, sampled from prod which holds 29812 articles across 22 sources)",
-    "article_count": 50,
-    "source_count": 10,
-    "production_total_articles": 29812,
-    "production_total_sources": 22
+    "generated_at": "2026-06-10T12:26:31.597991+00:00",
+    "source": "live production sample (75 rows — 50 EN / 25 DE — across 15 sources, sampled from prod which holds 34678 articles across 31 sources). Fully enriched: sentiment + magnitude, 2114 quality-gated entity mentions, 406 category labels.",
+    "article_count": 75,
+    "article_count_en": 50,
+    "article_count_de": 25,
+    "source_count": 15,
+    "entity_mention_count": 2114,
+    "category_count": 406,
+    "production_total_articles": 34678,
+    "production_total_sources": 31
   },
   "sources": [
     {
-      "name": "independent",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "nytimes",
-      "country": null,
-      "language": null
+      "name": "financialpost",
+      "country": "us",
+      "language": "en"
     },
     {
       "name": "bbc",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "financialpost",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "bloomberg",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "google-news",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "cnbc",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "phys",
-      "country": null,
-      "language": null
-    },
-    {
-      "name": "dw",
-      "country": null,
-      "language": null
+      "country": "gb",
+      "language": "en"
     },
     {
       "name": "guardian",
-      "country": null,
-      "language": null
+      "country": "gb",
+      "language": "en"
+    },
+    {
+      "name": "dw",
+      "country": "de",
+      "language": "en"
+    },
+    {
+      "name": "cnbc",
+      "country": "us",
+      "language": "en"
+    },
+    {
+      "name": "independent",
+      "country": "gb",
+      "language": "en"
+    },
+    {
+      "name": "phys",
+      "country": "us",
+      "language": "en"
+    },
+    {
+      "name": "iotbusinessnews",
+      "country": "us",
+      "language": "en"
+    },
+    {
+      "name": "focus",
+      "country": "de",
+      "language": "de"
+    },
+    {
+      "name": "tagesschau",
+      "country": "de",
+      "language": "de"
+    },
+    {
+      "name": "sueddeutsche",
+      "country": "de",
+      "language": "de"
+    },
+    {
+      "name": "faz",
+      "country": "de",
+      "language": "de"
+    },
+    {
+      "name": "stern",
+      "country": "de",
+      "language": "de"
+    },
+    {
+      "name": "handelsblatt",
+      "country": "de",
+      "language": "de"
+    },
+    {
+      "name": "spiegel",
+      "country": "de",
+      "language": "de"
     }
   ],
   "articles": [
     {
-      "title": "Has Bruno Fernandes equalled the Premier League assist record?",
-      "description": "Fernandes was not credited with assisting Benjamin Sesko’s goal against Liverpool, even if he got the points on Fantasy Premier League",
-      "url": "https://www.independent.co.uk/sport/football/bruno-fernandes-assist-record-fpl-man-utd-premier-league-b2969756.html",
-      "image_url": "https://static.independent.co.uk/2026/05/03/16/01KQQ6WHBR6B3ZSGJF9MB2C0C5.jpg?width=1200&auto=webp&crop=3%3A2",
-      "published_at": "2026-05-03T15:29:50+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.4000000059604645,
-      "source_name": "independent"
-    },
-    {
-      "title": "Disgruntled former employee drove car packed with explosives into Oregon sports club",
-      "description": "Investigators found a mix of pipe bombs and propane tanks inside the wreckage, with some devices failing to ignite during the crash",
-      "url": "https://www.independent.co.uk/news/world/americas/crime/oregon-vehicle-crash-athletic-club-explosives-attack-b2969742.html",
-      "image_url": "https://static.independent.co.uk/2026/05/03/00/OREGON-CLUB_DEPORTIVO-CHOQUE_47332.jpg?width=1200&auto=webp&crop=3%3A2",
-      "published_at": "2026-05-03T15:20:18+00:00",
-      "language": "en",
-      "country": "uk",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "independent"
-    },
-    {
-      "title": "Jeanine Pirro has evidence White House correspondents’ dinner suspect fired shot that hit officer",
-      "description": "The gunman was reportedly looking to target members of the Trump administration",
-      "url": "https://www.independent.co.uk/news/world/americas/jeanine-pirro-agent-shot-cole-tomas-allen-shelling-b2969752.html",
-      "image_url": "https://static.independent.co.uk/2026/05/01/01/download.jpg?width=1200&auto=webp&crop=3%3A2",
-      "published_at": "2026-05-03T15:15:50+00:00",
-      "language": "en",
-      "country": "uk",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.699999988079071,
-      "source_name": "independent"
-    },
-    {
-      "title": "‘War relic’ explodes under campfire in Austria sending five children to hospital",
-      "description": "World War Two-era bombs are still being uncovered in Austria",
-      "url": "https://www.independent.co.uk/news/world/europe/austria-war-relic-explosion-children-injured-world-war-two-b2969747.html",
-      "image_url": "https://static.independent.co.uk/2026/05/03/14/47/iStock-1257611249.jpg?width=1200&auto=webp&crop=3%3A2",
-      "published_at": "2026-05-03T14:58:43+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "independent"
-    },
-    {
-      "title": "Badenoch accuses Farage of ducking TV interview to avoid questions about £5m ‘gift’",
-      "description": "Reform UK leader has been referred to Parliament’s standards watchdog over the donation from Christopher Harborne, a Thai-based billionaire who helped bankroll Brexit",
-      "url": "https://www.independent.co.uk/news/uk/politics/badenoch-farage-reform-donation-bbc-harborne-b2969706.html",
-      "image_url": "https://static.independent.co.uk/2026/05/01/12/01KQHN2Y29D45AE77V9RYTSYWT.jpg?width=1200&auto=webp&crop=3%3A2",
-      "published_at": "2026-05-03T14:36:37+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.699999988079071,
-      "source_name": "independent"
-    },
-    {
-      "title": "Tariffs, Rebates, Chaos: Boutique Businesses Wonder What’s Next",
-      "description": "A Brooklyn general store that sells Taiwanese imports was pummeled by tariffs. A rebate would help, but the confusion still lingers.",
-      "url": "https://www.nytimes.com/2026/05/03/nyregion/nyc-tariffs-yun-hai-taiwan-pantry.html",
-      "image_url": "https://static01.nyt.com/images/2026/05/03/multimedia/03met-tariffs-nyc-01-ptmg/03met-tariffs-nyc-01-ptmg-mediumSquareAt3X.jpg",
-      "published_at": "2026-05-03T14:50:29+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "nytimes"
-    },
-    {
-      "title": "‘Wartime Relic’ Explodes Under Campfire in Austria, Injuring Five Children",
-      "description": "The children, aged 10 to 14, were taken to a hospital for treatment after the explosion in Upper Austria, the police said.",
-      "url": "https://www.nytimes.com/2026/05/03/world/europe/austria-explosion-campfire.html",
+      "title": "AGI Realigns Manufacturing to Deliver Storage Solutions Closer to U.S. Farmers",
+      "description": "Investment adds U.S. bin capacity and supports job growth in Kansas CLAY CENTER, Kan. &#8212; Ag Growth International Inc. (“AGI”) today announced a multi-million dollar investment in its Clay Center, Kansas facility to add U.S. production of 4-inch corrugated farm grain bins and strengthen its North American manufacturing network. “Adding bin capacity in the heart [&#8230;]",
+      "url": "https://financialpost.com/pmn/business-wire-news-releases-pmn/agi-realigns-manufacturing-to-deliver-storage-solutions-closer-to-u-s-farmers",
       "image_url": null,
-      "published_at": "2026-05-03T14:37:53+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.4000000059604645,
-      "source_name": "nytimes"
-    },
-    {
-      "title": "Jeeves and Ask.com Shut Down After Almost 30 Years",
-      "description": "The pioneering search engine shut down on May 1, after nearly 30 years in operation.",
-      "url": "https://www.nytimes.com/2026/05/03/business/ask-jeeves-shuts-down-internet-search-engine.html",
-      "image_url": "https://static01.nyt.com/images/2026/05/03/multimedia/03xp-Jeeves1/03xp-Jeeves1-mediumSquareAt3X.jpg",
-      "published_at": "2026-05-03T14:36:35+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "technology",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.4000000059604645,
-      "source_name": "nytimes"
-    },
-    {
-      "title": "‘Wartime Relic’ Explodes Under Campfire in Austria, Injuring Five Children",
-      "description": "The children, aged between 10 and 14, were transported to a hospital for treatment after the explosion in northern Upper Austria, the police said.",
-      "url": "https://www.nytimes.com/2026/05/03/world/europe/03xp-austria-explosion-campfire.html",
-      "image_url": null,
-      "published_at": "2026-05-03T13:34:39+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "general",
-      "sentiment_label": "neutral",
-      "sentiment_score": -0.20000000298023224,
-      "source_name": "nytimes"
-    },
-    {
-      "title": "Driving Electric in Costa Rica Is Surprisingly Doable",
-      "description": "The charging network is spotty, but it’s a small country.",
-      "url": "https://www.nytimes.com/2026/05/03/business/costa-rica-electric-vehicle-road-trip.html",
-      "image_url": "https://static01.nyt.com/images/2026/04/29/multimedia/00biz-ev-roadtrip-01-mgtz/00biz-ev-roadtrip-01-mgtz-mediumSquareAt3X.jpg",
-      "published_at": "2026-05-03T12:34:50+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "science",
-      "sentiment_label": "neutral",
-      "sentiment_score": -0.10000000149011612,
-      "source_name": "nytimes"
-    },
-    {
-      "title": "South African police officer lowered into crocodile-infested river to recover human remains",
-      "description": "Police suspect the human remains belong to a businessman swept away by floodwater last week.",
-      "url": "https://www.bbc.com/news/articles/cz92gk18xn4o",
-      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b9dc/live/aa766de0-4706-11f1-bd22-17beaec4bfbd.jpg",
-      "published_at": "2026-05-03T15:41:29+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "bbc"
-    },
-    {
-      "title": "Fish, eels and birds killed in river pollution incident",
-      "description": "Fly fishers say the salmon population at the burn in Moray has been wiped out and could take years to recover.",
-      "url": "https://www.bbc.com/news/articles/c78k57py38do",
-      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/5fea/live/142c50e0-46f0-11f1-9217-a5b6a670d3f7.jpg",
-      "published_at": "2026-05-03T15:09:30+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.4000000059604645,
-      "source_name": "bbc"
-    },
-    {
-      "title": "Sir Alex Ferguson taken to hospital as precaution before Man Utd v Liverpool",
-      "description": "Sir Alex Ferguson is taken to hospital after falling unwell at Old Trafford shortly before Manchester United's Premier League match with Liverpool on Sunday.",
-      "url": "https://www.bbc.com/sport/football/articles/c0r2nvpvylxo",
-      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/fc64/live/27c200f0-46fa-11f1-9217-a5b6a670d3f7.jpg",
-      "published_at": "2026-05-03T14:56:40+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "neutral",
-      "sentiment_score": -0.20000000298023224,
-      "source_name": "bbc"
-    },
-    {
-      "title": "Concern for jailed Iranian Nobel laureate as brother fears she is dying",
-      "description": "Her family said the 54-year-old had been taken from prison to a local hospital after a sharp deterioration in her health.",
-      "url": "https://www.bbc.com/news/articles/c362pd8epw9o",
-      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/94bb/live/7de3ccb0-4638-11f1-aa14-ad910202f501.png",
-      "published_at": "2026-05-03T14:44:04+00:00",
-      "language": "en",
-      "country": "gb",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.699999988079071,
-      "source_name": "bbc"
-    },
-    {
-      "title": "Jury convicts former Florida congressman in Venezuela lobbying case",
-      "description": "David Rivera, Marco Rubio's former housemate, was accused of accepting millions from the Maduro regime to lobby US politicians.",
-      "url": "https://www.bbc.com/news/articles/c1524vdn9dqo",
-      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/f4d5/live/b51f8060-458a-11f1-a2d5-4b93b338d3d0.jpg",
-      "published_at": "2026-05-03T14:36:27+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.699999988079071,
-      "source_name": "bbc"
-    },
-    {
-      "title": "Trump Weighs Iranian Peace Offer Without Ruling Out More Strikes",
-      "description": "US President Donald Trump said he’ll review Iran’s latest peace proposal while not ruling out a resumption of military strikes should the Islamic Republic’s rulers “misbehave.”",
-      "url": "https://financialpost.com/pmn/business-pmn/trump-weighs-iranian-peace-offer-without-ruling-out-more-strikes",
-      "image_url": null,
-      "published_at": "2026-05-03T07:53:16+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "financialpost"
-    },
-    {
-      "title": "Iran Juggles Oil Cuts and Storage Strain to Resist US Blockade",
-      "description": "As the US naval blockade in the Strait of Hormuz tightens around Iran’s oil trade, exports have plunged in recent weeks and storage is rapidly filling. Already, the country has begun curbing production, according to a senior Iranian official.",
-      "url": "https://financialpost.com/pmn/business-pmn/iran-juggles-oil-cuts-and-storage-strain-to-resist-us-blockade",
-      "image_url": null,
-      "published_at": "2026-05-02T12:54:31+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "neutral",
-      "sentiment_score": -0.10000000149011612,
-      "source_name": "financialpost"
-    },
-    {
-      "title": "Imperial Oil cuts 130 jobs as it continues a painful restructuring",
-      "description": "The move is part of its broader plan to move its headquarters outside of Calgary in the coming years",
-      "url": "https://financialpost.com/commodities/energy/oil-gas/imperial-oil-cuts-130-jobs-restructuring",
-      "image_url": null,
-      "published_at": "2026-05-02T12:16:36+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.30000001192092896,
-      "source_name": "financialpost"
-    },
-    {
-      "title": "Oil Tanker Pricing Feud Embroils a Centuries-Old London Market",
-      "description": "A legal claim from one of the world’s largest oil traders is throwing a spotlight on an arcane but critical corner of global finance — the multibillion-dollar freight market and the 282-year-old City of London institution that sits at the heart of it.",
-      "url": "https://financialpost.com/pmn/business-pmn/oil-tanker-pricing-feud-embroils-a-centuries-old-london-market",
-      "image_url": null,
-      "published_at": "2026-05-02T12:03:17+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "neutral",
-      "sentiment_score": -0.20000000298023224,
-      "source_name": "financialpost"
-    },
-    {
-      "title": "Could OPEC lose its grip on oil?",
-      "description": "The UAE leaving the OPEC+ alliance raises questions about how much control it can exert over global oil supply",
-      "url": "https://financialpost.com/commodities/energy/oil-gas/opec-grip-on-oil",
-      "image_url": null,
-      "published_at": "2026-05-01T15:24:40+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.30000001192092896,
-      "source_name": "financialpost"
-    },
-    {
-      "title": "Apple iPhone 18 Display Specs Tipped; Pro Models To Get Under-Display Face ID",
-      "description": "Apple iPhone 18 Display Specs Tipped; Pro Models To Get Under-Display Face ID",
-      "url": "https://www.ndtvprofit.com/technology/apple-iphone-18-display-specs-tipped-pro-models-to-get-under-display-face-id",
-      "image_url": null,
-      "published_at": "2026-01-15T05:19:50+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "neutral",
-      "sentiment_score": 0.0,
-      "source_name": "bloomberg"
-    },
-    {
-      "title": "US Stock Market Today: Wall Street Extends Losses, Nasdaq Down 1%; Nvidia, Microsoft Top Drags",
-      "description": "US Stock Market Today: Wall Street Extends Losses, Nasdaq Down 1%; Nvidia, Microsoft Top Drags",
-      "url": "https://www.ndtvprofit.com/markets/us-stock-market-today-wall-street-extends-losses-nasdaq-down-1-nvidia-microsoft-top-drags",
-      "image_url": null,
-      "published_at": "2026-01-14T15:34:37+00:00",
+      "published_at": "2026-06-10T02:37:37+00:00",
       "language": "en",
       "country": "us",
       "category": "business",
       "sentiment_label": "neutral",
       "sentiment_score": 0.10000000149011612,
-      "source_name": "bloomberg"
+      "sentiment_magnitude": 17.700000762939453,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "North American",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_America",
+          "mid": "/m/059g4",
+          "salience": 0.008270575664937496,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Business Wire",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Business_Wire",
+          "mid": "/m/05l0qw",
+          "salience": 0.007094741333276033,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Kansas",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kansas",
+          "mid": "/m/0488g",
+          "salience": 0.004219692666083574,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "CLAY CENTER",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Clay_Center,_Kansas",
+          "mid": "/m/0t5w2",
+          "salience": 0.0035519388038665056,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Mike Baker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mike_Baker_(CIA_officer)",
+          "mid": "/m/0b__8cg",
+          "salience": 0.0023716536816209555,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Postmedia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.0020015467889606953,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "St. Boniface",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/St._Boniface,_Winnipeg",
+          "mid": "/m/028ld3",
+          "salience": 0.00198757229372859,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0009673379827290773,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Manitoba",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manitoba",
+          "mid": "/m/04s7y",
+          "salience": 0.0005225031636655331,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Clay County",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Clay_County,_Kansas",
+          "mid": "/m/0fvct",
+          "salience": 0.0005222508916631341,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bank_of_Canada",
+          "mid": "/m/08_yv2",
+          "salience": 0.0004460281634237617,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Italy",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.0003919894224964082,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.0003917212598025799,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.0003917212598025799,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Cenovus",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cenovus_Energy",
+          "mid": "/m/0cqf7zm",
+          "salience": 0.0003915926208719611,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.000273980142083019,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "France",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 0.00017174860113300383,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.00017174860113300383,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "Brazil",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brazil",
+          "mid": "/m/015fr",
+          "salience": 0.00017174860113300383,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Agriculture & Forestry/Agricultural Equipment",
+          "confidence": 0.8706708550453186,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.5450147390365601,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Agriculture & Forestry/Crops & Seed",
+          "confidence": 0.16804921627044678,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Agriculture & Forestry/Other",
+          "confidence": 0.1269841492176056,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Manufacturing/Other",
+          "confidence": 0.1010265052318573,
+          "analyzed_at": "2026-06-10T08:02:02.644942+00:00"
+        }
+      ]
     },
     {
-      "title": "US Supreme Court Again Skips Ruling On Trump Tariffs",
-      "description": "US Supreme Court Again Skips Ruling On Trump Tariffs",
-      "url": "https://www.ndtvprofit.com/world/us-supreme-court-again-skips-ruling-on-trump-tariffs",
-      "image_url": null,
-      "published_at": "2026-01-14T15:33:09+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "positive",
-      "sentiment_score": 0.4000000059604645,
-      "source_name": "bloomberg"
-    },
-    {
-      "title": "Infosys ADR Jumps Over 8% After Q3 Results, Higher FY26 Revenue Guidance",
-      "description": "Infosys ADR Jumps Over 8% After Q3 Results, Higher FY26 Revenue Guidance",
-      "url": "https://www.ndtvprofit.com/markets/infosys-adr-jumps-over-8-after-q3-results-higher-fy26-revenue-guidance",
-      "image_url": null,
-      "published_at": "2026-01-14T14:51:57+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "neutral",
-      "sentiment_score": 0.0,
-      "source_name": "bloomberg"
-    },
-    {
-      "title": "Baby Girl ‘Sold’ For Rs 35,000 Rescued In Odisha’s Bhadrak",
-      "description": "Baby Girl ‘Sold’ For Rs 35,000 Rescued In Odisha’s Bhadrak",
-      "url": "https://www.ndtvprofit.com/nation/baby-girl-sold-for-rs-35000-rescued-in-odishas-bhadrak",
-      "image_url": null,
-      "published_at": "2026-01-14T14:41:32+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "business",
-      "sentiment_label": "neutral",
-      "sentiment_score": 0.0,
-      "source_name": "bloomberg"
-    },
-    {
-      "title": "I went to A&E with a stomach pain - then I was told I’d need an 11-seater car - The Sun",
-      "description": "I went to A&E with a stomach pain - then I was told I’d need an 11-seater car&nbsp;&nbsp;The Sun",
-      "url": "https://news.google.com/rss/articles/CBMijAFBVV95cUxNTXlwZTloS0dmOU82a2tJSWxkYzRvSjlTZzJrallQV3BTX2F1cVU4bWRUTVdWdUlhZGdoR0NHMVJEOWx0MXBiVl9HUGxvVU1SbTlsa0Y1ZG9tZFBfeDc1azQ5YWNiLWhZY3UyN2k5QmVyN2gyS1E3YnJ0WmgtRWxZbXFnNkQxWXdNeFRJdw",
-      "image_url": null,
-      "published_at": "2026-05-03T14:56:58+00:00",
+      "title": "Man arrested on suspicion of attempted murder after 'brutal' knife attack in Belfast",
+      "description": "A man in his 30s, who police believe to be Somali, remains in custody after the incident and the victim is in a serious condition.",
+      "url": "https://www.bbc.com/news/articles/cdejnjdg08eo",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/56ea/live/9b4f6d90-63cf-11f1-b048-bfb92c644ab6.jpg",
+      "published_at": "2026-06-09T09:44:42+00:00",
       "language": "en",
       "country": "gb",
-      "category": "health",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "google-news"
-    },
-    {
-      "title": "US Iran war news LIVE: Iran Guards warn US faces 'impossible' military option or 'bad deal' - Hindustan Times",
-      "description": "US Iran war news LIVE: Iran Guards warn US faces 'impossible' military option or 'bad deal'&nbsp;&nbsp;Hindustan TimesView Full coverage on Google News",
-      "url": "https://news.google.com/rss/articles/CBMiiwJBVV95cUxPSlN3Z20xVUVZVnhQQnJnWXJBTWZVNVM4T0tCOXlCeHpFQjVicmQ5LURYVTZ6U1kxTUZwQU9La3ZCQ1BQZDdLdmdFcVI4LWl4TlVzTGQwVndFeHpZQVhpakFNTl9Qb0xUbWVHTkdUaDVHVExrOGU2VkNLMVg1dFFxdjJlWmRCdW5lZElEVk9teGxCei0zSWRsZXJ5UTA3X1F0eERzS1ptNDVCWEo1NklzVGtpWVV6M2hVcUFSTUxBSmhyUXJsUC1FeTVpZFBqQVk3d3pKSzRLTUN1cGpSMGUyODlJdWdxaE5zMlMyWDczSjZnQ0ktYmRIM0d1dFFnT0VsWHN5dFlKT25WMEU",
-      "image_url": null,
-      "published_at": "2026-05-03T10:13:56+00:00",
-      "language": "en",
-      "country": "in",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "google-news"
-    },
-    {
-      "title": "4 subtle signs you aren’t eating enough protein - The Washington Post",
-      "description": "4 subtle signs you aren’t eating enough protein&nbsp;&nbsp;The Washington PostThe Rise in High Protein Diets: Is Food Political?&nbsp;&nbsp;Brig Newspaper",
-      "url": "https://news.google.com/rss/articles/CBMigwFBVV95cUxQWFhJU1Y2aTZTV3dSdlMzSERja2ktY1lKRzlMcGRNbjNrZUdqVXpQQUZ3OWZ1SzVnY0IxaGxTYTZUUXFYVHBsX2xYRlVrSjByZzZXcnFCWDc4YXhscjcxQkNrUmlYWFBvemZmbmZzRXJGR1Q3ODlJTkxMb0dkcHFOd0dZWQ",
-      "image_url": null,
-      "published_at": "2026-05-03T10:12:36+00:00",
-      "language": "en",
-      "country": "ca",
-      "category": "health",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.30000001192092896,
-      "source_name": "google-news"
-    },
-    {
-      "title": "US Iran war news LIVE: ‘Iran has not yet paid big enough price for what it has done to humanity’, says Trump | World News - Hindustan Times",
-      "description": "US Iran war news LIVE: ‘Iran has not yet paid big enough price for what it has done to humanity’, says Trump | World News&nbsp;&nbsp;Hindustan TimesTrump expresses doubt that Iran’s peace proposal is ‘acceptable’&nbsp;&nbsp;Al Jazeera'If they misbehave…': Trump warns of fresh strikes, says he wants to 'eliminate' Iran's missile capability&nbsp;&nbsp;The Times of IndiaTrump warns US could restart Iran strikes if Tehran ‘misbehaves’ even as he reviews proposed deal&nbsp;&nbsp;India TodayDonald Trump says if Iran ‘misbehaves’, there could be ‘possibility’ of strikes&nbsp;&...",
-      "url": "https://news.google.com/rss/articles/CBMiiwJBVV95cUxPSlN3Z20xVUVZVnhQQnJnWXJBTWZVNVM4T0tCOXlCeHpFQjVicmQ5LURYVTZ6U1kxTUZwQU9La3ZCQ1BQZDdLdmdFcVI4LWl4TlVzTGQwVndFeHpZQVhpakFNTl9Qb0xUbWVHTkdUaDVHVExrOGU2VkNLMVg1dFFxdjJlWmRCdW5lZElEVk9teGxCei0zSWRsZXJ5UTA3X1F0eERzS1ptNDVCWEo1NklzVGtpWVV6M2hVcUFSTUxBSmhyUXJsUC1FeTVpZFBqQVk3d3pKSzRLTUN1cGpSMGUyODlJdWdxaE5zMlMyWDczSjZnQ0ktYmRIM0d1dFFnT0VsWHN5dFlKT25WMEXSAZACQVVfeXFMUDIzV1p3eXZDb3NhX1NXcHlHYTJPQ3hkVnJXYjc2eU5QY29aV3RBZlU5dkE3OElUajl1eHljY2RtZG1CRW5OUFRhaFRIMkk3WllfU09YY0hRT1NRLXl2NjA5TTdkMEdoNEZaXzR6ZnU0bUhLTi1GTlRnX1JaanZRR04tQlI3RFlLVGNwTjA5M01WQUJWYW16aFFRS2didXNsU2Niakp3SE9USW0xWjJIejBxY2dJSVNoU0ZlNUJvbHhvb2xPOUVjTmZ0cDczeUs3LWw2ZVVYYlZGckRESjhxWThNUVpEX1dkTkJPdWs1WDByc1I0ZzYyZ21xbGd5V1BuaFE2VHY1N2V2NkVYR1FRLWU",
-      "image_url": null,
-      "published_at": "2026-05-03T09:51:36+00:00",
-      "language": "en",
-      "country": "in",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.699999988079071,
-      "source_name": "google-news"
-    },
-    {
-      "title": "Brutal ‘rape festival’ stuns the world - News.com.au",
-      "description": "Brutal ‘rape festival’ stuns the world&nbsp;&nbsp;News.com.au",
-      "url": "https://news.google.com/rss/articles/CBMi0AFBVV95cUxQVWZzMGhfbWljcDJjR2ExRm5xeVBVSkhscWY3YkFEY2U4ZG5XMjhzUHA4X1hJazh6MFNoTWhmTk9SZS0zYmR6MVJISjJZMkRVSEN2R3dQTVVrdWJVTGotYXRZa1VVTGh0eXpEVXBiTjhJek9ONnA5WUtpOHNoeVQ0dmxvT2tUeUV0cFN5ZklMVmozd29XRkVkZ0cwbWtDdHVxTHZyUkhocTM2ZjdDWkNBWUl5YXp1RUZ4bGFJOUQ4aEQwYW5YU3dFeFkwaFRLaGs4",
-      "image_url": null,
-      "published_at": "2026-05-03T05:08:32+00:00",
-      "language": "en",
-      "country": "au",
       "category": "general",
       "sentiment_label": "negative",
       "sentiment_score": -0.30000001192092896,
-      "source_name": "google-news"
+      "sentiment_magnitude": 38.0,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Democratic Unionist Party",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Democratic_Unionist_Party",
+          "mid": "/m/01gb1c",
+          "salience": 0.053427185863256454,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Northern Ireland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Northern_Ireland",
+          "mid": "/m/05bcl",
+          "salience": 0.02118690311908722,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Belfast",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belfast",
+          "mid": "/m/01l63",
+          "salience": 0.011141549795866013,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Gavin Robinson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gavin_Robinson",
+          "mid": "/m/0j_4bll",
+          "salience": 0.0076096258126199245,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Police Service of Northern Ireland",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Police_Service_of_Northern_Ireland",
+          "mid": "/m/01qzpl",
+          "salience": 0.0060156891122460365,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.0053465659730136395,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "BBC News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC",
+          "mid": "/m/0ncl8zk",
+          "salience": 0.00413045659661293,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.003984993789345026,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Michelle O'Neill",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michelle_O'Neill",
+          "mid": "/m/02pxlkg",
+          "salience": 0.0030409267637878656,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Dublin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dublin",
+          "mid": "/m/02cft",
+          "salience": 0.0028013777919113636,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Nigel Farage",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nigel_Farage",
+          "mid": "/m/025qb6",
+          "salience": 0.0012572818668559194,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Emma Little-Pengelly",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emma_Little-Pengelly",
+          "mid": "/g/11bw63qbn5",
+          "salience": 0.0011547291651368141,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Sudanese",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sudan",
+          "mid": "/m/06tw8",
+          "salience": 0.0009563965140841901,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Jim Allister",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jim_Allister",
+          "mid": "/m/035ymk",
+          "salience": 0.0009183241636492312,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Rupert Lowe",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rupert_Lowe",
+          "mid": "/m/03p_qr",
+          "salience": 0.0008685158682055771,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0008506778976880014,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Somali",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Somalia",
+          "mid": "/m/06tgw",
+          "salience": 0.0007069425191730261,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Naomi Long",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Naomi_Long",
+          "mid": "/m/05sqmb",
+          "salience": 0.0006364298751577735,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "House of Commons",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/House_of_Commons_of_the_United_Kingdom",
+          "mid": "/m/03ljr",
+          "salience": 0.0005944224540144205,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Hilary Benn",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hilary_Benn",
+          "mid": "/m/01t5w7",
+          "salience": 0.0005042279954068363,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "County Antrim",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/County_Antrim",
+          "mid": "/g/11bc612gjg",
+          "salience": 0.00047661515418440104,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Ballymena",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ballymena",
+          "mid": "/m/04_zbj",
+          "salience": 0.00047661515418440104,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Belfast North",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belfast_North_(UK_Parliament_constituency)",
+          "mid": "/m/03jjv8",
+          "salience": 0.00043470802484080195,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Conservative Party",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Conservative_Party_(UK)",
+          "mid": "/m/07wpm",
+          "salience": 0.00036987054045312107,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Reform Party",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Reform_UK",
+          "mid": "/g/11h0j_f4n6",
+          "salience": 0.0003696026105899364,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Traditional Unionist Voice",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Traditional_Unionist_Voice",
+          "mid": "/m/03d95ys",
+          "salience": 0.0002577355189714581,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Alliance Party",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alliance_Party_of_Northern_Ireland",
+          "mid": "/m/01_7yn",
+          "salience": 0.00023236058768816292,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Kemi Badenoch",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kemi_Badenoch",
+          "mid": "/g/11bw8fq3s2",
+          "salience": 0.0002284898655489087,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Sinn Féin",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sinn_Féin",
+          "mid": "/m/06_72",
+          "salience": 0.00014353955339174718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Jon Burrows",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jon_Burrows",
+          "mid": "/g/11yh39pvl0",
+          "salience": 0.00014353955339174718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "UUP",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ulster_Unionist_Party",
+          "mid": "/m/0j8cs",
+          "salience": 0.00014353955339174718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "Claire Hanna",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Claire_Hanna",
+          "mid": "/g/11bwcf5m3f",
+          "salience": 0.00014353955339174718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "SDLP",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Social_Democratic_and_Labour_Party",
+          "mid": "/m/016k2w",
+          "salience": 0.00014353955339174718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.9834191203117371,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.34860464930534363,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.2589338719844818,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Law Enforcement",
+          "confidence": 0.23940283060073853,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.23849084973335266,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.1376153528690338,
+          "analyzed_at": "2026-06-09T16:03:38.432149+00:00"
+        }
+      ]
     },
     {
-      "title": "Pirro reveals new Trump attack evidence; Cole Allen challenges 'suicide precautions'",
-      "description": "Until U.S. Attorney Jeanine Pirro's comments, prosecutors had not disclosed whose bullet hit the agent.",
-      "url": "https://www.cnbc.com/2026/05/03/trump-assassination-cole-allen-suicide-pirro.html",
-      "image_url": null,
-      "published_at": "2026-05-03T15:10:46+00:00",
+      "title": "Widow 'distressed' by firm's nine-month delay to husband's pension",
+      "description": "BBC Scotland has heard testimony from people affected by delays in pensions managed by outsourcing firm Capita.",
+      "url": "https://www.bbc.com/news/articles/c1m2mjxz7mmo",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/6cf6/live/ad334c30-60ea-11f1-89a3-d1f559421220.jpg",
+      "published_at": "2026-06-08T05:21:56+00:00",
       "language": "en",
-      "country": "us",
+      "country": "gb",
       "category": "general",
       "sentiment_label": "negative",
       "sentiment_score": -0.4000000059604645,
-      "source_name": "cnbc"
+      "sentiment_magnitude": 39.79999923706055,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Capita",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Capita",
+          "mid": "/m/06fftw",
+          "salience": 0.7135035991668701,
+          "mention_count": 25,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Barry Donald",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Barry_Donald",
+          "mid": "/g/11byz7xp96",
+          "salience": 0.044673673808574677,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "BBC Scotland",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_Scotland",
+          "mid": "/m/02r05k",
+          "salience": 0.017133567482233047,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Social Security Scotland",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Social_Security_Scotland",
+          "mid": "/g/11f5tgf5tp",
+          "salience": 0.002326586749404669,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Nick Symonds",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nick_Thomas-Symonds",
+          "mid": "/m/01370399",
+          "salience": 0.00175873888656497,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Fran Heathcote",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fran_Heathcote",
+          "mid": "/g/11tnfb5blc",
+          "salience": 0.0014843691606074572,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0014215053524821997,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Glasgow",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Glasgow",
+          "mid": "/m/0hyxv",
+          "salience": 0.0007660827832296491,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Civil Service Pension Scheme",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Civil_Service_Retirement_System",
+          "mid": "/m/065hvc",
+          "salience": 0.0005050038453191519,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Cabinet Office",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cabinet_Office",
+          "mid": "/m/01ryjp",
+          "salience": 0.00030367501312866807,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Asda",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asda",
+          "mid": "/m/016gd7",
+          "salience": 0.0002528092300053686,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Bishopbriggs",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bishopbriggs",
+          "mid": "/m/01h09p",
+          "salience": 0.00019356828124728054,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0001562138058943674,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "PCS Union",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Public_and_Commercial_Services_Union",
+          "mid": "/m/02cwjk",
+          "salience": 0.0001165304274763912,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "Royal Mail",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://ru.wikipedia.org/wiki/Королевская_почта",
+          "mid": "/m/01z3w3",
+          "salience": 5.1137172704329714e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.647335946559906,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "/Finance/Financial Planning & Management/Retirement & Pension",
+          "confidence": 0.6398833394050598,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.1833038330078125,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.15262176096439362,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Work & Labor Issues",
+          "confidence": 0.13161376118659973,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        },
+        {
+          "name": "/People & Society/Seniors & Retirement",
+          "confidence": 0.10458516329526901,
+          "analyzed_at": "2026-06-09T08:52:35.287867+00:00"
+        }
+      ]
     },
     {
-      "title": "Healthcare cost surge makes parental paid leave benefits a target for workplace cuts",
-      "description": "As healthcare costs soar and companies search for savings, generous paid parental leave is a benefit being cut, with recent examples from Zoom and Deloitte.",
-      "url": "https://www.cnbc.com/2026/05/03/healthcare-costs-parental-paid-leave-employee-benefits-cuts.html",
-      "image_url": null,
-      "published_at": "2026-05-03T14:14:40+00:00",
+      "title": "‘I don’t think we’ve ever felt closer’: five writers on their most memorable family holidays",
+      "description": "Rallying the kids can be chaotic and frustrating, but from Interrailing all the way to Turkey to Vespa rides in Naples, these trips brought families togetherFinland has been named the world’s happiest country for nine years running, but arriving in Helsinki, dishevelled from one of my first flights with my nine-month-old baby, I was less interested in national rankings and more in having a nice nap. My husband, Jake, and I had emerged from the fog of newborn life and the idea of a holiday felt possible again. My ambitions were small: a sunset beer, a walk in the woods, reading a few pages of...",
+      "url": "https://www.theguardian.com/travel/2026/jun/07/memorable-family-holidays-interrail-naples-glamping-finland",
+      "image_url": "https://i.guim.co.uk/img/media/665527bd0a742d7d9666ce7877351c3fe55c3464/137_221_3298_2638/master/3298.jpg?width=140&quality=85&auto=format&fit=max&s=049ef319edfeeffd7bd16fbbb2901547",
+      "published_at": "2026-06-07T06:00:25+00:00",
       "language": "en",
-      "country": "us",
-      "category": "general",
-      "sentiment_label": "positive",
-      "sentiment_score": 0.6000000238418579,
-      "source_name": "cnbc"
-    },
-    {
-      "title": "Used EV sales are surging — how their ownership costs compare to gas-powered cars",
-      "description": "With more affordable electric vehicles hitting used-car lots, buyers should be aware of some ownership costs that may differ from those that come with gas cars.",
-      "url": "https://www.cnbc.com/2026/05/03/ev-ownership-costs.html",
-      "image_url": null,
-      "published_at": "2026-05-03T13:30:01+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.4000000059604645,
-      "source_name": "cnbc"
-    },
-    {
-      "title": "OPEC+ announces 188,000 barrels-per-day output increase in first meeting without UAE",
-      "description": "Concerns around production were amplified further last week with news of the UAE's shock departure.",
-      "url": "https://www.cnbc.com/2026/05/03/opec-announces-188000-barrels-per-day-output-increase-.html",
-      "image_url": null,
-      "published_at": "2026-05-03T11:28:54+00:00",
-      "language": "en",
-      "country": "us",
+      "country": "gb",
       "category": "general",
       "sentiment_label": "neutral",
       "sentiment_score": 0.10000000149011612,
-      "source_name": "cnbc"
+      "sentiment_magnitude": 56.79999923706055,
+      "source_name": "guardian",
+      "entities": [
+        {
+          "name": "Finland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Finland",
+          "mid": "/m/02vzc",
+          "salience": 0.01894083246588707,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Naples",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Naples",
+          "mid": "/m/0fhsz",
+          "salience": 0.007015720941126347,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Helsinki",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Helsinki",
+          "mid": "/m/03khn",
+          "salience": 0.0069754282012581825,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Maradona",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Diego_Maradona",
+          "mid": "/m/02c7q",
+          "salience": 0.0029324814677238464,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Kallio",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kallio",
+          "mid": "/m/06kg6d",
+          "salience": 0.0015444003511220217,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Everyman's Right",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Freedom_to_roam",
+          "mid": "/m/027l_p",
+          "salience": 0.0015389390755444765,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Kraftwerk",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kraftwerk",
+          "mid": "/m/048xh",
+          "salience": 0.0013763343449681997,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Interrailing",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Interrail",
+          "mid": "/m/0433f4",
+          "salience": 0.001160819549113512,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Norway",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Norway",
+          "mid": "/m/05b4w",
+          "salience": 0.001022977870889008,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Baltic Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Baltic_Sea",
+          "mid": "/m/01522",
+          "salience": 0.0007221503183245659,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Botox",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Botulinum_toxin",
+          "mid": "/g/120zt_4k",
+          "salience": 0.0006513053085654974,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Europe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0006153401918709278,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Brasov",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brașov",
+          "mid": "/m/0hjtg",
+          "salience": 0.0006042617605999112,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Kotka",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kotka",
+          "mid": "/m/021l12",
+          "salience": 0.0005784027744084597,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Finns",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Finns",
+          "mid": "/m/0318mh",
+          "salience": 0.0005647048819810152,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Sandringham",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sandringham_House",
+          "mid": "/m/03w3lr",
+          "salience": 0.000521530513651669,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Old Hunstanton",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hunstanton",
+          "mid": "/m/0pfg3",
+          "salience": 0.0004760588053613901,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Cornwall",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cornwall",
+          "mid": "/m/01q1j",
+          "salience": 0.0004435352748259902,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "English",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/English_language",
+          "mid": "/m/02h40lc",
+          "salience": 0.0004052589647471905,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Nigel Harris",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nigel_Harris_(American_football)",
+          "mid": "/g/11fzfcsv7b",
+          "salience": 0.00038874652818776667,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Spanish",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spanish_language",
+          "mid": "/m/06nm1",
+          "salience": 0.00038680629222653806,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Quartieri Spagnoli",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Quartieri_Spagnoli",
+          "mid": "/m/08sf49",
+          "salience": 0.00038680629222653806,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Wine",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wine",
+          "mid": "/m/081qc",
+          "salience": 0.0003862028825096786,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Vesuvius",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Vesuvius",
+          "mid": "/m/0cmnc",
+          "salience": 0.0003853744128718972,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Pompeii",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pompeii",
+          "mid": "/g/1tctbwg6",
+          "salience": 0.00038518826477229595,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Blue Grotto",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Blue_Grotto_(Capri)",
+          "mid": "/m/0255yl",
+          "salience": 0.0003845895698759705,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Sognsvann lake",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sognsvann",
+          "mid": "/m/09881n",
+          "salience": 0.00036716178874485195,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "TikTok",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/TikTok",
+          "mid": "/g/11f555cn8l",
+          "salience": 0.00035580070107243955,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Asia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asia",
+          "mid": "/m/0j0k",
+          "salience": 0.00035519577795639634,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Oslo",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oslo",
+          "mid": "/m/05l64",
+          "salience": 0.00033519844873808324,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Viking",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vikings",
+          "mid": "/m/07_my",
+          "salience": 0.00030371296452358365,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Fifa",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA",
+          "mid": "/m/02zm3",
+          "salience": 0.00028142231167294085,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Trans-Europe Express",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trans-Europe_Express_(album)",
+          "mid": "/m/01hjq39",
+          "salience": 0.0002668687666300684,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.0002665948122739792,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Airbnb",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Airbnb",
+          "mid": "/m/010qmszp",
+          "salience": 0.0002664914063643664,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Bergen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bergen",
+          "mid": "/m/0fm7s",
+          "salience": 0.0002395887131569907,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Viking Ship Museum",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Viking_Ship_Museum_(Oslo)",
+          "mid": "/m/08_syc",
+          "salience": 0.0002121784636983648,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Flåm",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flåm",
+          "mid": "/m/0621qb",
+          "salience": 0.00021210216800682247,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Flåmsbana",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flåm_Line",
+          "mid": "/m/08v11q",
+          "salience": 0.00021210216800682247,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "England",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/England",
+          "mid": "/m/02jx1",
+          "salience": 0.00021193832799326628,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Hovedøya",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hovedøya",
+          "mid": "/m/06zszf",
+          "salience": 0.00018637464381754398,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Nærøyfjord",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nærøyfjord",
+          "mid": "/m/06xyyg",
+          "salience": 0.00018627337703946978,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Italy",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.00018612947314977646,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Romania",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Romania",
+          "mid": "/m/06c1y",
+          "salience": 0.00015068042557686567,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Danube delta",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Danube_Delta",
+          "mid": "/m/0p880",
+          "salience": 0.00011714921129168943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Stuttgart",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stuttgart",
+          "mid": "/m/0727_",
+          "salience": 0.00011714921129168943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Budapest",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Budapest",
+          "mid": "/m/095w_",
+          "salience": 0.00011714921129168943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Carpathian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Carpathian_Mountains",
+          "mid": "/m/0cdsk",
+          "salience": 0.00011714921129168943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Ceaușescu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nicolae_Ceaușescu",
+          "mid": "/m/0d5hv",
+          "salience": 0.00011714921129168943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "St Pancras",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/St_Pancras_railway_station",
+          "mid": "/m/01t66l",
+          "salience": 0.00011714921129168943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "İzmir",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/İzmir_Province",
+          "mid": "/m/0282qv",
+          "salience": 0.00011713455751305446,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Bulgaria",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bulgaria",
+          "mid": "/m/015qh",
+          "salience": 0.00011713455751305446,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Istanbul",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Istanbul",
+          "mid": "/m/09949m",
+          "salience": 0.00011713455751305446,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Ankara",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ankara",
+          "mid": "/m/0jyw",
+          "salience": 0.00011713455751305446,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Selçuk",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Selçuk",
+          "mid": "/m/06dxc9",
+          "salience": 0.00011713455751305446,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Aegean",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aegean_Airlines",
+          "mid": "/m/053bnz",
+          "salience": 0.00011712005652952939,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Amsterdam",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amsterdam",
+          "mid": "/m/0k3p",
+          "salience": 0.00011710570834111422,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "ustria",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Austria",
+          "mid": "/m/0h7x",
+          "salience": 0.00011709149111993611,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Ephesus",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ephesus",
+          "mid": "/m/02p8r",
+          "salience": 0.00011703602649504319,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "Ron Watts",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ron_Watts",
+          "mid": "/m/047gbyb",
+          "salience": 0.00011702249321388081,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Travel Guides & Travelogues",
+          "confidence": 0.916764497756958,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Specialty Travel/Family Travel",
+          "confidence": 0.8331389427185059,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Other",
+          "confidence": 0.6370888948440552,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Family/Other",
+          "confidence": 0.24546588957309723,
+          "analyzed_at": "2026-06-09T08:25:20.595313+00:00"
+        }
+      ]
     },
     {
-      "title": "Top Wall Street analysts like these 3 stocks for their long-term prospects",
-      "description": "The recommendations and analysis of these Wall Street experts can provide useful insights for stock selection.",
-      "url": "https://www.cnbc.com/2026/05/03/top-street-analysts-like-these-3-stocks-for-their-long-term-prospects.html",
+      "title": "Germany news: Teen Karl to miss World Cup through injury",
+      "description": "Bayern Munich's 18-year-old midfielder Lennart Karl sustained an injury during training in Chicago. Meanwhile, politically-motivated crimes have doubled in a decade, according to a newspaper report. DW has the latest.",
+      "url": "https://www.dw.com/en/germany-news-teen-karl-to-miss-world-cup-through-injury/live-77443232",
       "image_url": null,
-      "published_at": "2026-05-03T11:13:01+00:00",
+      "published_at": "2026-06-06T11:16:00+00:00",
       "language": "en",
-      "country": "us",
+      "country": "de",
       "category": "general",
-      "sentiment_label": "positive",
-      "sentiment_score": 0.699999988079071,
-      "source_name": "cnbc"
-    },
-    {
-      "title": "Cities are getting hotter—and bigger. New research reveals the scale of the challenge",
-      "description": "We tend to think of climate change impacts as dramatic and destructive. Storms and floods that bring down landslides and swamp streets, or raging wildfires that tear through forests and farmland.",
-      "url": "https://phys.org/news/2026-04-cities-hotter-bigger-reveals-scale.html",
-      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2026/hot-city.jpg",
-      "published_at": "2026-05-03T15:30:01+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "science",
-      "sentiment_label": "neutral",
-      "sentiment_score": 0.0,
-      "source_name": "phys"
-    },
-    {
-      "title": "'GangTok': Insights into the presence of gang culture on TikTok",
-      "description": "In a new study, a University of Cincinnati sociologist and his research team are shedding light on how TikTok content produced by gang members could be used to better inform law enforcement and policymakers for more appropriate action. The team led by John Leverso, an assistant professor in the UC School of Criminal Justice, has published their research in Crime, Media, Culture: An International Journal.",
-      "url": "https://phys.org/news/2026-04-gangtok-insights-presence-gang-culture.html",
-      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2021/gang.jpg",
-      "published_at": "2026-05-03T14:00:04+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "science",
       "sentiment_label": "neutral",
       "sentiment_score": -0.10000000149011612,
-      "source_name": "phys"
+      "sentiment_magnitude": 40.400001525878906,
+      "source_name": "dw",
+      "entities": [
+        {
+          "name": "Germany",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.17124812304973602,
+          "mention_count": 43,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Alexander Zverev",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alexander_Zverev",
+          "mid": "/m/0w336lx",
+          "salience": 0.11022675782442093,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Volodymyr Zelenskyy",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Volodymyr_Zelenskyy",
+          "mid": "/m/0w4j2z1",
+          "salience": 0.02534058876335621,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Munich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Munich",
+          "mid": "/m/02h6_6p",
+          "salience": 0.020745521411299706,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Munich Airport",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Munich_Airport",
+          "mid": "/m/01nhzy",
+          "salience": 0.019663773477077484,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.019436417147517204,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Emmanuel Macron",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emmanuel_Macron",
+          "mid": "/m/011ncr8c",
+          "salience": 0.008639649488031864,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.006751269102096558,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Frank-Walter Steinmeier",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Frank-Walter_Steinmeier",
+          "mid": "/m/089zlv",
+          "salience": 0.005522659048438072,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Hamburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamburg",
+          "mid": "/m/03hrz",
+          "salience": 0.005445227492600679,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "French Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/French_Open",
+          "mid": "/m/012xcl",
+          "salience": 0.0048210639506578445,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Friedrich Merz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Friedrich_Merz",
+          "mid": "/m/069pky",
+          "salience": 0.0033463304862380028,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Frankfurt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Frankfurt",
+          "mid": "/m/02z0j",
+          "salience": 0.0032879335340112448,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Ironman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ironman_Triathlon",
+          "mid": "/m/0lbks",
+          "salience": 0.0029784056823700666,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Grand Slam",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Grand_Slam_(tennis)",
+          "mid": "/m/01c2c1",
+          "salience": 0.002662407699972391,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Saxony",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saxony",
+          "mid": "/m/070zc",
+          "salience": 0.002570684300735593,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Alternative for Germany",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alternative_for_Germany",
+          "mid": "/m/0rfdxh0",
+          "salience": 0.0023903839755803347,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0023903839755803347,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Boris Pistorius",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boris_Pistorius",
+          "mid": "/m/0cg1xfw",
+          "salience": 0.0022931257262825966,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "DW News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deutsche_Welle",
+          "mid": "/m/01qrd7",
+          "salience": 0.0015133395791053772,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Otto Fricke",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Otto_Fricke",
+          "mid": "/m/0c7j6yl",
+          "salience": 0.0014433764154091477,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "1996 Australian Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/1996_Australian_Open",
+          "mid": "/m/06b3h9",
+          "salience": 0.0014379976782947779,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Thuringia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Thuringia",
+          "mid": "/m/07nf6",
+          "salience": 0.001425157068297267,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 0.0011937724193558097,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "WDR",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Westdeutscher_Rundfunk",
+          "mid": "/m/03dhs2",
+          "salience": 0.0011237215949222445,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 0.0010869719553738832,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Marcus Hoffmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Marcus_Hoffmann",
+          "mid": "/m/0gtw9tj",
+          "salience": 0.0010505218524485826,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Bundeswehr",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bundeswehr",
+          "mid": "/m/01q9lq",
+          "salience": 0.0008846849668771029,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Sophia Schiebe",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Sophia_Schiebe",
+          "mid": "/g/11s_wlt1hh",
+          "salience": 0.0008823139360174537,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Boris Becker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boris_Becker",
+          "mid": "/m/01ckb6",
+          "salience": 0.0008796851034276187,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Vladimir Putin",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vladimir_Putin",
+          "mid": "/m/08193",
+          "salience": 0.0008586443727836013,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Flavio Cobolli",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flavio_Cobolli",
+          "mid": "/g/11f2cj2m4q",
+          "salience": 0.0006671488517895341,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Tag der Bundeswehr",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Tag_der_Bundeswehr",
+          "mid": "/g/11c6w0bz1z",
+          "salience": 0.000662652833852917,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Landrat",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Landrat",
+          "mid": "/g/1224t4lh",
+          "salience": 0.0006251935847103596,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Thomas Benninghaus",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Thomas_Benninghaus",
+          "mid": "/g/11wc8phxkz",
+          "salience": 0.0006072644027881324,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Aue-Bad Schlema",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aue-Bad_Schlema",
+          "mid": "/m/02vwb8m",
+          "salience": 0.0005969091434963048,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Deutschlandfunk",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deutschlandfunk",
+          "mid": "/m/05_myb",
+          "salience": 0.0005766078247688711,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "United States",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0005236247670836747,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Freie Sachsen",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Freie_Sachsen",
+          "mid": "/g/11k4ng5b6q",
+          "salience": 0.0004962277598679066,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "World Cup",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA_World_Cup",
+          "mid": "/m/030q7",
+          "salience": 0.0004521539085544646,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Munich 1972",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/1972_Summer_Olympics",
+          "mid": "/m/0l98s",
+          "salience": 0.00042526901233941317,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Olympic",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Olympic_Games",
+          "mid": "/m/05nd_",
+          "salience": 0.00042315872269682586,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Hamburger Abendblatt",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamburger_Abendblatt",
+          "mid": "/m/0288r0_",
+          "salience": 0.0003756042569875717,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Children's Rights",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Children's_rights",
+          "mid": "/m/03qc82m",
+          "salience": 0.0003715042839758098,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Kiel",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kiel",
+          "mid": "/m/0g7pm",
+          "salience": 0.0003405663592275232,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Hindu",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hinduism",
+          "mid": "/m/03j6c",
+          "salience": 0.00032708465005271137,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "neo-Nazi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neo-Nazism",
+          "mid": "/m/0f69h",
+          "salience": 0.00031205909908749163,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.0003099305904470384,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Mecklenburg-Western Pomerania",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mecklenburg-Vorpommern",
+          "mid": "/m/09hzw",
+          "salience": 0.0002992299559991807,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Lars Klingbeil",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lars_Klingbeil",
+          "mid": "/m/0c6bf23",
+          "salience": 0.00028854908305220306,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Ganges",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ganges",
+          "mid": "/m/038df",
+          "salience": 0.00028725690208375454,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "DOSB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Olympic_Sports_Confederation",
+          "mid": "/m/02x9gq8",
+          "salience": 0.00028668687446042895,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Armed Forces Day",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Armed_Forces_Day",
+          "mid": "/m/0fc0yx",
+          "salience": 0.00027356139617040753,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Pope Francis",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pope_Francis",
+          "mid": "/m/05ngt2",
+          "salience": 0.00027319215587340295,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Köln-Höhenberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Höhenberg_(Köln)",
+          "mid": "/g/1q66q_4t7",
+          "salience": 0.0002555522369220853,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "UN",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 0.00023229161160998046,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Christian-Albrechts University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kiel_University",
+          "mid": "/m/02p72j",
+          "salience": 0.00023224271717481315,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Spree River",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spree_(river)",
+          "mid": "/m/014_fb",
+          "salience": 0.0002318369661225006,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Adolf Hitler",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Adolf_Hitler",
+          "mid": "/m/07_m9_",
+          "salience": 0.0002233951963717118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Nazis",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nazism",
+          "mid": "/m/05hyf",
+          "salience": 0.0002233951963717118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Rhine-Ruhr",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rhine-Ruhr_metropolitan_region",
+          "mid": "/m/02j8yj",
+          "salience": 0.00022295188682619482,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Qatar",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Qatar",
+          "mid": "/m/0697s",
+          "salience": 0.00022278203687164932,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Langenwetzendorf",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Langenwetzendorf",
+          "mid": "/m/03cb1rc",
+          "salience": 0.00022267444001045078,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Greiz",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greiz_(district)",
+          "mid": "/m/01pwst",
+          "salience": 0.00022267444001045078,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Jan Frodeno",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jan_Frodeno",
+          "mid": "/m/04jfl9z",
+          "salience": 0.00022183444525580853,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "CDU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Democratic_Union_of_Germany",
+          "mid": "/m/0gg68",
+          "salience": 0.00022110265854280442,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Schleswig-Holstein",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Schleswig-Holstein",
+          "mid": "/m/06rf7",
+          "salience": 0.00020387877884786576,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Vatican",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vatican_City",
+          "mid": "/m/07ytt",
+          "salience": 0.00020371934806462377,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Neukölln",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neukölln",
+          "mid": "/m/022ndj",
+          "salience": 0.00020364331430755556,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Saalekreis",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saalekreis",
+          "mid": "/m/02vmpt0",
+          "salience": 0.00019073458679486066,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Saxony-Anhalt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saxony-Anhalt",
+          "mid": "/m/09hrc",
+          "salience": 0.0001788648369256407,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Brandenburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brandenburg",
+          "mid": "/m/017wh",
+          "salience": 0.0001684083981672302,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Saalfeld-Rudolstadt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saalfeld-Rudolstadt",
+          "mid": "/m/01zf83",
+          "salience": 0.00015358621021732688,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Middle East",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Middle_East",
+          "mid": "/m/04wsz",
+          "salience": 0.00015293296019081026,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Kyiv",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kyiv",
+          "mid": "/m/02sn34",
+          "salience": 0.00015284733672160655,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Moscow",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Moscow",
+          "mid": "/m/04swd",
+          "salience": 0.00015284733672160655,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Ostprignitz-Ruppin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ostprignitz-Ruppin",
+          "mid": "/m/0153fv",
+          "salience": 0.00015276549675036222,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Sonneberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sonneberg",
+          "mid": "/m/04vcs6",
+          "salience": 0.0001527258864371106,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Anadolu Agency",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Anadolu_Agency",
+          "mid": "/m/027bzq4",
+          "salience": 0.0001214910444105044,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Kai Havertz",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kai_Havertz",
+          "mid": "/g/11c1wqbf40",
+          "salience": 0.00012147725647082552,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Björn Höcke",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Björn_Höcke",
+          "mid": "/g/11b63dqkv3",
+          "salience": 0.00010682425636332482,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Bonn",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bonn",
+          "mid": "/m/0150n",
+          "salience": 0.00010677162936190143,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Champions League",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UEFA_Champions_League",
+          "mid": "/m/0c1q0",
+          "salience": 0.00010669648327166215,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Leroy Sane",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leroy_Sané",
+          "mid": "/m/010fksk0",
+          "salience": 0.00010668437607819214,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Bundeswehr University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Universität_der_Bundeswehr_München",
+          "mid": "/m/03cfb70",
+          "salience": 9.882912127068266e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Eurofighter",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Eurofighter_Typhoon",
+          "mid": "/m/016dy9",
+          "salience": 9.452437370782718e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Russia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 7.629273022757843e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Baltic Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Baltic_Sea",
+          "mid": "/m/01522",
+          "salience": 6.705149280605838e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Stefan Sauer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stefan_Sauer",
+          "mid": "/g/120kmx8v",
+          "salience": 6.702146492898464e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Neubiberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neubiberg",
+          "mid": "/m/03d1jt",
+          "salience": 6.70116933179088e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "Julian Nagelsmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Julian_Nagelsmann",
+          "mid": "/g/11bwjbhzf8",
+          "salience": 5.762047294410877e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Transportation/Air Travel",
+          "confidence": 0.5478546619415283,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.3470616638660431,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.2059384137392044,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        },
+        {
+          "name": "/Sports/Individual Sports/Racquet Sports",
+          "confidence": 0.16877301037311554,
+          "analyzed_at": "2026-06-10T08:05:52.542616+00:00"
+        }
+      ]
     },
     {
-      "title": "New imaging method maps reversed DNA replication forks in single cells",
-      "description": "Researchers at The University of Texas MD Anderson Cancer Center have developed a new imaging method, known as RF-SIRF, that quantitatively detects and maps reversed DNA replication forks with single-cell resolution. The results also demonstrated a unique epigenetic code for DNA replication stress that can be further examined to understand mechanisms of genomic stability, aging and treatment response.",
-      "url": "https://phys.org/news/2026-04-imaging-method-reversed-dna-replication.html",
-      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2026/imaging-tool-reveals-n.jpg",
-      "published_at": "2026-05-03T14:00:01+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "science",
-      "sentiment_label": "positive",
-      "sentiment_score": 0.4000000059604645,
-      "source_name": "phys"
-    },
-    {
-      "title": "This 'living plastic' activates and self-destructs on command",
-      "description": "Many plastic products are designed to be used only once, yet the material itself lasts for years. But a new strategy is addressing this problem by creating products that self-destruct on command, known as living plastics. These materials incorporate activatable, plastic-degrading microbes alongside the polymers. One team reporting in ACS Applied Polymer Materials used two bacterial strains that worked together and completely broke down the material within just six days, without making microplastics.",
-      "url": "https://phys.org/news/2026-04-plastic-destructs.html",
-      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2026/this-living-plastic-ac.jpg",
-      "published_at": "2026-05-03T12:00:06+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "science",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.30000001192092896,
-      "source_name": "phys"
-    },
-    {
-      "title": "Nest‑building chimpanzees seem to anticipate future weather",
-      "description": "Every evening, as they move from place to place through the forest, chimpanzees stop to build a nest—most often in a tree—to sleep in. Using a selection of branches, leaves and twigs, they create comfortable and safe spaces to get some shuteye.",
-      "url": "https://phys.org/news/2026-04-nestbuilding-chimpanzees-future-weather.html",
-      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2026/chimp.jpg",
-      "published_at": "2026-05-03T12:00:01+00:00",
-      "language": "en",
-      "country": "us",
-      "category": "science",
-      "sentiment_label": "positive",
-      "sentiment_score": 0.699999988079071,
-      "source_name": "phys"
-    },
-    {
-      "title": "Nigeria summons South Africa envoy over xenophobic incidents",
-      "description": "Nigeria joins other international voices warning against rising anti-migrant sentiment targeting Africans in South Africa.",
-      "url": "https://www.dw.com/en/nigeria-summons-south-africa-envoy-over-xenophobic-incidents/a-77023858",
+      "title": "Trump defends DOJ fund after Senate Republicans push back",
+      "description": "Trump defends DOJ fund after Senate Republicans push back",
+      "url": "https://www.cnbc.com/2026/05/22/trump-doj-fund-republicans.html",
       "image_url": null,
-      "published_at": "2026-05-03T13:32:00+00:00",
+      "published_at": "2026-05-22T14:05:01+00:00",
       "language": "en",
-      "country": "de",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.30000001192092896,
-      "source_name": "dw"
-    },
-    {
-      "title": "How Serbia's government dominates the country's media",
-      "description": "Since Serbia's ruling SNS party came to power in 2012, it has tightened its grip on the media. With an election expected soon, experts fear authorities will try to eliminate the last pockets of independent reporting.",
-      "url": "https://www.dw.com/en/how-serbia-s-government-dominates-the-country-s-media/a-77004243",
-      "image_url": null,
-      "published_at": "2026-05-03T11:52:00+00:00",
-      "language": "en",
-      "country": "de",
+      "country": "us",
       "category": "general",
       "sentiment_label": "negative",
       "sentiment_score": -0.4000000059604645,
-      "source_name": "dw"
+      "sentiment_magnitude": 22.299999237060547,
+      "source_name": "cnbc",
+      "entities": [
+        {
+          "name": "Donald Trump",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.518815815448761,
+          "mention_count": 26,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Todd Blanche",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Todd_Blanche",
+          "mid": "/g/11pxx8dgkw",
+          "salience": 0.015857478603720665,
+          "mention_count": 6,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Jodey Arrington",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jodey_Arrington",
+          "mid": "/m/0g9_f_1",
+          "salience": 0.011827715672552586,
+          "mention_count": 6,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Department of Justice",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Department_of_Justice",
+          "mid": "/m/0dtj5",
+          "salience": 0.0040887705981731415,
+          "mention_count": 6,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "White House",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/White_House",
+          "mid": "/m/081sq",
+          "salience": 0.002959224861115217,
+          "mention_count": 6,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "IRS",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Internal_Revenue_Service",
+          "mid": "/m/03z19",
+          "salience": 0.002064388943836093,
+          "mention_count": 3,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Oval Office",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oval_Office",
+          "mid": "/m/01hhz7",
+          "salience": 0.0019614179618656635,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Washington, DC",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Washington,_D.C.",
+          "mid": "/m/0rh6k",
+          "salience": 0.0018502890598028898,
+          "mention_count": 4,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Congress",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Congress",
+          "mid": "/m/07t31",
+          "salience": 0.0017899282975122333,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0017747265519574285,
+          "mention_count": 3,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Donald Jr.",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump_Jr.",
+          "mid": "/m/0dzqp5",
+          "salience": 0.0017238084692507982,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Senate",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Senate",
+          "mid": "/m/07t58",
+          "salience": 0.0015008642803877592,
+          "mention_count": 3,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Mitch McConnell",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mitch_McConnell",
+          "mid": "/m/01z6ls",
+          "salience": 0.0014424350811168551,
+          "mention_count": 4,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Citizens for Responsibility and Ethics in Washington",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Citizens_for_Responsibility_and_Ethics_in_Washington",
+          "mid": "/m/05ql9c",
+          "salience": 0.0013149939477443695,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Republicans",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Republican_Party_(United_States)",
+          "mid": "/m/07wbk",
+          "salience": 0.0010939593194052577,
+          "mention_count": 11,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "James Comer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/James_Comer",
+          "mid": "/m/0j65cf0",
+          "salience": 0.001087644719518721,
+          "mention_count": 3,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Slush Fund",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Slush_fund",
+          "mid": "/m/0g3sm",
+          "salience": 0.0008385854889638722,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Katherine Clark",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Katherine_Clark",
+          "mid": "/m/0fpjc8b",
+          "salience": 0.0007942928350530565,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Tom Emmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tom_Emmer",
+          "mid": "/m/06w2w3l",
+          "salience": 0.0007513163145631552,
+          "mention_count": 3,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "U.S. District Court",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_district_court",
+          "mid": "/m/0j75z",
+          "salience": 0.0007317907875403762,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Administrative Procedure Act",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Administrative_Procedure_Act",
+          "mid": "/m/02tvpd",
+          "salience": 0.0005900599644519389,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Freedom of Information Act",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Freedom_of_Information_Act_(United_States)",
+          "mid": "/m/02t27n",
+          "salience": 0.0005890905158594251,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Biden",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joe_Biden",
+          "mid": "/m/012gx2",
+          "salience": 0.0005874740891158581,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Squawk Box",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Squawk_Box",
+          "mid": "/m/067hjz",
+          "salience": 0.0005479701794683933,
+          "mention_count": 3,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Biden Administration",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Presidency_of_Joe_Biden",
+          "mid": "/g/11qnb9gr97",
+          "salience": 0.0005206696223467588,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "U.S. Constitution",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Constitution_of_the_United_States",
+          "mid": "/m/07sdd",
+          "salience": 0.0005173730314709246,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Alexandria",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alexandria,_Virginia",
+          "mid": "/m/013h9",
+          "salience": 0.0005147962365299463,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "New Haven",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Haven,_Connecticut",
+          "mid": "/m/0f2nf",
+          "salience": 0.00044561480171978474,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Kevin Warsh",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kevin_Warsh",
+          "mid": "/m/0clm1s",
+          "salience": 0.00040045432979241014,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "John Thune",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_Thune",
+          "mid": "/m/03ybyn",
+          "salience": 0.00040045432979241014,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Department of Homeland Security",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Department_of_Homeland_Security",
+          "mid": "/m/0fytk",
+          "salience": 0.0003981697664130479,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Tax Returns",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tax_return",
+          "mid": "/g/121vr3lx",
+          "salience": 0.0003971732221543789,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "California",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/California",
+          "mid": "/m/01n7q",
+          "salience": 0.0003941667382605374,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Truth Social",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Truth_Social",
+          "mid": "/g/11p6w0djqy",
+          "salience": 0.00034901531762443483,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Mar-a-Lago",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mar-a-Lago",
+          "mid": "/m/052rh6",
+          "salience": 0.000348815432516858,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "California State University Channel Islands",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/California_State_University,_Channel_Islands",
+          "mid": "/m/033w82",
+          "salience": 0.0003464691690169275,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Tom Suozzi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tom_Suozzi",
+          "mid": "/m/060n4d",
+          "salience": 0.00031919789034873247,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Pa.",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pennsylvania",
+          "mid": "/m/05tbn",
+          "salience": 0.00031919789034873247,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Brian Fitzpatrick",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brian_Fitzpatrick_(American_politician)",
+          "mid": "/g/11c2l6lhlm",
+          "salience": 0.00031919789034873247,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Kilmar Abrego Garcia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://es.wikipedia.org/wiki/Kilmar_Armando_Ábrego_García",
+          "mid": "/g/11x6c_d8r2",
+          "salience": 0.0003187839756719768,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "House Oversight Committee",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_House_Committee_on_Oversight_and_Government_Reform",
+          "mid": "/m/05rw4y",
+          "salience": 0.00029876589542254806,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Arlington National Cemetery",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arlington_National_Cemetery",
+          "mid": "/m/0lbp_",
+          "salience": 0.0001671796344453469,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "House Budget Committee",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_House_Committee_on_the_Budget",
+          "mid": "/m/05fnfn",
+          "salience": 0.00013107192353345454,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Fed",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Federal_Reserve",
+          "mid": "/m/02xmb",
+          "salience": 0.00010521574586164206,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Kentucky",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kentucky",
+          "mid": "/m/0498y",
+          "salience": 0.00010517326154513285,
+          "mention_count": 2,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "Texas",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Texas",
+          "mid": "/m/07b_l",
+          "salience": 0.00010497972834855318,
+          "mention_count": 1,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Politics",
+          "confidence": 0.8799999952316284,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        },
+        {
+          "name": "/Law & Government",
+          "confidence": 0.5699999928474426,
+          "analyzed_at": "2026-05-24T08:15:09.427374+00:00"
+        }
+      ]
     },
     {
-      "title": "Philippines' Mayon volcano spews ash — Pictures",
-      "description": "The most active volcano in the Philippines is erupting, sending lava down its slope and covering surrounding villages in ash.",
-      "url": "https://www.dw.com/en/philippines-mayon-volcano-spews-ash-pictures/a-77022712",
+      "title": "Apotex, Backers Raise $932 Million in Canada IPO Priced at Top",
+      "description": "Apotex Health Corp. and some of its backers raised C$1.3 billion ($932 million) in a Toronto initial public offering, the country’s largest since 2021.",
+      "url": "https://financialpost.com/pmn/business-pmn/apotex-backers-raise-932-million-in-canada-ipo-priced-at-top",
       "image_url": null,
-      "published_at": "2026-05-03T09:22:00+00:00",
+      "published_at": "2026-06-10T01:45:05+00:00",
       "language": "en",
-      "country": "de",
-      "category": "general",
+      "country": "us",
+      "category": "business",
       "sentiment_label": "neutral",
-      "sentiment_score": 0.0,
-      "source_name": "dw"
+      "sentiment_score": -0.10000000149011612,
+      "sentiment_magnitude": 10.699999809265137,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "Apotex Health Corp.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Apotex",
+          "mid": "/m/0dlhn8",
+          "salience": 0.11095692217350006,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Toronto",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Toronto",
+          "mid": "/m/0h7h6",
+          "salience": 0.013075846247375011,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Barry Sherman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Barry_Sherman",
+          "mid": "/m/03b_fdn",
+          "salience": 0.012876112945377827,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Canadian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.008465426973998547,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "APTX",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/AptX",
+          "mid": "/m/05mxfg6",
+          "salience": 0.005579018034040928,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Postmedia Network Inc.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.005046347621828318,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Bloomberg News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bloomberg_News",
+          "mid": "/m/0vpsrmz",
+          "salience": 0.004295590333640575,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Toronto Stock Exchange",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Toronto_Stock_Exchange",
+          "mid": "/m/01d4qg",
+          "salience": 0.001467408612370491,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Bank of Montreal",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bank_of_Montreal",
+          "mid": "/m/01vhgl",
+          "salience": 0.0009146207012236118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Bank of Nova Scotia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Scotiabank",
+          "mid": "/m/01zrhv",
+          "salience": 0.0009146207012236118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Toronto-Dominion Bank",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Toronto-Dominion_Bank",
+          "mid": "/m/01vsxp",
+          "salience": 0.0009146207012236118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 0.000643750827293843,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Jefferies Financial Group Inc.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jefferies_Financial_Group",
+          "mid": "/m/07hn3p",
+          "salience": 0.0006433820817619562,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Bloomberg Businessweek",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bloomberg_Businessweek",
+          "mid": "/m/03s60l",
+          "salience": 0.0004616368387360126,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "Royal Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Royal_Bank_of_Canada",
+          "mid": "/m/02wjhf",
+          "salience": 0.0004057226760778576,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Pharmaceuticals & Biotech",
+          "confidence": 0.7300162315368652,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.6915266513824463,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/News/Business News/Financial Markets News",
+          "confidence": 0.5270659327507019,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Stocks & Bonds",
+          "confidence": 0.47451016306877136,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/News/Health News",
+          "confidence": 0.16945208609104156,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/Health/Pharmacy/Drugs & Medications",
+          "confidence": 0.1644853800535202,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.148548424243927,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Other",
+          "confidence": 0.11999763548374176,
+          "analyzed_at": "2026-06-10T08:02:07.961085+00:00"
+        }
+      ]
     },
     {
-      "title": "Where Germany's economy still excels",
-      "description": "German industry is being lapped in key sectors like solar panels, semiconductors and even cars — but the country's midsize businesses suggest the economy isn't losing its edge.",
-      "url": "https://www.dw.com/en/where-germany-s-economy-still-excels/a-77020320",
-      "image_url": null,
-      "published_at": "2026-05-03T05:58:00+00:00",
-      "language": "en",
-      "country": "de",
-      "category": "general",
-      "sentiment_label": "neutral",
-      "sentiment_score": 0.0,
-      "source_name": "dw"
-    },
-    {
-      "title": "North Korea rejects US cybercrime claims as 'absurd slander'",
-      "description": "Pyongyang refutes allegations of hacking and crypto theft, even as a UN panel estimated billions stolen by North Korea-linked cyberattacks.",
-      "url": "https://www.dw.com/en/north-korea-rejects-us-cybercrime-claims-as-absurd-slander/a-77021832",
-      "image_url": null,
-      "published_at": "2026-05-03T04:03:00+00:00",
-      "language": "en",
-      "country": "de",
-      "category": "general",
-      "sentiment_label": "negative",
-      "sentiment_score": -0.800000011920929,
-      "source_name": "dw"
-    },
-    {
-      "title": "Jewish Londoners deserve to live without fear – we are taking action to ensure their safety | Sadiq Khan",
-      "description": "During dark times, we must stand by our Jewish neighbours as generations of Londoners have done before usSadiq Khan is the mayor of LondonJewish people are living in fear – a fear that has been building for years but has become acute in recent weeks. It now seeps into every part of daily life: the school run, a walk down the high street, a meal in a restaurant, attending synagogue on Shabbat.Jewish friends and colleagues have spoken to me about how they now find themselves looking over their shoulder in public and worrying about their children wearing religious symbols. This is heartbreaking...",
-      "url": "https://www.theguardian.com/commentisfree/2026/may/03/jewish-community-london-safety-sadiq-khan",
-      "image_url": "https://i.guim.co.uk/img/media/f736427c9cc36091fbdbf3e90f3aae14b14a683c/362_0_5000_4000/master/5000.jpg?width=140&quality=85&auto=format&fit=max&s=10db620d4a3dd69461f2d44acf24a240",
-      "published_at": "2026-05-03T12:48:43+00:00",
+      "title": "Belfast stabbing latest: Starmer calls for calm as bystanders who tackled alleged knife attacker hailed ‘heroes’",
+      "description": "Northern Ireland secretary Hilary Benn thanked those who tried to stop the attack, saying ‘you showed the very best of humanity’",
+      "url": "https://www.independent.co.uk/news/uk/crime/belfast-knife-attack-stabbing-latest-updates-kinnaird-b2992451.html",
+      "image_url": "https://static.independent.co.uk/2026/06/09/12/12/belfast111.jpeg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-09T12:48:58+00:00",
       "language": "en",
       "country": "gb",
       "category": "general",
       "sentiment_label": "negative",
-      "sentiment_score": -0.5,
-      "source_name": "guardian"
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 23.899999618530273,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Northern Ireland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Northern_Ireland",
+          "mid": "/m/05bcl",
+          "salience": 0.06390055269002914,
+          "mention_count": 16,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "PSNI Police",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Police_Service_of_Northern_Ireland",
+          "mid": "/m/01qzpl",
+          "salience": 0.03898012638092041,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Naomi Long",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Naomi_Long",
+          "mid": "/m/05sqmb",
+          "salience": 0.03553527966141701,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.02482951246201992,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Belfast",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belfast",
+          "mid": "/m/01l63",
+          "salience": 0.0222836472094059,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Jon Boutcher",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jon_Boutcher",
+          "mid": "/g/11vc1mxf3f",
+          "salience": 0.020853357389569283,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.010121740400791168,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Hilary Benn",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hilary_Benn",
+          "mid": "/m/01t5w7",
+          "salience": 0.004801259841769934,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Michelle O'Neill",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michelle_O'Neill",
+          "mid": "/m/02pxlkg",
+          "salience": 0.004462006967514753,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.0042228903621435165,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Sudan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sudan",
+          "mid": "/m/06tw8",
+          "salience": 0.0031402690801769495,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Jim O'Callaghan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jim_O'Callaghan",
+          "mid": "/g/11c3ypq3mc",
+          "salience": 0.0028532177675515413,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Emma Little-Pengelly",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emma_Little-Pengelly",
+          "mid": "/g/11bw63qbn5",
+          "salience": 0.001034711953252554,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Common Travel Area",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Common_Travel_Area",
+          "mid": "/m/05j7hk",
+          "salience": 0.0006782233249396086,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "Dublin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dublin",
+          "mid": "/m/02cft",
+          "salience": 0.00019637265359051526,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.9124400019645691,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Law Enforcement",
+          "confidence": 0.38611435890197754,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.3425668179988861,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.2882196605205536,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.19699956476688385,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.18610340356826782,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.1803329735994339,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.13388210535049438,
+          "analyzed_at": "2026-06-09T16:02:20.340972+00:00"
+        }
+      ]
     },
     {
-      "title": "Premier League latest, Scottish title race heating up, and more – football live",
-      "description": "⚽ All the latest going into Sunday’s big games⚽ Scores | Tables | Follow us on Bluesky | Mail EmilliaMikel Arteta said his Arsenal team had played some of their best football of the season in Saturday’s 3-0 home win over Fulham and demanded that they take the positive feelings into the return leg of their Champions League semi-final against Atlético Madrid on Tuesday.He said: “It says to us and toward our dressing room that we keep the dream alive. hat what these guys have done, not now, but throughout the season to win that many games is remarkable. Because I think it’s going to...",
-      "url": "https://www.theguardian.com/football/live/2026/may/03/premier-league-latest-scottish-title-race-heating-up-and-more-football-live",
-      "image_url": "https://i.guim.co.uk/img/media/5fe365ef198770678d5859b644bc73827ad769d4/39_31_4961_3969/master/4961.jpg?width=140&quality=85&auto=format&fit=max&s=f6165029cf67bf27536604d0342a1c07",
-      "published_at": "2026-05-03T07:18:38+00:00",
+      "title": "Attacks inquiry revealed miscarriage of justice, victim's mother says",
+      "description": "The bereaved families of the victims of Valdo Calocane speak at a press conference in London.",
+      "url": "https://www.bbc.com/news/articles/cy8d932zl27o",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b3a8/live/f28b1bb0-60c6-11f1-8b8c-6d33e1d5abb6.jpg",
+      "published_at": "2026-06-08T11:47:19+00:00",
       "language": "en",
       "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 32.29999923706055,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Nottingham",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nottingham",
+          "mid": "/m/09tlh",
+          "salience": 0.06055682525038719,
+          "mention_count": 22,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "BBC Woman's Hour",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC",
+          "mid": "/m/0ncl8zk",
+          "salience": 0.004039654042571783,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "NHS",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Health_Service_(England)",
+          "mid": "/m/01fw9h",
+          "salience": 0.0030267233960330486,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.0022804085165262222,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Nottinghamshire Police",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nottinghamshire_Police",
+          "mid": "/m/09hflc",
+          "salience": 0.0017921103863045573,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Nottingham University Hospitals NHS Trust",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nottingham_University_Hospitals_NHS_Trust",
+          "mid": "/m/0286chq",
+          "salience": 0.0011548582697287202,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.0008488745079375803,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Jonathan Zito",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Killing_of_Jonathan_Zito",
+          "mid": "/g/11kwg6226j",
+          "salience": 0.0005970323691144586,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "BBC Radio Nottingham",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_Radio_Nottingham",
+          "mid": "/m/02r1rc",
+          "salience": 0.00026917719515040517,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Nottingham City Council",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nottingham_City_Council",
+          "mid": "/m/08rm90",
+          "salience": 0.00022100572823546827,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Mary Ward House",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mary_Ward_House",
+          "mid": "/g/11bw3h26k3",
+          "salience": 0.0001567092549521476,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Mental Health Act",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mental_Health_Act_1983",
+          "mid": "/m/08mxx4",
+          "salience": 0.00014353825827129185,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Independent Office for Police Conduct",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Independent_Office_for_Police_Conduct",
+          "mid": "/g/11bc5y5mnh",
+          "salience": 0.0001343803305644542,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.00012256841000635177,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.00010764330363599584,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "WhatsApp",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/WhatsApp",
+          "mid": "/m/0gwzvs1",
+          "salience": 0.00010762501915451139,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "eastmidsnews@bbc.co.uk",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_Online",
+          "mid": "/m/02zf_l",
+          "salience": 0.00010762501915451139,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Stab",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stabbing",
+          "mid": "/m/02x52f",
+          "salience": 8.569622150389478e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/University",
+          "mid": "/m/07tf8",
+          "salience": 8.569622150389478e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "Early Intervention in Psychosis",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Early_intervention_in_psychosis",
+          "mid": "/m/056mhxj",
+          "salience": 6.341314292512834e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.9332112669944763,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.7801405787467957,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.39107707142829895,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.254163920879364,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.14695696532726288,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        },
+        {
+          "name": "/Health/Mental Health/Other",
+          "confidence": 0.10932524502277374,
+          "analyzed_at": "2026-06-09T08:47:30.931544+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Revealed: The imprisoned stalker who could hold the key to freeing British couple jailed in Iran",
+      "description": "Exclusive: Britain is holding an ageing Iranian stalker whose deportation could help spare Lindsay and Craig Foreman from a 10-year jail sentence – so why won’t officials let him go? Crime correspondent Amy-Clare Martin investigates",
+      "url": "https://www.independent.co.uk/news/uk/crime/iran-craig-lindsay-foreman-stalker-richard-jan-b2976560.html",
+      "image_url": "https://static.independent.co.uk/2026/06/04/15/41/irandetainsplit.jpeg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-07T05:00:11+00:00",
+      "language": "en",
+      "country": "uk",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.4000000059604645,
+      "sentiment_magnitude": 53.599998474121094,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Craig Foreman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Detention_of_Craig_and_Lindsay_Foreman",
+          "mid": "/g/11x2wcvjyg",
+          "salience": 0.09345719963312149,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Ehsan Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.02148299105465412,
+          "mention_count": 49,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "British",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.017821617424488068,
+          "mention_count": 26,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Foreign Office",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Foreign,_Commonwealth_and_Development_Office",
+          "mid": "/m/0g7hr",
+          "salience": 0.003645439865067601,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "County Durham",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/County_Durham",
+          "mid": "/m/023sm8",
+          "salience": 0.0022839484736323357,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Nazanin Zaghari-Ratcliffe",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nazanin_Zaghari-Ratcliffe",
+          "mid": "/g/11cn8wwl1n",
+          "salience": 0.0018917674897238612,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Tehran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.0011377804912626743,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Parole Board",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Parole_board",
+          "mid": "/m/02r15x",
+          "salience": 0.0011096515227109194,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Frankland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/HM_Prison_Frankland",
+          "mid": "/m/0bgtm3",
+          "salience": 0.0007100309594534338,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Iranians",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iranian_peoples",
+          "mid": "/m/04nrnz",
+          "salience": 0.0006897312123328447,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Levi Bellfield",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Levi_Bellfield",
+          "mid": "/m/0dcxf9",
+          "salience": 0.0003750788455363363,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Tony Vaughan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tony_Vaughan_(politician)",
+          "mid": "/g/11tnwq660k",
+          "salience": 0.0002878759696613997,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Evin prison",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Evin_Prison",
+          "mid": "/m/01pncf",
+          "salience": 0.00025648949667811394,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Wayne Couzens",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Murder_of_Sarah_Everard",
+          "mid": "/g/11pb820tvk",
+          "salience": 0.00023335691366810352,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.00022474848083220422,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Mohsen Baharvand",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mohsen_Baharvand",
+          "mid": "/g/11p61rw1b5",
+          "salience": 0.00010490915883565322,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Lightbulb",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Incandescent_light_bulb",
+          "mid": "/m/0cpk7",
+          "salience": 9.075158595805988e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Tulip Siddiq",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tulip_Siddiq",
+          "mid": "/m/0h65tkk",
+          "salience": 7.024017395451665e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Milly Dowler",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Murder_of_Milly_Dowler",
+          "mid": "/g/11fll5c4g9",
+          "salience": 6.131634290795773e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 6.091087561799213e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Ealing",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ealing",
+          "mid": "/m/013c2f",
+          "salience": 6.068900984246284e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Isfahan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Isfahan",
+          "mid": "/m/01gk3x",
+          "salience": 1.8459197235642932e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "Labour",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Labour_Party_(UK)",
+          "mid": "/m/01c9x",
+          "salience": 1.8453052689437754e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.9652535915374756,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.28898993134498596,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.23528341948986053,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Visa & Immigration",
+          "confidence": 0.22668948769569397,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/Law & Government/Legal/Other",
+          "confidence": 0.2090986669063568,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.18194660544395447,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Other",
+          "confidence": 0.17504116892814636,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.12886331975460052,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.10606943815946579,
+          "analyzed_at": "2026-06-09T08:27:05.032025+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Why Oil’s Not at $200 After the Biggest Supply Shock in History",
+      "description": "For decades, oil traders, executives and analysts warned that closing the Strait of Hormuz would be a global economic catastrophe.",
+      "url": "https://financialpost.com/pmn/business-pmn/why-oils-not-at-200-after-the-biggest-supply-shock-in-history",
+      "image_url": null,
+      "published_at": "2026-06-06T12:21:34+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 32.70000076293945,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "Donald Trump",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.02867819368839264,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Postmedia Network Inc.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.005945713724941015,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.004686088301241398,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Strait of Hormuz",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Strait_of_Hormuz",
+          "mid": "/m/075t9",
+          "salience": 0.004651243798434734,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.00228746491484344,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Maria Angelicoussis",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maria_Angelicoussis",
+          "mid": "/g/11c5j7rn2q",
+          "salience": 0.001813917770050466,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Nicolas Maduro",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nicolás_Maduro",
+          "mid": "/m/0h7hb4",
+          "salience": 0.0017286200309172273,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Chinese",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chinese_language",
+          "mid": "/m/01r2l",
+          "salience": 0.001135405502282083,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Tom Baker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tom_Baker",
+          "mid": "/m/015csj",
+          "salience": 0.0007705450407229364,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0007224527653306723,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Strategic Petroleum Reserve",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Strategic_Petroleum_Reserve_(United_States)",
+          "mid": "/m/016bhq",
+          "salience": 0.0006088538793846965,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "US Central Command",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Central_Command",
+          "mid": "/m/01xsrd",
+          "salience": 0.0005536577082239091,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Russian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 0.0005342625081539154,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "White House",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/White_House",
+          "mid": "/m/081sq",
+          "salience": 0.0005126600153744221,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bank_of_Canada",
+          "mid": "/m/08_yv2",
+          "salience": 0.0005122773582115769,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "National Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Bank_of_Canada",
+          "mid": "/m/030z_n",
+          "salience": 0.0005120945279486477,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Pacific Investment Management Co.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/PIMCO",
+          "mid": "/m/05crjs",
+          "salience": 0.0004547077987808734,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Venezuelan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Venezuela",
+          "mid": "/m/07ylj",
+          "salience": 0.0004542929818853736,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Europe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0004537842469289899,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Greek",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greek_language",
+          "mid": "/m/0349s",
+          "salience": 0.000450783729320392,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.0004499014758039266,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Cenovus",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cenovus_Energy",
+          "mid": "/m/0cqf7zm",
+          "salience": 0.00044974088086746633,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Cushing",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cushing,_Oklahoma",
+          "mid": "/m/0z96c",
+          "salience": 0.00041567254811525345,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Oklahoma",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oklahoma",
+          "mid": "/m/05mph",
+          "salience": 0.00041567254811525345,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Asia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asia",
+          "mid": "/m/0j0k",
+          "salience": 0.00041557502117939293,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Indian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.00041538546793162823,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "United Arab Emirates",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Arab_Emirates",
+          "mid": "/m/0j1z8",
+          "salience": 0.0003121532790828496,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Fujairah",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fujairah",
+          "mid": "/g/1pznmngfz",
+          "salience": 0.0003121532790828496,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Raymond James",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Raymond_James_Financial",
+          "mid": "/m/03p31c0",
+          "salience": 0.0003118766762781888,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Archie Hunter",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Archie_Hunter",
+          "mid": "/m/04hrh_",
+          "salience": 0.00021791756444144994,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.00021788422600366175,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Persian Gulf",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Persian_Gulf",
+          "mid": "/m/0661z",
+          "salience": 0.0001707856572465971,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Saudi Arabia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saudi_Arabia",
+          "mid": "/m/01z215",
+          "salience": 0.00015572522534057498,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 0.00013700505951419473,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "ING Groep NV",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/ING_Group",
+          "mid": "/m/01hlqz",
+          "salience": 0.0001368390367133543,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Singapore",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Singapore",
+          "mid": "/m/06t2t",
+          "salience": 0.0001368390367133543,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "Red Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Red_Sea",
+          "mid": "/m/06jfd",
+          "salience": 0.0001367618388030678,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Energy & Utilities/Oil & Gas",
+          "confidence": 0.9879408478736877,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/News/Business News/Financial Markets News",
+          "confidence": 0.28136536478996277,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.264851838350296,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/News/Business News/Economy News",
+          "confidence": 0.24478460848331451,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Commodities & Futures Trading",
+          "confidence": 0.13465474545955658,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Shipping & Logistics/Freight Transport/Maritime Transport",
+          "confidence": 0.12437845021486282,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.11581484228372574,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.11047880351543427,
+          "analyzed_at": "2026-06-10T08:05:03.436263+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Theoretical model developed to understand how isotopes change spectroscopy results",
+      "description": "When researchers want to uncover what atoms make up a material, they turn to a number of tried-and-true spectroscopy methods. Spectroscopy works by shining a specific type of light onto a substance and then analyzing how that light is either absorbed, emitted, or scattered. Every atom has a different way of interacting with light, and scientists study this light-matter interaction to identify the atoms in the material.",
+      "url": "https://phys.org/news/2026-06-theoretical-isotopes-spectroscopy-results.html",
+      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2026/developing-a-theoretic.jpg",
+      "published_at": "2026-06-10T02:40:01+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "science",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 9.399999618530273,
+      "source_name": "phys",
+      "entities": [
+        {
+          "name": "Kyushu University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kyushu_University",
+          "mid": "/m/01rp_s",
+          "salience": 0.06636260449886322,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "Raman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Raman_spectroscopy",
+          "mid": "/m/0hyrx",
+          "salience": 0.007670045364648104,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "The Journal of Physical Chemistry C",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Journal_of_Physical_Chemistry_C",
+          "mid": "/m/03m95f9",
+          "salience": 0.0029319939203560352,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "DOI",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Digital_object_identifier",
+          "mid": "/m/026p9_",
+          "salience": 0.0009055972914211452,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "English",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/English_language",
+          "mid": "/m/02h40lc",
+          "salience": 0.0009051228407770395,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Science/Chemistry",
+          "confidence": 0.7946953773498535,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "/Science/Physics",
+          "confidence": 0.7487632036209106,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "/Jobs & Education/Education/Academic Conferences & Publications",
+          "confidence": 0.5256726741790771,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "/Reference/General Reference/Educational Resources",
+          "confidence": 0.2231818586587906,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        },
+        {
+          "name": "/Science/Other",
+          "confidence": 0.1115817129611969,
+          "analyzed_at": "2026-06-10T08:01:57.205774+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Man who murdered partner and blew up home jailed",
+      "description": "Clifton George stabbed Annabel Rook 31 times before starting a fire at their house in north London.",
+      "url": "https://www.bbc.com/news/articles/cddl4jq9d3do",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1a2d/live/537ff930-6139-11ee-b101-6f93d6dfbcc2.png",
+      "published_at": "2026-06-09T11:35:45+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.4000000059604645,
+      "sentiment_magnitude": 23.600000381469727,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Stoke Newington",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stoke_Newington",
+          "mid": "/m/0nc8j",
+          "salience": 0.003056176006793976,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Snaresbrook Crown Court",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Snaresbrook_Crown_Court",
+          "mid": "/g/11bvg1g7ds",
+          "salience": 0.0011809838470071554,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0011753435246646404,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.001056885696016252,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Murder",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Murder",
+          "mid": "/m/051_y",
+          "salience": 0.0001443180808564648,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Metropolitan Police",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Metropolitan_Police",
+          "mid": "/m/01bb7n",
+          "salience": 0.00014018690853845328,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Old Bailey",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Old_Bailey",
+          "mid": "/m/01hbd0",
+          "salience": 0.00014018690853845328,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Glastonbury Festival",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Glastonbury_Festival",
+          "mid": "/m/0kks6",
+          "salience": 0.0001294257235713303,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "BBC Radio London",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_Radio_London",
+          "mid": "/m/02r27m",
+          "salience": 9.643498196965083e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 6.783432036172599e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 6.783432036172599e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.964053213596344,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.7946271300315857,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.24490106105804443,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.20757617056369781,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.18852603435516357,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Troubled Relationships",
+          "confidence": 0.11152537912130356,
+          "analyzed_at": "2026-06-09T16:03:21.757188+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Bombardier and Elie Saab Debut First-of-its-kind Collaboration, Introducing the Haute Couture of Aviation with Bespoke Global 8000 Cabin Design",
+      "description": "A collaboration that represents a new expression of business aviation Bombardier and ELIE SAAB redefine the onboard experience A new standard of comfort and craftmanship at 50,000 feet MONACO, June 08, 2026 (GLOBE NEWSWIRE) &#8212; Bombardier and ELIE SAAB are proud to unveil a bold new chapter in business aviation: a bespoke cabin design for [&#8230;]",
+      "url": "https://financialpost.com/globe-newswire/bombardier-and-elie-saab-debut-first-of-its-kind-collaboration-introducing-the-haute-couture-of-aviation-with-bespoke-global-8000-cabin-design",
+      "image_url": null,
+      "published_at": "2026-06-08T05:31:40+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 32.099998474121094,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "GlobeNewswire Bombardier",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bombardier_Inc.",
+          "mid": "/m/01gyd",
+          "salience": 0.05907902866601944,
+          "mention_count": 19,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "ELIE SAAB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Elie_Saab",
+          "mid": "/m/06gppb",
+          "salience": 0.03093045763671398,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "GlobeNewswire",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/GlobeNewswire",
+          "mid": "/m/0cnxsd6",
+          "salience": 0.006786566227674484,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Global 8000",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://pt.wikipedia.org/wiki/Bombardier_Global_8000",
+          "mid": "/g/121vrjtp",
+          "salience": 0.00267431209795177,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "MONACO",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Monaco",
+          "mid": "/m/04w58",
+          "salience": 0.0023961872793734074,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Postmedia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.0018097750144079328,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Formula 1 Grand Prix",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Formula_One",
+          "mid": "/m/02xz2",
+          "salience": 0.0008121526916511357,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Canadian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0007001232588663697,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Haute Couture",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Haute_couture",
+          "mid": "/m/02_8m1",
+          "salience": 0.0006157441530376673,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "National Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Bank_of_Canada",
+          "mid": "/m/030z_n",
+          "salience": 0.0005443488480523229,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "IMF",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Monetary_Fund",
+          "mid": "/m/03y48",
+          "salience": 0.0005441360408440232,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Amazon",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amazon_(company)",
+          "mid": "/m/0mgkg",
+          "salience": 0.0005441360408440232,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Doug Ford",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Doug_Ford",
+          "mid": "/m/0dsdr1x",
+          "salience": 0.0005376858753152192,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Éric Martel",
+          "type": "PERSON",
+          "wikipedia_url": "https://fr.wikipedia.org/wiki/Éric_Martel",
+          "mid": "/g/11bwyxqhvh",
+          "salience": 0.0005020886892452836,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.000499001587741077,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Sustainability",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sustainability",
+          "mid": "/m/0hkst",
+          "salience": 0.000426275422796607,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Lebanon",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.00037407904164865613,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "France",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 0.0003739859675988555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Chambre Syndicale",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fédération_de_la_Haute_Couture_et_de_la_Mode",
+          "mid": "/m/03d7tdc",
+          "salience": 0.0003739859675988555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.0003739859675988555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Milan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Milan",
+          "mid": "/m/0947l",
+          "salience": 0.0003739859675988555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Dubai",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dubai",
+          "mid": "/m/01f08r",
+          "salience": 0.0003739859675988555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Beirut",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beirut",
+          "mid": "/m/09bjv",
+          "salience": 0.0003739859675988555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.0002613495453260839,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "Mexico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.0001641127746552229,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "United States",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0001641127746552229,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Aerospace & Defense/Aviation Industry",
+          "confidence": 0.8040198087692261,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.6658303141593933,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "/Autos & Vehicles/Motor Vehicles (By Brand)/Saab",
+          "confidence": 0.5813912153244019,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Transportation/Air Travel",
+          "confidence": 0.32335320115089417,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.16912688314914703,
+          "analyzed_at": "2026-06-09T08:51:52.961878+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Readers reply: If an alien asked you: ‘What is music?’ what would you play for them?",
+      "description": "The long-running series in which readers answer other readers’ questions comes up with an epic extraterrestrial playlist for Earth’s first contact from beyond the starsThis week’s new question: Experts say we should use passkeys, but can a smartphone PIN really be safer than a password?If an alien landed and asked you: “What is this thing you call music?” what would you play for them? And why? Heather, KentSend new questions to nq@theguardian.com. Continue reading...",
+      "url": "https://www.theguardian.com/lifeandstyle/2026/jun/07/readers-reply-alien-music-playlist-first-contact",
+      "image_url": "https://i.guim.co.uk/img/media/13a4da08294f294b7f6b417d27aaec5cbc0b7764/399_0_5000_4000/master/5000.jpg?width=140&quality=85&auto=format&fit=max&s=025770a17a4947f97bcf8deae7de1aac",
+      "published_at": "2026-06-07T13:00:33+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 51.20000076293945,
+      "source_name": "guardian",
+      "entities": [
+        {
+          "name": "Earth",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Earth",
+          "mid": "/m/02j71",
+          "salience": 0.017880083993077278,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Arnold Schoenberg",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arnold_Schoenberg",
+          "mid": "/m/0hnlx",
+          "salience": 0.00985980685800314,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Bach",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Johann_Sebastian_Bach",
+          "mid": "/m/03_f0",
+          "salience": 0.008527460508048534,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Bessie Smith",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bessie_Smith",
+          "mid": "/m/0dq47",
+          "salience": 0.003945266827940941,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "B-52s",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_B-52s",
+          "mid": "/m/017_hq",
+          "salience": 0.003420931287109852,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Klingon",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Klingon",
+          "mid": "/m/08_ykq",
+          "salience": 0.003371000522747636,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Autechre",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Autechre",
+          "mid": "/m/0mzml",
+          "salience": 0.0033000034745782614,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "The Marriage of Figaro",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Marriage_of_Figaro",
+          "mid": "/m/04d0cyq",
+          "salience": 0.003253789385780692,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "iStockphoto",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/IStock",
+          "mid": "/m/09h47q",
+          "salience": 0.0029249589424580336,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Equinoxe",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Equinoxe",
+          "mid": "/m/042w5d",
+          "salience": 0.002769564976915717,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Pierrot Lunaire",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pierrot_lunaire",
+          "mid": "/m/01ndg6",
+          "salience": 0.0027243902441114187,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "nq@theguardian.com",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian",
+          "mid": "/m/0cnn5",
+          "salience": 0.0025344043970108032,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Gustav Holst",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gustav_Holst",
+          "mid": "/m/0d3wx",
+          "salience": 0.00253111869096756,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Klaatu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Klaatu_(band)",
+          "mid": "/m/016mx7",
+          "salience": 0.0025128666311502457,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Carpenters",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Carpenters",
+          "mid": "/m/03n2zz",
+          "salience": 0.0025128666311502457,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Max Richter",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Max_Richter",
+          "mid": "/m/05jh2m",
+          "salience": 0.0023941434919834137,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Hen Wlad Fy Nhadau",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hen_Wlad_Fy_Nhadau",
+          "mid": "/g/121k3jd3",
+          "salience": 0.002215628745034337,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "I Lost My Heart to a Starship Trooper",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/I_Lost_My_Heart_to_a_Starship_Trooper",
+          "mid": "/m/027b9s2",
+          "salience": 0.0022148455027490854,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "London Bridge Is Falling Down",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London_Bridge_Is_Falling_Down",
+          "mid": "/m/02h4cs",
+          "salience": 0.0020275574643164873,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Beefheart and His Magic Band",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Magic_Band",
+          "mid": "/g/11bx4bm9sb",
+          "salience": 0.0018922269809991121,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Erik Satie",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Erik_Satie",
+          "mid": "/m/02q4r",
+          "salience": 0.0016625674907118082,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Lewis Thomas",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lewis_Thomas",
+          "mid": "/m/02nrjl",
+          "salience": 0.0013625110732391477,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "David Gilmour",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/David_Gilmour",
+          "mid": "/m/01vs4ff",
+          "salience": 0.001189305679872632,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "John Peel",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_Peel",
+          "mid": "/m/01vs4dc",
+          "salience": 0.001071925857104361,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "The Flaming Lips",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Flaming_Lips",
+          "mid": "/m/0l8g0",
+          "salience": 0.0009460374712944031,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Slim Whitman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Slim_Whitman",
+          "mid": "/m/05f6z9",
+          "salience": 0.0009451411897316575,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Giancarlo Menotti",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gian_Carlo_Menotti",
+          "mid": "/m/01msq1",
+          "salience": 0.000942461600061506,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Mark Knopfler",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mark_Knopfler",
+          "mid": "/m/01c8v0",
+          "salience": 0.0009411714854650199,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Claude Achille Debussy",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Claude_Debussy",
+          "mid": "/m/01vvy",
+          "salience": 0.000895254488568753,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Another Green World",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Another_Green_World",
+          "mid": "/m/01l2p30",
+          "salience": 0.0008705426007509232,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Les Indes Galantes",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Les_Indes_galantes",
+          "mid": "/m/0cw_1l",
+          "salience": 0.0008533052750863135,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Miles Davis",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Miles_Davis",
+          "mid": "/m/053yx",
+          "salience": 0.0007950672879815102,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Kind of Blue",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kind_of_Blue",
+          "mid": "/m/01bwdt",
+          "salience": 0.0007950672879815102,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "John Williams",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_Williams",
+          "mid": "/m/0146pg",
+          "salience": 0.0006628467817790806,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Close Encounters of the Third Kind",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Close_Encounters_of_the_Third_Kind",
+          "mid": "/m/012mrr",
+          "salience": 0.0006628467817790806,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Louis Armstrong",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Louis_Armstrong",
+          "mid": "/m/04n32",
+          "salience": 0.0006375409429892898,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Charli xcx",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Charli_XCX",
+          "mid": "/m/0j42l4h",
+          "salience": 0.000637431163340807,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Napoleon XIV",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Napoleon_XIV",
+          "mid": "/m/01lpt3c",
+          "salience": 0.0006371107301674783,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Onesiphorus",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Onesiphorus",
+          "mid": "/m/0d8mr9",
+          "salience": 0.0006369042675942183,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Walk on the Wild Side",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Walk_on_the_Wild_Side_(Lou_Reed_song)",
+          "mid": "/m/05ymwh",
+          "salience": 0.0006369042675942183,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Rameau",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Philippe_Rameau",
+          "mid": "/m/013xj7",
+          "salience": 0.0006363159045577049,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "William Christie",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/William_Christie_(musician)",
+          "mid": "/m/01whsk7",
+          "salience": 0.0006363159045577049,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Rick Astley",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rick_Astley",
+          "mid": "/m/029kz0",
+          "salience": 0.0006361293490044773,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Crazy Frog",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Crazy_Frog",
+          "mid": "/m/09jgvk",
+          "salience": 0.0006358576356433332,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Aqua",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aqua_(band)",
+          "mid": "/m/09kx_8",
+          "salience": 0.0006358576356433332,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Apple",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Apple_Inc.",
+          "mid": "/m/0k8z",
+          "salience": 0.0006329445750452578,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Hyperballad",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hyperballad",
+          "mid": "/m/06gh84",
+          "salience": 0.0006327804876491427,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Japan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Japan",
+          "mid": "/m/03_3d",
+          "salience": 0.0006317203515209258,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "August Wilhelmj",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/August_Wilhelmj",
+          "mid": "/m/09n4sl",
+          "salience": 0.0006315801874734461,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "My Bloody Valentine",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/My_Bloody_Valentine_(band)",
+          "mid": "/m/011kc9",
+          "salience": 0.0006314425263553858,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Dumpy's Rusty Nuts",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dumpy's_Rusty_Nuts",
+          "mid": "/m/01w8glk",
+          "salience": 0.000583091692533344,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Jean-Michel Jarre",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Michel_Jarre",
+          "mid": "/m/0c9d9",
+          "salience": 0.0005829355795867741,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Indonesia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Indonesia",
+          "mid": "/m/03ryn",
+          "salience": 0.0005826333072036505,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.0005826333072036505,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Modern Talking",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Modern_Talking",
+          "mid": "/m/020jvt",
+          "salience": 0.0005824147956445813,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Motörhead",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Motörhead",
+          "mid": "/m/05841",
+          "salience": 0.0005823434330523014,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Welsh",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wales",
+          "mid": "/m/0j5g9",
+          "salience": 0.0005822028033435345,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "John Redwood",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_Redwood",
+          "mid": "/m/015rxq",
+          "salience": 0.0005822028033435345,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Eamonn McCabe",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Eamonn_McCabe",
+          "mid": "/m/05x_z67",
+          "salience": 0.0005817969213239849,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Another Girl, Another Planet",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Another_Girl,_Another_Planet",
+          "mid": "/m/096jnl",
+          "salience": 0.000475662003736943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Elton John",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Elton_John",
+          "mid": "/m/01vrz41",
+          "salience": 0.0004754839465022087,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Iannis Xenakis",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iannis_Xenakis",
+          "mid": "/m/014wsb",
+          "salience": 0.00043665655539371073,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Trout Mask Replica",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trout_Mask_Replica",
+          "mid": "/m/01l1yvl",
+          "salience": 0.00043665655539371073,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Merzbow",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Merzbow",
+          "mid": "/m/01r9d_2",
+          "salience": 0.00043665655539371073,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Pulse Demon",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pulse_Demon",
+          "mid": "/m/01jkgcm",
+          "salience": 0.00043665655539371073,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Philip Glass",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Philip_Glass",
+          "mid": "/m/06449",
+          "salience": 0.0004364767228253186,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Michael Dorn",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michael_Dorn",
+          "mid": "/m/01s54v",
+          "salience": 0.00043637165799736977,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Paramount",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paramount_Global",
+          "mid": "/g/11j3hkzt1h",
+          "salience": 0.00043633708264678717,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Up the Junction",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Up_the_Junction_(song)",
+          "mid": "/m/073w2z",
+          "salience": 0.0004091947339475155,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "She's a Rainbow",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/She's_a_Rainbow",
+          "mid": "/m/0fkfkw",
+          "salience": 0.00035733560798689723,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Famous Blue Raincoat",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Famous_Blue_Raincoat",
+          "mid": "/m/096rzz",
+          "salience": 0.0003474427212495357,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Stranglers",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Stranglers",
+          "mid": "/m/07ht5",
+          "salience": 0.0003471864911261946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Pretty Vacant",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pretty_Vacant",
+          "mid": "/m/04nj69",
+          "salience": 0.0003051333478651941,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Moments of Pleasure",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Moments_of_Pleasure",
+          "mid": "/m/027fqr7",
+          "salience": 0.0003051333478651941,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "John Cage",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_Cage",
+          "mid": "/m/0hgqq",
+          "salience": 0.00030504169990308583,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Lady Gaga",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lady_Gaga",
+          "mid": "/m/0478__m",
+          "salience": 0.0003050191153306514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Bent Fabric",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bent_Fabric",
+          "mid": "/m/04ddcy",
+          "salience": 0.00030495223472826183,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Gershwin",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/George_Gershwin",
+          "mid": "/m/03f4k",
+          "salience": 0.000304886547382921,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Beethoven's Fifth",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Symphony_No._5_(Beethoven)",
+          "mid": "/m/01h5sx",
+          "salience": 0.000304886547382921,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Rhapsody in Blue",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rhapsody_in_Blue",
+          "mid": "/m/013wll",
+          "salience": 0.000304886547382921,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Concerto for Two Violins",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Concerto_for_Two_Violins_(Bach)",
+          "mid": "/m/03jdgj",
+          "salience": 0.00027062787557952106,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "David Bowie",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/David_Bowie",
+          "mid": "/m/01vsy7t",
+          "salience": 0.00024643613141961396,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Brandenburg Concertos",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brandenburg_Concertos",
+          "mid": "/m/01ktwr",
+          "salience": 0.00023926443827804178,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Claire de Lune",
+          "type": "PERSON",
+          "wikipedia_url": "https://pt.wikipedia.org/wiki/Clair_de_lune",
+          "mid": "/m/0gbm9gq",
+          "salience": 0.00023915152996778488,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Alamy",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alamy",
+          "mid": "/m/04y04k",
+          "salience": 0.00023912946926429868,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Groundhog_Phil",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Groundhog",
+          "mid": "/m/016cps",
+          "salience": 0.00021856465900782496,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "God",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/God",
+          "mid": "/m/0d05l6",
+          "salience": 0.0002185407211072743,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Richard Strauss",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Richard_Strauss",
+          "mid": "/m/0hr3g",
+          "salience": 0.00021842420392204076,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Cardiacs",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cardiacs",
+          "mid": "/m/01mjc1l",
+          "salience": 0.00019192768377251923,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "The Residents",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Residents",
+          "mid": "/m/07jp9",
+          "salience": 0.00019190685998182744,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Netherlands Bach Society",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Netherlands_Bach_Society",
+          "mid": "/m/0dpsyg0",
+          "salience": 0.0001918657508213073,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "2001: A Space Odyssey",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/2001:_A_Space_Odyssey",
+          "mid": "/m/08ct6",
+          "salience": 0.0001918054185807705,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "The Beach Boys",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Beach_Boys",
+          "mid": "/m/01fl3",
+          "salience": 0.00019178564252797514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Flock of Seagulls",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/A_Flock_of_Seagulls",
+          "mid": "/m/016vp8",
+          "salience": 0.00019170819723512977,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "African",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Africa",
+          "mid": "/m/0dg3n1",
+          "salience": 0.00019167042046319693,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Blackstar",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Blackstar_(album)",
+          "mid": "/g/11bwh9zq8c",
+          "salience": 0.00019157856877427548,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "Rick Wakeman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rick_Wakeman",
+          "mid": "/m/0ftps",
+          "salience": 0.00019150759908370674,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Arts & Entertainment/Music & Audio/Other",
+          "confidence": 0.31602567434310913,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Offbeat/Occult & Paranormal",
+          "confidence": 0.27190932631492615,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/Science/Astronomy",
+          "confidence": 0.24565157294273376,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/People & Society/Subcultures & Niche Interests",
+          "confidence": 0.21294090151786804,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Fun & Trivia/Other",
+          "confidence": 0.20249922573566437,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.1365334391593933,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Offbeat/Other",
+          "confidence": 0.10892264544963837,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Humor/Other",
+          "confidence": 0.10103768110275269,
+          "analyzed_at": "2026-06-09T08:36:22.068703+00:00"
+        }
+      ]
+    },
+    {
+      "title": "High-functioning depression: When success masks suffering",
+      "description": "People with depression don't always feel overwhelmed or struggle to get things done — some are highly efficient and productive, despite their low moods. So it can't be that bad, right? Wrong!",
+      "url": "https://www.dw.com/en/high-functioning-depression-when-success-masks-suffering/a-77358072",
+      "image_url": null,
+      "published_at": "2026-06-06T13:32:00+00:00",
+      "language": "en",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 30.0,
+      "source_name": "dw",
+      "entities": [
+        {
+          "name": "JavaScript",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/JavaScript",
+          "mid": "/m/02p97",
+          "salience": 0.0209954883903265,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "Ulrich Hegerl",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Ulrich_Hegerl",
+          "mid": "/g/11fktgnb6d",
+          "salience": 0.010394644923508167,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "German",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.0033348379656672478,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "ICD‐10",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/ICD-10",
+          "mid": "/m/025rwrz",
+          "salience": 0.0011957791866734624,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "Suicide Prevention Foundation",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/American_Foundation_for_Suicide_Prevention",
+          "mid": "/m/026cxhc",
+          "salience": 0.0010623037815093994,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "International Classification of Diseases",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Classification_of_Diseases",
+          "mid": "/m/03zlr",
+          "salience": 0.0010501936776563525,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "Bonn",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bonn",
+          "mid": "/m/0150n",
+          "salience": 0.0009723777766339481,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "Germany",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.00039961442234925926,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "Florida",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Florida",
+          "mid": "/m/02xry",
+          "salience": 0.00032033733441494405,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "Tampa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tampa,_Florida",
+          "mid": "/m/0n1rj",
+          "salience": 0.00032033733441494405,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Health/Mental Health/Depression",
+          "confidence": 0.943598747253418,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "/People & Society/Self-Help & Motivational",
+          "confidence": 0.5891558527946472,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "/Health/Mental Health/Anxiety & Stress",
+          "confidence": 0.48664018511772156,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "/Health/Medical Literature & Resources/Other",
+          "confidence": 0.3339155316352844,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Psychology",
+          "confidence": 0.2952951490879059,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Self-Harm",
+          "confidence": 0.25035175681114197,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Family/Other",
+          "confidence": 0.14995291829109192,
+          "analyzed_at": "2026-06-09T08:00:39.307545+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Rail Freight Wagon Tracking Set for Steady Growth, but Penetration Remains Limited",
+      "description": "Tracking devices on rail freight wagons are forecast to reach nearly 1.4 million by 2030, yet penetration will remain below 25 percent, highlighting significant growth potential but uneven digital visibility.The post Rail Freight Wagon Tracking Set for Steady Growth, but Penetration Remains Limited appeared first on IoT Business News.",
+      "url": "https://iotbusinessnews.com/2026/06/10/rail-freight-wagon-tracking-set-for-steady-growth-but-penetration-remains-limited/",
+      "image_url": null,
+      "published_at": "2026-06-10T07:05:18+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 8.5,
+      "source_name": "iotbusinessnews",
+      "entities": [
+        {
+          "name": "IoT Business News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Internet_of_things",
+          "mid": "/m/02vnd10",
+          "salience": 0.02578151971101761,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Stadler Rail",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stadler_Rail",
+          "mid": "/m/0c86df",
+          "salience": 0.0032825006637722254,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Hitachi Rail",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hitachi_Rail",
+          "mid": "/g/11c56rkzrr",
+          "salience": 0.0032825006637722254,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Siemens Mobility",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Siemens_Mobility",
+          "mid": "/m/03cxlgw",
+          "salience": 0.0015021665021777153,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Alstom",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alstom",
+          "mid": "/m/011wfk",
+          "salience": 0.0015021665021777153,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "CAF",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Construcciones_y_Auxiliar_de_Ferrocarriles",
+          "mid": "/m/09p60f",
+          "salience": 0.0015021665021777153,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "PJM",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/PJM_Interconnection",
+          "mid": "/m/04f2lh1",
+          "salience": 0.0014989913906902075,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Giesecke+Devrient",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Giesecke_&_Devrient",
+          "mid": "/m/03c5_zw",
+          "salience": 0.0014989913906902075,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "North America",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_America",
+          "mid": "/m/059g4",
+          "salience": 0.0013825889909639955,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Europe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0013825889909639955,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "ORBCOMM",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Orbcomm",
+          "mid": "/m/09q7q8",
+          "salience": 0.0013752032537013292,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Nomad Digital",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nomad_Digital",
+          "mid": "/m/0134qx85",
+          "salience": 0.00045220315223559737,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "Quester Tangent",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Quester_Tangent_Corporation",
+          "mid": "/m/0j_79xv",
+          "salience": 0.00045220315223559737,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Shipping & Logistics/Freight Transport/Rail Freight",
+          "confidence": 0.8812739849090576,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "/Computers & Electronics/Consumer Electronics/GPS & Navigation",
+          "confidence": 0.5246102809906006,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.29283612966537476,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Shipping & Logistics/Freight Transport/Other",
+          "confidence": 0.20226141810417175,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.1646437644958496,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "/News/Technology News",
+          "confidence": 0.13076598942279816,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        },
+        {
+          "name": "/Computers & Electronics/Software/Business & Productivity Software",
+          "confidence": 0.10206758975982666,
+          "analyzed_at": "2026-06-10T08:01:02.382397+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Swap Bodrum for the Black Sea and Istanbul for Datça: Lesser-known Turkey destinations where you can escape the crowds",
+      "description": "From ski resorts to prehistoric ruins and mountain hikes to Michelin stars, Annabel Grossman shares the destinations you might not have previously considered",
+      "url": "https://www.independent.co.uk/travel/europe/turkey/beautiful-turkey-destinations-crowd-free-b2992394.html",
+      "image_url": "https://static.independent.co.uk/2024/09/24/15/Bozcaada-Coast-View-3.jpg?width=1200&auto=webp&crop=3%3A2",
+      "published_at": "2026-06-09T11:51:30+00:00",
+      "language": "en",
+      "country": "uk",
       "category": "general",
       "sentiment_label": "positive",
       "sentiment_score": 0.4000000059604645,
-      "source_name": "guardian"
+      "sentiment_magnitude": 23.100000381469727,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Turkish Riviera",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Turkish_Riviera",
+          "mid": "/m/0bxwrk",
+          "salience": 0.008782538585364819,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Sümela Monastery",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sumela_Monastery",
+          "mid": "/m/06dw_d",
+          "salience": 0.008479253388941288,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "GoTürkiye",
+          "type": "OTHER",
+          "wikipedia_url": "https://tr.wikipedia.org/wiki/Türkiye_Turizm_Tanıtım_ve_Geliştirme_Ajansı",
+          "mid": "/g/11smkltfh7",
+          "salience": 0.005780938547104597,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Marmaris",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Marmaris",
+          "mid": "/m/03f1t_",
+          "salience": 0.004761658608913422,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Bozcaada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tenedos",
+          "mid": "/m/02rptj",
+          "salience": 0.003164049703627825,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Akyaka",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Akyaka,_Ula",
+          "mid": "/m/02qhd65",
+          "salience": 0.0027809799648821354,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Bodrum",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bodrum",
+          "mid": "/m/01skxx",
+          "salience": 0.0026185999158769846,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Ercİyes Ski Resort",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Erciyes_Ski_Resort",
+          "mid": "/m/03m5mkx",
+          "salience": 0.0016236519441008568,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Köprülü Kanyon National Park",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Köprülü_Canyon",
+          "mid": "/m/02qx8pd",
+          "salience": 0.0013764151372015476,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Göbekli Tepe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Göbekli_Tepe",
+          "mid": "/m/02kgnz",
+          "salience": 0.0013447547098621726,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Cappadocia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cappadocia",
+          "mid": "/m/0kpgn",
+          "salience": 0.0012306737480685115,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Black Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Black_Sea",
+          "mid": "/m/015h7",
+          "salience": 0.0010397316655144095,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Istanbul",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Istanbul",
+          "mid": "/m/09949m",
+          "salience": 0.0009740252862684429,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Strabo",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Strabo",
+          "mid": "/m/0dq55",
+          "salience": 0.00075295235728845,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Erciyes",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Erciyes",
+          "mid": "/g/128dgqf1b",
+          "salience": 0.0006997798918746412,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Pontic Mountains",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pontic_Mountains",
+          "mid": "/m/026pm__",
+          "salience": 0.000690537563059479,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Aegean Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aegean_Sea",
+          "mid": "/m/0k2q",
+          "salience": 0.000577755447011441,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "God",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/God",
+          "mid": "/m/0d05l6",
+          "salience": 0.0005580472061410546,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Antalya",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Antalya",
+          "mid": "/m/01_hhp",
+          "salience": 0.0005502196145243943,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Central Anatolia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Central_Anatolia_region",
+          "mid": "/m/026_7m1",
+          "salience": 0.000512584752868861,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Uludağ",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Uludağ",
+          "mid": "/m/0f2dv4",
+          "salience": 0.00044960257946513593,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Fethiye",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fethiye",
+          "mid": "/m/0bj7dp",
+          "salience": 0.00042663441854529083,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Kemer",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kemer",
+          "mid": "/m/06rjkm",
+          "salience": 0.00042663441854529083,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Karadağ",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Montenegro",
+          "mid": "/m/056vv",
+          "salience": 0.00042663441854529083,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Pre-Pottery Neolithic",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neolithic",
+          "mid": "/m/059vp",
+          "salience": 0.0003394684463273734,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Şanlıurfa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Urfa",
+          "mid": "/m/01pz6s",
+          "salience": 0.00033708070986904204,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Greek",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greek_language",
+          "mid": "/m/0349s",
+          "salience": 0.00032806245144456625,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Rockies",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Colorado_Rockies",
+          "mid": "/m/01ync",
+          "salience": 0.00032519709202460945,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Datça Peninsula",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Datça_Peninsula",
+          "mid": "/m/0985th",
+          "salience": 0.00031842716271057725,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Stonehenge",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stonehenge",
+          "mid": "/m/06wfg",
+          "salience": 0.00030039437115192413,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Samsun",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Samsun",
+          "mid": "/m/0302hx",
+          "salience": 0.0002864870766643435,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Greek Orthodox",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greek_Orthodox_Church",
+          "mid": "/m/01gr6h",
+          "salience": 0.0002860163222067058,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Alps",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alps",
+          "mid": "/m/0lcd",
+          "salience": 0.00028560173814184964,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Phoenicians",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Phoenicia",
+          "mid": "/m/0617q",
+          "salience": 0.00026405934477224946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Persians",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Persians",
+          "mid": "/m/064pj",
+          "salience": 0.00026405934477224946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Byzantines",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantine_Empire",
+          "mid": "/m/017cw",
+          "salience": 0.00026405934477224946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Venetians",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Republic_of_Venice",
+          "mid": "/m/02wm6l",
+          "salience": 0.00026405934477224946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Kaz Dağları",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Ida_(Turkey)",
+          "mid": "/m/041_1t",
+          "salience": 0.00020706055511254817,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "iStock",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/IStock",
+          "mid": "/m/09h47q",
+          "salience": 0.0001979284279514104,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Adatepe",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Adatepe,_Ayvacık",
+          "mid": "/g/1224zqd6",
+          "salience": 0.00013816113641951233,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Homer's Iliad",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iliad",
+          "mid": "/m/03tt2",
+          "salience": 0.00013809023948851973,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Dalyan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dalyan",
+          "mid": "/m/0dy2t5",
+          "salience": 0.00011254865967202932,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Izmir",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/İzmir",
+          "mid": "/m/02s2xy",
+          "salience": 8.689687820151448e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "Michelin",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michelin_Guide",
+          "mid": "/m/06grr4",
+          "salience": 8.680379687575623e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Travel Guides & Travelogues",
+          "confidence": 0.8118959665298462,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Other",
+          "confidence": 0.7413110733032227,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Beaches & Islands",
+          "confidence": 0.26437878608703613,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Specialty Travel/Adventure Travel",
+          "confidence": 0.129848450422287,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Online Media/Online Image Galleries",
+          "confidence": 0.12015023082494736,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Hotels & Accommodations/Other",
+          "confidence": 0.10407712310552597,
+          "analyzed_at": "2026-06-09T16:03:00.299354+00:00"
+        }
+      ]
     },
     {
-      "title": "I’m a late arrival to short-form video – its effect on my life has shocked me | Rhiannon Lucy Cosslett",
-      "description": "Consuming constant clips made me feel stupider and lonelier. Thank God I’m old enough to remember a world beforeA clip from Before Sunrise. A woman joking that she won’t date men with flat heads because their lack of tummy time as babies betrays parental neglect that any female partner will be tasked with unpicking. Another woman gathering dahlias from her garden. A man discussing how Trump’s erratic night-time posting is a sign of the “sundowning” behaviours of patients with advanced dementia. Bob Mortimer being Bob Mortimer. An American cooking spaghetti in the same pan as a creamy...",
-      "url": "https://www.theguardian.com/commentisfree/2026/may/03/algorithm-short-form-video-overload",
-      "image_url": "https://i.guim.co.uk/img/media/a7483a32c0b3313266bb387d68617d2ea5f07b7e/1527_878_5153_4123/master/5153.jpg?width=140&quality=85&auto=format&fit=max&s=67cdc2f4eb1141e1a12d46df44735b7f",
-      "published_at": "2026-05-03T07:00:47+00:00",
+      "title": "What to do as murder is exploited to spread lies about race and privilege? Stand firm – fight back | Nesrine Malik",
+      "description": "Too many leaders have appeased the rightwing culture warriors. In the wake of the Henry Nowak rioting, the time for a push against toxicity and untruths is nowIt is easy to regard, and thus disregard, the riots following the conviction of Henry Nowak’s murderer as an explosion of reaction by a flammable and motivated minority. The more uncomfortable truth is that a specific notion, that people of colour have been privileged over and above mere equality, and been given dominion over white people, is now mainstream. Whether it is in the rejection of diversity, equity and inclusion initiatives...",
+      "url": "https://www.theguardian.com/commentisfree/2026/jun/08/murder-exploited-lies-race-privilege-henry-nowak",
+      "image_url": "https://i.guim.co.uk/img/media/f5dfb41ef8b94dfd34581526e038c2c36528e3a3/0_0_3950_3160/master/3950.jpg?width=140&quality=85&auto=format&fit=max&s=4678d373d19885c57d0ecc208f27b571",
+      "published_at": "2026-06-08T05:00:18+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.4000000059604645,
+      "sentiment_magnitude": 27.899999618530273,
+      "source_name": "guardian",
+      "entities": [
+        {
+          "name": "Nigel Farage",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nigel_Farage",
+          "mid": "/m/025qb6",
+          "salience": 0.03501874953508377,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Southampton",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Southampton",
+          "mid": "/m/0grd7",
+          "salience": 0.006913952995091677,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Tommy Robinson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tommy_Robinson",
+          "mid": "/m/0h1ht5z",
+          "salience": 0.004288353957235813,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Shutterstock View",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Shutterstock",
+          "mid": "/m/07ylgxl",
+          "salience": 0.003956540022045374,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Shabana Mahmood",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Shabana_Mahmood",
+          "mid": "/m/0bwl5cy",
+          "salience": 0.0025697520468384027,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Nesrine Malik",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nesrine_Malik",
+          "mid": "/g/11dd_v76c5",
+          "salience": 0.0022421348839998245,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Labour",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Labour_Party_(UK)",
+          "mid": "/m/01c9x",
+          "salience": 0.0014851713785901666,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Black Lives Matter",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Black_Lives_Matter",
+          "mid": "/m/012hdhkj",
+          "salience": 0.0010359237203374505,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.00048202177276834846,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Elon Musk",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Elon_Musk",
+          "mid": "/m/03nzf1",
+          "salience": 0.00048202177276834846,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Marina Hyde",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Marina_Hyde",
+          "mid": "/m/0fqnc_",
+          "salience": 0.00048202177276834846,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "Deindustrialisation",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deindustrialization",
+          "mid": "/m/02694t8",
+          "salience": 0.00021187978563830256,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.6659548878669739,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Discrimination & Identity Relations",
+          "confidence": 0.5861788392066956,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.38906145095825195,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.3604201674461365,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Other",
+          "confidence": 0.3573910892009735,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Law Enforcement",
+          "confidence": 0.26434144377708435,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.18774308264255524,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Other",
+          "confidence": 0.16651299595832825,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Human Rights & Liberties",
+          "confidence": 0.10718239098787308,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.10653891414403915,
+          "analyzed_at": "2026-06-09T08:53:35.456868+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Leila Farzad on not being able to return to Iran: ‘Going back got more complicated and dangerous’",
+      "description": "The ‘I Hate Suzie’ star hasn’t been back to her family’s war-torn homeland since her teens – but now she’s starring in a stage adaptation of one of the biggest Iranian films of the 21st century. She tells Ellie Harrison about reconnecting with her heritage, and how after years of tokenistic casting, she nearly gave up acting for good",
+      "url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/features/leila-farzad-iran-under-the-shadow-b2989626.html",
+      "image_url": "https://static.independent.co.uk/2026/06/03/14/52/TwoWeeksInAugust-2026-067_EditedBG-copy.jpeg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-07T05:00:00+00:00",
+      "language": "en",
+      "country": "uk",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.10000000149011612,
+      "sentiment_magnitude": 48.400001525878906,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Leila Farzad",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leila_Farzad",
+          "mid": "/g/11f5v51d1b",
+          "salience": 0.029903586953878403,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.02166556753218174,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Iranians",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iranian_peoples",
+          "mid": "/m/04nrnz",
+          "salience": 0.005119638983160257,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Almeida",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Almeida_Theatre",
+          "mid": "/m/04rlsg",
+          "salience": 0.0018770672613754869,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Iran-Iraq war",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran–Iraq_War",
+          "mid": "/m/03vc6",
+          "salience": 0.0016676412196829915,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Bafta",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/British_Academy_Film_Awards",
+          "mid": "/m/04y5rz9",
+          "salience": 0.001252089743502438,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Billie Piper",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Billie_Piper",
+          "mid": "/m/025mp5",
+          "salience": 0.001229823799803853,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.0012007263721898198,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Tehran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.001174529199488461,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Bridget Jones: Mad About the Boy",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bridget_Jones:_Mad_About_the_Boy",
+          "mid": "/g/11ldr1dp5r",
+          "salience": 0.0006123461644165218,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0006024197209626436,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Iraq",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iraq",
+          "mid": "/m/0d05q4",
+          "salience": 0.0005818300996907055,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Lucy Prebble",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lucy_Prebble",
+          "mid": "/m/05b370l",
+          "salience": 0.0005747240502387285,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Israel",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.0004683868319261819,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Islamic Republic",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islamic_republic",
+          "mid": "/m/01fgl7",
+          "salience": 0.00046733630006201565,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Sudanese",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sudan",
+          "mid": "/m/06tw8",
+          "salience": 0.0004654494405258447,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Lebanese",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.0004654494405258447,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Under the Shadow",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Under_the_Shadow",
+          "mid": "/g/11c3w1nhsl",
+          "salience": 0.00044554154737852514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Jane Fonda",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jane_Fonda",
+          "mid": "/m/0h1mt",
+          "salience": 0.0003159968473482877,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "British",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.000315802259137854,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Pakistani",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pakistan",
+          "mid": "/m/05sb1",
+          "salience": 0.0003125450457446277,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Indian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.0003125450457446277,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "I Hate Suzie",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/I_Hate_Suzie",
+          "mid": "/g/11jr8r17qf",
+          "salience": 0.00026971561601385474,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Sky UK",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sky_UK",
+          "mid": "/m/011ljgqv",
+          "salience": 0.00024597818264737725,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "JFK",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_F._Kennedy",
+          "mid": "/m/0d3k14",
+          "salience": 0.00021591494441963732,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "Tom Stoppard",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tom_Stoppard",
+          "mid": "/m/07h07",
+          "salience": 0.00015089842781890184,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Arts & Entertainment/Celebrities & Entertainment News",
+          "confidence": 0.7003871202468872,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Movies/Other",
+          "confidence": 0.36453333497047424,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "/People & Society/Other",
+          "confidence": 0.1740836650133133,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.15002122521400452,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Movies/Drama Films",
+          "confidence": 0.14315274357795715,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Performing Arts/Acting & Theater",
+          "confidence": 0.10390879958868027,
+          "analyzed_at": "2026-06-09T08:27:44.477767+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Palestinian baby shot dead by Israeli troops in occupied West Bank",
+      "description": "The seven-month-old, Sam Fahd Abu Haikal, was in his mother’s arms when soldiers fired on family in HebronIsraeli troops killed a seven-month-old Palestinian baby in the occupied West Bank and injured one of the child’s parents after opening fire on the family’s car, despite it having complied with an order to stop.Soldiers opened fire on Friday on a car carrying the infant and his parents in the Tel Rumeida area of Hebron. The seven-month-old, Sam Fahd Abu Haikal, was critically injured, evacuated in critical condition to a hospital, where he later died. His parents were also injured...",
+      "url": "https://www.theguardian.com/world/2026/jun/06/palestinian-baby-shot-dead-israeli-troops-occupied-west-bank",
+      "image_url": "https://i.guim.co.uk/img/media/7b1502f4737fba2035091024af186e1793036a8a/582_0_5802_4644/master/5802.jpg?width=140&quality=85&auto=format&fit=max&s=def2c18c4627d177a6ae1afd950d5166",
+      "published_at": "2026-06-06T11:25:41+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 26.200000762939453,
+      "source_name": "guardian",
+      "entities": [
+        {
+          "name": "Israeli",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.03924662619829178,
+          "mention_count": 19,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Hebron",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hebron",
+          "mid": "/m/09lvk",
+          "salience": 0.005200264044106007,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Israel Defense Forces",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel_Defense_Forces",
+          "mid": "/m/09s93",
+          "salience": 0.0019002617336809635,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Palestinian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Palestine",
+          "mid": "/m/01k0p4",
+          "salience": 0.0018523815087974072,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Haaretz",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Haaretz",
+          "mid": "/m/0h8mw",
+          "salience": 0.0017406842671334743,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "West Bank",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/West_Bank",
+          "mid": "/m/082pc",
+          "salience": 0.0015632662689313293,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Tel Rumeida",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tel_Rumeida",
+          "mid": "/m/0407xv4",
+          "salience": 0.001165015739388764,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Yesh Din",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yesh_Din",
+          "mid": "/m/05f9fh8",
+          "salience": 0.0007669375627301633,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "East Jerusalem",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jerusalem",
+          "mid": "/m/0430_",
+          "salience": 0.0005243875784799457,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Bethlehem University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bethlehem_University",
+          "mid": "/m/094gz_",
+          "salience": 0.0004367502115201205,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "B'Tselem",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/B'Tselem",
+          "mid": "/m/0h6bz",
+          "salience": 0.00038270786171779037,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Gaza Strip",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gaza_Strip",
+          "mid": "/m/0357_",
+          "salience": 0.00031410035444423556,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "British",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.00026824086671695113,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Tamoun",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tammun",
+          "mid": "/g/121v233m",
+          "salience": 0.0002681572223082185,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Hamas",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamas",
+          "mid": "/m/03m6j",
+          "salience": 0.00023586741008330137,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "Khan Younis",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Khan_Yunis",
+          "mid": "/m/0pq_y",
+          "salience": 0.00014074960199650377,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "UN",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 8.203845209209248e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.9822384119033813,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.6626493334770203,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.2241571843624115,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.15728870034217834,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Other",
+          "confidence": 0.12198705971240997,
+          "analyzed_at": "2026-06-10T08:05:40.490002+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Carer who 'couldn't go on' not guilty of mother's murder",
+      "description": "Stefania Glowka denied murder but pleaded guilty to manslaughter based on diminished responsibility.",
+      "url": "https://www.bbc.com/news/articles/cp8re26zl7do",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/821c/live/7e116d10-5ffa-11f1-b682-cf91850925ea.jpg",
+      "published_at": "2026-06-09T11:37:02+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 21.5,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Wiltshire Police",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wiltshire_Police",
+          "mid": "/m/09hfvs",
+          "salience": 0.008046528324484825,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Wiltshire",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wiltshire",
+          "mid": "/m/0dj0x",
+          "salience": 0.004164456389844418,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Bristol Crown Court",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bristol_Crown_Court",
+          "mid": "/m/0c96tm",
+          "salience": 0.003766266629099846,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Christmas Day",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christmas",
+          "mid": "/m/01vq3",
+          "salience": 0.003258698619902134,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0019259154796600342,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Devizes",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Devizes",
+          "mid": "/m/029_4v",
+          "salience": 0.0013945854734629393,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Chris Hughes",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chris_Hughes_(TV_personality)",
+          "mid": "/g/11h7t0cj4g",
+          "salience": 0.0011930137407034636,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Murder",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Murder",
+          "mid": "/m/051_y",
+          "salience": 0.0004226767341606319,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "English",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/English_language",
+          "mid": "/m/02h40lc",
+          "salience": 0.0003411127545405179,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.00021232270228210837,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Poland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Poland",
+          "mid": "/m/05qhw",
+          "salience": 0.00021232270228210837,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "England",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/England",
+          "mid": "/m/02jx1",
+          "salience": 0.0001265873434022069,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "University of Birmingham",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/University_of_Birmingham",
+          "mid": "/m/01dthg",
+          "salience": 0.0001111735837184824,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Wales",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wales",
+          "mid": "/m/0j5g9",
+          "salience": 0.0001111735837184824,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.0001111405945266597,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0001111405945266597,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "WhatsApp",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/WhatsApp",
+          "mid": "/m/0gwzvs1",
+          "salience": 0.00011110839113825932,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "Tower block",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tower_block",
+          "mid": "/m/0vlys",
+          "salience": 6.980665784794837e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.9188336133956909,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.7683625221252441,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.2632085084915161,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.2445105016231537,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.2184602916240692,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Family/Other",
+          "confidence": 0.10110881924629211,
+          "analyzed_at": "2026-06-09T16:03:18.271954+00:00"
+        }
+      ]
+    },
+    {
+      "title": "ECB Risks Repeating 2011 Mistake With Rate Hike, Economists Warn",
+      "description": "The European Central Bank’s resolve to uphold its inflation-quashing reputation risks luring it into a damaging error when it meets this week, economists warn.",
+      "url": "https://financialpost.com/pmn/business-pmn/ecb-risks-repeating-2011-mistake-with-rate-hike-economists-warn",
+      "image_url": null,
+      "published_at": "2026-06-08T04:36:03+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 26.600000381469727,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "ECB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Central_Bank",
+          "mid": "/m/02l6_",
+          "salience": 0.2336500734090805,
+          "mention_count": 14,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Eurostat",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Eurostat",
+          "mid": "/m/0328nz",
+          "salience": 0.0067786555737257,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Isabel Schnabel",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Isabel_Schnabel",
+          "mid": "/m/011snnr9",
+          "salience": 0.00559596810489893,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Yannis Stournaras",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yannis_Stournaras",
+          "mid": "/m/0k28fhy",
+          "salience": 0.003200644627213478,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Postmedia Network Inc.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.0025991923175752163,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.002259025350213051,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.002256356179714203,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Jean-Claude Trichet",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Claude_Trichet",
+          "mid": "/m/01_85c",
+          "salience": 0.0021738766226917505,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Peter Praet",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Peter_Praet",
+          "mid": "/m/0g4tm1p",
+          "salience": 0.0018370741745457053,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Holger Schmieding",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Holger_Schmieding",
+          "mid": "/m/0ll4z67",
+          "salience": 0.001569757703691721,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Christine Lagarde",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christine_Lagarde",
+          "mid": "/m/027xqz7",
+          "salience": 0.0012723051477223635,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Europe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0012118953745812178,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "TS Lombard",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/TS_Lombard",
+          "mid": "/m/088ck5",
+          "salience": 0.0008426945423707366,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Greek",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greek_language",
+          "mid": "/m/0349s",
+          "salience": 0.0008416019845753908,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "National Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Bank_of_Canada",
+          "mid": "/m/030z_n",
+          "salience": 0.000764863973017782,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Olli Rehn",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Olli_Rehn",
+          "mid": "/m/04pkc9",
+          "salience": 0.0007554914336651564,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Canadian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0006983442581258714,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Lehman Brothers",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lehman_Brothers",
+          "mid": "/m/0jt5_vh",
+          "salience": 0.0005716700106859207,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Mario Draghi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mario_Draghi",
+          "mid": "/m/09lfbm",
+          "salience": 0.0005714392173103988,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Group of Seven",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Group_of_Seven_(artists)",
+          "mid": "/m/01kgmf",
+          "salience": 0.0005707895033992827,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Federal Reserve",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Federal_Reserve",
+          "mid": "/m/02xmb",
+          "salience": 0.0005707895033992827,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Societe Generale",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Société_Générale",
+          "mid": "/m/02qhc8",
+          "salience": 0.0005649087252095342,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Doug Ford",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Doug_Ford",
+          "mid": "/m/0dsdr1x",
+          "salience": 0.0005634064436890185,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "IMF",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Monetary_Fund",
+          "mid": "/m/03y48",
+          "salience": 0.0005230995011515915,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Amazon",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amazon_(company)",
+          "mid": "/m/0mgkg",
+          "salience": 0.0005230995011515915,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.0005229277303442359,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Russia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 0.0005225975182838738,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 0.0005225975182838738,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Finland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Finland",
+          "mid": "/m/02vzc",
+          "salience": 0.0005221322644501925,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Morgan Stanley",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Morgan_Stanley",
+          "mid": "/m/0jvs0",
+          "salience": 0.00044661114225164056,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.00027395773213356733,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "France",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 0.00017219108121935278,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "Ireland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ireland",
+          "mid": "/m/012wgb",
+          "salience": 0.00017210084479302168,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "PGIM",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/PGIM",
+          "mid": "/g/11c5xvfls6",
+          "salience": 0.00017201433365698904,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Business News/Economy News",
+          "confidence": 0.7315109968185425,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Other",
+          "confidence": 0.4404112696647644,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "/News/Business News/Financial Markets News",
+          "confidence": 0.219099223613739,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "/Finance/Banking/Other",
+          "confidence": 0.21272563934326172,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Economics",
+          "confidence": 0.19986529648303986,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "/News/Business News/Fiscal Policy News",
+          "confidence": 0.15317954123020172,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.11914511024951935,
+          "analyzed_at": "2026-06-09T08:48:04.910762+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Germany news: Far-right push in low-key eastern elections",
+      "description": "The four local votes are widely seen as a barometer for state elections in eastern Germany in September. Meanwhile, Merz heads to London to discuss the Ukraine war as Putin rejects face-to-face talks.",
+      "url": "https://www.dw.com/en/germany-news-far-right-push-in-low-key-eastern-elections/live-77443232",
+      "image_url": null,
+      "published_at": "2026-06-07T07:39:00+00:00",
+      "language": "en",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.10000000149011612,
+      "sentiment_magnitude": 40.400001525878906,
+      "source_name": "dw",
+      "entities": [
+        {
+          "name": "Germany",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.17124812304973602,
+          "mention_count": 43,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Alexander Zverev",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alexander_Zverev",
+          "mid": "/m/0w336lx",
+          "salience": 0.11022675782442093,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Volodymyr Zelenskyy",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Volodymyr_Zelenskyy",
+          "mid": "/m/0w4j2z1",
+          "salience": 0.02534058876335621,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Munich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Munich",
+          "mid": "/m/02h6_6p",
+          "salience": 0.020745521411299706,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Munich Airport",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Munich_Airport",
+          "mid": "/m/01nhzy",
+          "salience": 0.019663773477077484,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.019436417147517204,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Emmanuel Macron",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emmanuel_Macron",
+          "mid": "/m/011ncr8c",
+          "salience": 0.008639649488031864,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.006751269102096558,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Frank-Walter Steinmeier",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Frank-Walter_Steinmeier",
+          "mid": "/m/089zlv",
+          "salience": 0.005522659048438072,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Hamburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamburg",
+          "mid": "/m/03hrz",
+          "salience": 0.005445227492600679,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "French Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/French_Open",
+          "mid": "/m/012xcl",
+          "salience": 0.0048210639506578445,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Friedrich Merz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Friedrich_Merz",
+          "mid": "/m/069pky",
+          "salience": 0.0033463304862380028,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Frankfurt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Frankfurt",
+          "mid": "/m/02z0j",
+          "salience": 0.0032879335340112448,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Ironman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ironman_Triathlon",
+          "mid": "/m/0lbks",
+          "salience": 0.0029784056823700666,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Grand Slam",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Grand_Slam_(tennis)",
+          "mid": "/m/01c2c1",
+          "salience": 0.002662407699972391,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Saxony",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saxony",
+          "mid": "/m/070zc",
+          "salience": 0.002570684300735593,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Alternative for Germany",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alternative_for_Germany",
+          "mid": "/m/0rfdxh0",
+          "salience": 0.0023903839755803347,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0023903839755803347,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Boris Pistorius",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boris_Pistorius",
+          "mid": "/m/0cg1xfw",
+          "salience": 0.0022931257262825966,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "DW News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deutsche_Welle",
+          "mid": "/m/01qrd7",
+          "salience": 0.0015133395791053772,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Otto Fricke",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Otto_Fricke",
+          "mid": "/m/0c7j6yl",
+          "salience": 0.0014433764154091477,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "1996 Australian Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/1996_Australian_Open",
+          "mid": "/m/06b3h9",
+          "salience": 0.0014379976782947779,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Thuringia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Thuringia",
+          "mid": "/m/07nf6",
+          "salience": 0.001425157068297267,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 0.0011937724193558097,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "WDR",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Westdeutscher_Rundfunk",
+          "mid": "/m/03dhs2",
+          "salience": 0.0011237215949222445,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 0.0010869719553738832,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Marcus Hoffmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Marcus_Hoffmann",
+          "mid": "/m/0gtw9tj",
+          "salience": 0.0010505218524485826,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Bundeswehr",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bundeswehr",
+          "mid": "/m/01q9lq",
+          "salience": 0.0008846849668771029,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Sophia Schiebe",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Sophia_Schiebe",
+          "mid": "/g/11s_wlt1hh",
+          "salience": 0.0008823139360174537,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Boris Becker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boris_Becker",
+          "mid": "/m/01ckb6",
+          "salience": 0.0008796851034276187,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Vladimir Putin",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vladimir_Putin",
+          "mid": "/m/08193",
+          "salience": 0.0008586443727836013,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Flavio Cobolli",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flavio_Cobolli",
+          "mid": "/g/11f2cj2m4q",
+          "salience": 0.0006671488517895341,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Tag der Bundeswehr",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Tag_der_Bundeswehr",
+          "mid": "/g/11c6w0bz1z",
+          "salience": 0.000662652833852917,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Landrat",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Landrat",
+          "mid": "/g/1224t4lh",
+          "salience": 0.0006251935847103596,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Thomas Benninghaus",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Thomas_Benninghaus",
+          "mid": "/g/11wc8phxkz",
+          "salience": 0.0006072644027881324,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Aue-Bad Schlema",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aue-Bad_Schlema",
+          "mid": "/m/02vwb8m",
+          "salience": 0.0005969091434963048,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Deutschlandfunk",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deutschlandfunk",
+          "mid": "/m/05_myb",
+          "salience": 0.0005766078247688711,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "United States",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0005236247670836747,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Freie Sachsen",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Freie_Sachsen",
+          "mid": "/g/11k4ng5b6q",
+          "salience": 0.0004962277598679066,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "World Cup",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA_World_Cup",
+          "mid": "/m/030q7",
+          "salience": 0.0004521539085544646,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Munich 1972",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/1972_Summer_Olympics",
+          "mid": "/m/0l98s",
+          "salience": 0.00042526901233941317,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Olympic",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Olympic_Games",
+          "mid": "/m/05nd_",
+          "salience": 0.00042315872269682586,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Hamburger Abendblatt",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamburger_Abendblatt",
+          "mid": "/m/0288r0_",
+          "salience": 0.0003756042569875717,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Children's Rights",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Children's_rights",
+          "mid": "/m/03qc82m",
+          "salience": 0.0003715042839758098,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Kiel",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kiel",
+          "mid": "/m/0g7pm",
+          "salience": 0.0003405663592275232,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Hindu",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hinduism",
+          "mid": "/m/03j6c",
+          "salience": 0.00032708465005271137,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "neo-Nazi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neo-Nazism",
+          "mid": "/m/0f69h",
+          "salience": 0.00031205909908749163,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.0003099305904470384,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Mecklenburg-Western Pomerania",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mecklenburg-Vorpommern",
+          "mid": "/m/09hzw",
+          "salience": 0.0002992299559991807,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Lars Klingbeil",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lars_Klingbeil",
+          "mid": "/m/0c6bf23",
+          "salience": 0.00028854908305220306,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Ganges",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ganges",
+          "mid": "/m/038df",
+          "salience": 0.00028725690208375454,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "DOSB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Olympic_Sports_Confederation",
+          "mid": "/m/02x9gq8",
+          "salience": 0.00028668687446042895,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Armed Forces Day",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Armed_Forces_Day",
+          "mid": "/m/0fc0yx",
+          "salience": 0.00027356139617040753,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Pope Francis",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pope_Francis",
+          "mid": "/m/05ngt2",
+          "salience": 0.00027319215587340295,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Köln-Höhenberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Höhenberg_(Köln)",
+          "mid": "/g/1q66q_4t7",
+          "salience": 0.0002555522369220853,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "UN",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 0.00023229161160998046,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Christian-Albrechts University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kiel_University",
+          "mid": "/m/02p72j",
+          "salience": 0.00023224271717481315,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Spree River",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spree_(river)",
+          "mid": "/m/014_fb",
+          "salience": 0.0002318369661225006,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Adolf Hitler",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Adolf_Hitler",
+          "mid": "/m/07_m9_",
+          "salience": 0.0002233951963717118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Nazis",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nazism",
+          "mid": "/m/05hyf",
+          "salience": 0.0002233951963717118,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Rhine-Ruhr",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rhine-Ruhr_metropolitan_region",
+          "mid": "/m/02j8yj",
+          "salience": 0.00022295188682619482,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Qatar",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Qatar",
+          "mid": "/m/0697s",
+          "salience": 0.00022278203687164932,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Langenwetzendorf",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Langenwetzendorf",
+          "mid": "/m/03cb1rc",
+          "salience": 0.00022267444001045078,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Greiz",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greiz_(district)",
+          "mid": "/m/01pwst",
+          "salience": 0.00022267444001045078,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Jan Frodeno",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jan_Frodeno",
+          "mid": "/m/04jfl9z",
+          "salience": 0.00022183444525580853,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "CDU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Democratic_Union_of_Germany",
+          "mid": "/m/0gg68",
+          "salience": 0.00022110265854280442,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Schleswig-Holstein",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Schleswig-Holstein",
+          "mid": "/m/06rf7",
+          "salience": 0.00020387877884786576,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Vatican",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vatican_City",
+          "mid": "/m/07ytt",
+          "salience": 0.00020371934806462377,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Neukölln",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neukölln",
+          "mid": "/m/022ndj",
+          "salience": 0.00020364331430755556,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Saalekreis",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saalekreis",
+          "mid": "/m/02vmpt0",
+          "salience": 0.00019073458679486066,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Saxony-Anhalt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saxony-Anhalt",
+          "mid": "/m/09hrc",
+          "salience": 0.0001788648369256407,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Brandenburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brandenburg",
+          "mid": "/m/017wh",
+          "salience": 0.0001684083981672302,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Saalfeld-Rudolstadt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saalfeld-Rudolstadt",
+          "mid": "/m/01zf83",
+          "salience": 0.00015358621021732688,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Middle East",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Middle_East",
+          "mid": "/m/04wsz",
+          "salience": 0.00015293296019081026,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Kyiv",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kyiv",
+          "mid": "/m/02sn34",
+          "salience": 0.00015284733672160655,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Moscow",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Moscow",
+          "mid": "/m/04swd",
+          "salience": 0.00015284733672160655,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Ostprignitz-Ruppin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ostprignitz-Ruppin",
+          "mid": "/m/0153fv",
+          "salience": 0.00015276549675036222,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Sonneberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sonneberg",
+          "mid": "/m/04vcs6",
+          "salience": 0.0001527258864371106,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Anadolu Agency",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Anadolu_Agency",
+          "mid": "/m/027bzq4",
+          "salience": 0.0001214910444105044,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Kai Havertz",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kai_Havertz",
+          "mid": "/g/11c1wqbf40",
+          "salience": 0.00012147725647082552,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Björn Höcke",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Björn_Höcke",
+          "mid": "/g/11b63dqkv3",
+          "salience": 0.00010682425636332482,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Bonn",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bonn",
+          "mid": "/m/0150n",
+          "salience": 0.00010677162936190143,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Champions League",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UEFA_Champions_League",
+          "mid": "/m/0c1q0",
+          "salience": 0.00010669648327166215,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Leroy Sane",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leroy_Sané",
+          "mid": "/m/010fksk0",
+          "salience": 0.00010668437607819214,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Bundeswehr University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Universität_der_Bundeswehr_München",
+          "mid": "/m/03cfb70",
+          "salience": 9.882912127068266e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Eurofighter",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Eurofighter_Typhoon",
+          "mid": "/m/016dy9",
+          "salience": 9.452437370782718e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Russia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 7.629273022757843e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Baltic Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Baltic_Sea",
+          "mid": "/m/01522",
+          "salience": 6.705149280605838e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Stefan Sauer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stefan_Sauer",
+          "mid": "/g/120kmx8v",
+          "salience": 6.702146492898464e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Neubiberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neubiberg",
+          "mid": "/m/03d1jt",
+          "salience": 6.70116933179088e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "Julian Nagelsmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Julian_Nagelsmann",
+          "mid": "/g/11bwjbhzf8",
+          "salience": 5.762047294410877e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Transportation/Air Travel",
+          "confidence": 0.5478546619415283,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.3470616638660431,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.2059384137392044,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        },
+        {
+          "name": "/Sports/Individual Sports/Racquet Sports",
+          "confidence": 0.16877301037311554,
+          "analyzed_at": "2026-06-09T08:21:41.291627+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Hunger in Oleshky: Ukraine asks for evacuation",
+      "description": "The Ukrainian city of Oleshky has been occupied by Russian troops since 2022. Many residents are cut off from the outside world and living in dire conditions. Now, Kyiv wants to rescue them.",
+      "url": "https://www.dw.com/en/hunger-in-oleshky-ukraine-asks-for-evacuation/a-77395744",
+      "image_url": null,
+      "published_at": "2026-06-06T13:16:00+00:00",
+      "language": "en",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 25.5,
+      "source_name": "dw",
+      "entities": [
+        {
+          "name": "Oleshky",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oleshky",
+          "mid": "/m/0gt48n",
+          "salience": 0.281440407037735,
+          "mention_count": 21,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 0.0540841743350029,
+          "mention_count": 18,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Kherson",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kherson",
+          "mid": "/m/03_dfy",
+          "salience": 0.026444820687174797,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "https://p.dw.com/p/5EkAS The Antonivka Road Bridge",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Antonivka_Road_Bridge",
+          "mid": "/g/1ydpbkqgk",
+          "salience": 0.012770495377480984,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Russians",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russians",
+          "mid": "/m/0g6ff",
+          "salience": 0.006143724545836449,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Kyiv",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kyiv",
+          "mid": "/m/02sn34",
+          "salience": 0.0047336784191429615,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "International Committee of the Red Cross",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Committee_of_the_Red_Cross",
+          "mid": "/m/0c_bfw",
+          "salience": 0.004555208142846823,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Russia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 0.004221396986395121,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Dnipro River",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dnieper",
+          "mid": "/m/021g_z",
+          "salience": 0.00355635117739439,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Kakhovka",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kakhovka",
+          "mid": "/m/0dqf35",
+          "salience": 0.0032205586321651936,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Ukrainians",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukrainians",
+          "mid": "/m/012f86",
+          "salience": 0.0009973619598895311,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Save Ukraine",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Save_Ukraine",
+          "mid": "/g/11lmdnvzb1",
+          "salience": 0.0006911884411238134,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Red Cross",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/American_Red_Cross",
+          "mid": "/m/0by8vb",
+          "salience": 0.0005626588244922459,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Moscow",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Moscow",
+          "mid": "/m/04swd",
+          "salience": 0.0005624580080620944,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "United Nations",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 0.0004968072171323001,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Tatyana Moskalkova",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tatyana_Moskalkova",
+          "mid": "/g/119pfzf1b",
+          "salience": 0.0004934764001518488,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Ukrainian Foreign Ministry",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ministry_of_Foreign_Affairs_of_Ukraine",
+          "mid": "/m/04gpzyc",
+          "salience": 0.00043158335029147565,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Skadovsk",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Skadovsk",
+          "mid": "/m/0dqf2g",
+          "salience": 0.0003725749847944826,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Belarusian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belarus",
+          "mid": "/m/0163v",
+          "salience": 0.00037058425368741155,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Organization for Security and Cooperation in Europe",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Organization_for_Security_and_Co-operation_in_Europe",
+          "mid": "/m/05q11",
+          "salience": 0.0002462805132381618,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Human Rights",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Human_rights",
+          "mid": "/m/03ll3",
+          "salience": 0.00020287997904233634,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "Moscow",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Moscow",
+          "mid": "/m/04swd",
+          "salience": 0.00018523157632444054,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.844626247882843,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.4984428584575653,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.24918068945407867,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.20370104908943176,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.1630070060491562,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.15844178199768066,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Accidents & Disasters",
+          "confidence": 0.119450643658638,
+          "analyzed_at": "2026-06-09T08:00:44.235748+00:00"
+        }
+      ]
+    },
+    {
+      "title": "We Love Green 2026 review: Gorillaz, Addison Rae and the xx lend Paris festival the clout to rival Primavera",
+      "description": "French festival offers a more low-key but no less impressive musical offering than its bigger Spanish sibling",
+      "url": "https://www.independent.co.uk/arts-entertainment/music/reviews/we-love-green-2026-review-gorillaz-addison-rae-b2992398.html",
+      "image_url": "https://static.independent.co.uk/2026/06/09/11/38/WLG-26-Gorillaz-credit_-isaacponseele-jpg23.jpg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-09T12:47:14+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 19.200000762939453,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "We Love Green",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/We_Love_Green",
+          "mid": "/g/11bzq320xz",
+          "salience": 0.0439484529197216,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Damon Albarn",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Damon_Albarn",
+          "mid": "/m/0phx4",
+          "salience": 0.0256001316010952,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Addison Rae",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Addison_Rae",
+          "mid": "/g/11j7vqw27y",
+          "salience": 0.016962481662631035,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Hayley Williams",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hayley_Williams",
+          "mid": "/m/057xn_m",
+          "salience": 0.01656648889183998,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Britney Spears",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Britney_Spears",
+          "mid": "/m/015f7",
+          "salience": 0.011733338236808777,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Clint Eastwood",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Clint_Eastwood",
+          "mid": "/m/0bwh6",
+          "salience": 0.010159582830965519,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Primavera",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Primavera_Sound",
+          "mid": "/m/02pgxdz",
+          "salience": 0.00944563653320074,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Omar Souleyman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Omar_Souleyman",
+          "mid": "/m/06w8xbh",
+          "salience": 0.008533366024494171,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Spanish",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spanish_language",
+          "mid": "/m/06nm1",
+          "salience": 0.007932999171316624,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Fatoumata Diawara",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fatoumata_Diawara",
+          "mid": "/m/0gcdx79",
+          "salience": 0.0074960594065487385,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Barcelona",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Barcelona",
+          "mid": "/m/01f62",
+          "salience": 0.005291542038321495,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Bois de Vincennes",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bois_de_Vincennes",
+          "mid": "/g/11zjkkjlnt",
+          "salience": 0.005258392542600632,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Gorillaz",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gorillaz",
+          "mid": "/m/03fbc",
+          "salience": 0.005236670840531588,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Oklou",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oklou",
+          "mid": "/g/11h426gnqk",
+          "salience": 0.004640158731490374,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Ethel Cain",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ethel_Cain",
+          "mid": "/g/11h4x0rtw6",
+          "salience": 0.0020677032880485058,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Damascus",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Damascus",
+          "mid": "/m/02gjp",
+          "salience": 0.00197181710973382,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Syrian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Syria",
+          "mid": "/m/06vbd",
+          "salience": 0.00197181710973382,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Malian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mali",
+          "mid": "/m/04v09",
+          "salience": 0.00197181710973382,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "British",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0013253832003101707,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "TikTok",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/TikTok",
+          "mid": "/g/11f555cn8l",
+          "salience": 0.001324174227192998,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "MTV",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/MTV",
+          "mid": "/m/04rqd",
+          "salience": 0.0013230497715994716,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "The xx",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_xx",
+          "mid": "/m/07kht64",
+          "salience": 0.0011685751378536224,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Paramore",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paramore",
+          "mid": "/m/09lwrt",
+          "salience": 0.001041393494233489,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.000914885604288429,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.0009143223287537694,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Dom Dolla",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dom_Dolla",
+          "mid": "/g/11gnst0x37",
+          "salience": 0.0006389835034497082,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Australian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Australia",
+          "mid": "/m/0chghy",
+          "salience": 0.0006389835034497082,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "Ninajirachi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ninajirachi",
+          "mid": "/g/11h91_fdsh",
+          "salience": 0.0006389835034497082,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Arts & Entertainment/Events & Listings/Concerts & Music Festivals",
+          "confidence": 0.48623645305633545,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Music & Audio/Rock Music",
+          "confidence": 0.3703697919845581,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Celebrities & Entertainment News",
+          "confidence": 0.2407766431570053,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Music & Audio/Pop Music",
+          "confidence": 0.17947223782539368,
+          "analyzed_at": "2026-06-09T16:02:32.762824+00:00"
+        }
+      ]
+    },
+    {
+      "title": "From Daytime Adventures to Evening Experiences: Explore RBG This Summer",
+      "description": "BURLINGTON, Ontario &#8212; Royal Botanical Gardens (RBG) is your go-to destination all season long. From family-friendly experiences to 19+ evening events, there are countless ways to explore the gardens and grounds this summer. Royal Botanical Gardens (RBG) is your go-to destination this summer! From family-friendly experiences to 19+ evening events, there are countless ways to [&#8230;]",
+      "url": "https://financialpost.com/pmn/business-wire-news-releases-pmn/from-daytime-adventures-to-evening-experiences-explore-rbg-this-summer",
+      "image_url": null,
+      "published_at": "2026-06-08T15:36:44+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 25.799999237060547,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "Royal Botanical Gardens",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Royal_Botanical_Gardens_(Ontario)",
+          "mid": "/m/04rmqq",
+          "salience": 0.07646697014570236,
+          "mention_count": 18,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Garden Article",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Article_(publishing)",
+          "mid": "/m/07t5cj",
+          "salience": 0.06882021576166153,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Business Wire",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Business_Wire",
+          "mid": "/m/05l0qw",
+          "salience": 0.006964548025280237,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Postmedia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.0019676529336720705,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Ontario",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ontario",
+          "mid": "/m/05kr_",
+          "salience": 0.0015945399645715952,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Lido Pimienta",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lido_Pimienta",
+          "mid": "/g/11fxdzn5jz",
+          "salience": 0.0012849702034145594,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.001090348931029439,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Patrick Watson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Patrick_Watson_(musician)",
+          "mid": "/m/0k_gyj",
+          "salience": 0.0008772590663284063,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "BADBADNOTGOOD",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BadBadNotGood",
+          "mid": "/m/0nhqzmz",
+          "salience": 0.0008772590663284063,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "The Barr Brothers",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Barr_Brothers",
+          "mid": "/m/0fqk8zz",
+          "salience": 0.0008772590663284063,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Hamilton Philharmonic Orchestra",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamilton_Philharmonic_Orchestra",
+          "mid": "/m/08t07v",
+          "salience": 0.0008772590663284063,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Stan Cho",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stan_Cho",
+          "mid": "/g/11ght6mjp8",
+          "salience": 0.0006319725653156638,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Amazon",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amazon_(company)",
+          "mid": "/m/0mgkg",
+          "salience": 0.000553726393263787,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Government of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Government_of_Canada",
+          "mid": "/m/02wz7x",
+          "salience": 0.0005428181611932814,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "National Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Bank_of_Canada",
+          "mid": "/m/030z_n",
+          "salience": 0.0004070945142302662,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Doug Ford",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Doug_Ford",
+          "mid": "/m/0dsdr1x",
+          "salience": 0.0004021114727947861,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.0002846750139724463,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.0002846750139724463,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "IMF",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Monetary_Fund",
+          "mid": "/m/03y48",
+          "salience": 0.0002846750139724463,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.00017856461636256427,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.00017856461636256427,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Regional Parks & Gardens",
+          "confidence": 0.802522599697113,
+          "analyzed_at": "2026-06-09T06:19:44.229044+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Why parents like me are living in fear of fake squishy dumpling toys",
+      "description": "First, it was Labubus, now it is all about new gel-filled squidgy dumpling toys – and there are counterfeit versions causing havoc. These crazes are driving mum of two, Charlotte Cripps, mad",
+      "url": "https://www.independent.co.uk/life-style/squishy-dumpling-toys-toxic-labubu-lafufu-b2988734.html",
+      "image_url": "https://static.independent.co.uk/2026/06/03/9/21/dumpling-squishies.jpeg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-07T05:00:00+00:00",
+      "language": "en",
+      "country": "uk",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 34.79999923706055,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Trading Standards",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trading_Standards",
+          "mid": "/m/0hn841c",
+          "salience": 0.013571481220424175,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "VOCs",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Volatile_organic_compound",
+          "mid": "/m/03zbcv",
+          "salience": 0.006652695592492819,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Trafford Council",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trafford_Council",
+          "mid": "/m/0_v3wz7",
+          "salience": 0.00561989052221179,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Labubu",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Labubu",
+          "mid": "/g/11wqzkqgmp",
+          "salience": 0.005470279138535261,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0048563797026872635,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "TikTok",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/TikTok",
+          "mid": "/g/11f555cn8l",
+          "salience": 0.002269201446324587,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Swansea Council",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Swansea_Council",
+          "mid": "/m/0d2gpv",
+          "salience": 0.0010792544344440103,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0008452179026789963,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "m-Xylene",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/M-Xylene",
+          "mid": "/m/095dn7",
+          "salience": 0.0008380676154047251,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Heathrow airport",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Heathrow_Airport",
+          "mid": "/m/03jn4",
+          "salience": 0.000678504176903516,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.0006775578367523849,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 0.00046469629160128534,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "Consumer Reports",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Consumer_Reports",
+          "mid": "/m/01q1hl",
+          "salience": 0.0002325777750229463,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "pH",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/PH",
+          "mid": "/m/0642d",
+          "salience": 0.0002325777750229463,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0002042559499386698,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "University of Aberdeen",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/University_of_Aberdeen",
+          "mid": "/m/01f6ss",
+          "salience": 0.00020413323363754898,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Shopping/Toys/Other",
+          "confidence": 0.6833712458610535,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "/Shopping/Consumer Resources/Product Reviews & Price Comparisons",
+          "confidence": 0.2740037143230438,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "/Health/Public Health/Toxic Substances & Poisoning",
+          "confidence": 0.20547577738761902,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Family/Other",
+          "confidence": 0.13454775512218475,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "/Health/Public Health/Other",
+          "confidence": 0.1321626752614975,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "/Food & Drink/Food/Snack Foods",
+          "confidence": 0.11160722374916077,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        },
+        {
+          "name": "/Shopping/Consumer Resources/Consumer Advocacy & Protection",
+          "confidence": 0.1089433804154396,
+          "analyzed_at": "2026-06-09T06:28:33.858506+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Birth rates are declining in most of the world—here's why it really matters",
+      "description": "Birth rates have been declining worldwide since the peak of the post-Second World War baby boom. Birth rates have now reached below replacement in most of the world, including Australia. Put simply, populations on average aren't replacing themselves.",
+      "url": "https://phys.org/news/2026-06-birth-declining-world.html",
+      "image_url": "https://scx1.b-cdn.net/csz/news/tmb/2026/birth-rates-are-declin.jpg",
+      "published_at": "2026-06-06T12:00:05+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "science",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 24.5,
+      "source_name": "phys",
+      "entities": [
+        {
+          "name": "Giorgia Meloni",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Giorgia_Meloni",
+          "mid": "/m/0dll6qf",
+          "salience": 0.015046737156808376,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "The Conversation",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Conversation_(website)",
+          "mid": "/m/0glqvf6",
+          "salience": 0.013809547759592533,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.013089971616864204,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Liz Allen",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Liz_Allan",
+          "mid": "/m/0468zl",
+          "salience": 0.008356446400284767,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Paul Ehrlich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paul_R._Ehrlich",
+          "mid": "/m/01_8tz",
+          "salience": 0.007678277790546417,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "The Population Bomb",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Population_Bomb",
+          "mid": "/m/0dts3",
+          "salience": 0.005669517442584038,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Australia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Australia",
+          "mid": "/m/0chghy",
+          "salience": 0.004547386895865202,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "South Korea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/South_Korea",
+          "mid": "/m/06qd3",
+          "salience": 0.004327720496803522,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Elon Musk",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Elon_Musk",
+          "mid": "/m/03nzf1",
+          "salience": 0.003966081887483597,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Italian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.003966081887483597,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Tony Abbott",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tony_Abbott",
+          "mid": "/m/02pr80",
+          "salience": 0.0038112050388008356,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Peter Costello",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Peter_Costello",
+          "mid": "/m/022h7g",
+          "salience": 0.0035415031015872955,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Jim Chalmers",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jim_Chalmers",
+          "mid": "/m/0y6979c",
+          "salience": 0.003538497956469655,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Overpopulation",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Human_overpopulation",
+          "mid": "/m/0cbx6v",
+          "salience": 0.002234804444015026,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "OECD",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/OECD",
+          "mid": "/m/018cqq",
+          "salience": 0.0014838220085948706,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Australians",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Australia_national_cricket_team",
+          "mid": "/m/020wyp",
+          "salience": 0.0013448391109704971,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Germany",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.0009970511309802532,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Thailand",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Thailand",
+          "mid": "/m/07f1x",
+          "salience": 0.0009963071206584573,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Greece",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greece",
+          "mid": "/m/035qy",
+          "salience": 0.0009963071206584573,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Cuba",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cuba",
+          "mid": "/m/0d04z6",
+          "salience": 0.0009963071206584573,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0009943151380866766,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Japan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Japan",
+          "mid": "/m/03_3d",
+          "salience": 0.0009720689267851412,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "United Nations",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 0.0009174817823804915,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "United Kingdom",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0005580980214290321,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "Creative Commons",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Creative_Commons",
+          "mid": "/m/0drb3",
+          "salience": 0.0004805159114766866,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/People & Society/Social Sciences/Demographics",
+          "confidence": 0.8939758539199829,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Family/Other",
+          "confidence": 0.2066696435213089,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Other",
+          "confidence": 0.12145829945802689,
+          "analyzed_at": "2026-06-10T08:05:18.118084+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Schoolgirl arrested after three hurt in knife attack",
+      "description": "Three people suffer knife wounds and a pupil is arrested at the school on Plant Hill Road in Blackley.",
+      "url": "https://www.bbc.com/news/articles/c4gydjpdwy2o",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/f3ed/live/7e6bb860-63e7-11f1-bb83-f9b0320ac35b.jpg",
+      "published_at": "2026-06-09T09:42:49+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 16.899999618530273,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Greater Manchester Police",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greater_Manchester_Police",
+          "mid": "/m/0863hf",
+          "salience": 0.03978079557418823,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Samuel Rhodes",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Samuel_Rhodes",
+          "mid": "/g/11bwyc1q9t",
+          "salience": 0.009153394959867,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.009153394959867,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "BBC Radio Manchester",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_Radio_Manchester",
+          "mid": "/m/0ccldx",
+          "salience": 0.008243400603532791,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Manchester Blackley",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manchester_Blackley_(UK_Parliament_constituency)",
+          "mid": "/m/05yt_4",
+          "salience": 0.007268185261636972,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Department for Education",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Department_for_Education",
+          "mid": "/m/0by1428",
+          "salience": 0.001104119117371738,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.0005305125960148871,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0005305125960148871,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "Whatsapp",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/WhatsApp",
+          "mid": "/m/0gwzvs1",
+          "salience": 0.0005303116049617529,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 1.0,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "/Jobs & Education/Education/Primary & Secondary Schooling (K-12)",
+          "confidence": 0.6352525949478149,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.5449779629707336,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.11062731593847275,
+          "analyzed_at": "2026-06-09T16:03:48.225037+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Iran-US war latest: Israel launches retaliatory strikes on Iran’s military targets after missile attack",
+      "description": "Explosions were reported in several cities, including Tehran and Isfahan",
+      "url": "https://www.independent.co.uk/news/world/middle-east/iran-us-war-live-trump-israel-strikes-missile-attack-b2991499.html",
+      "image_url": "https://static.independent.co.uk/2026/06/08/01/2026-06-07T193703Z_689254017_RC27PLAPSPBI_RTRMADP_3_IRAN-CRISIS-ISRAEL.JPG.jpg?width=1200&auto=webp&crop=3%3A2",
+      "published_at": "2026-06-08T03:55:49+00:00",
       "language": "en",
       "country": "gb",
       "category": "general",
       "sentiment_label": "neutral",
       "sentiment_score": -0.10000000149011612,
-      "source_name": "guardian"
+      "sentiment_magnitude": 25.700000762939453,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.19872769713401794,
+          "mention_count": 32,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.18307943642139435,
+          "mention_count": 23,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.03481804579496384,
+          "mention_count": 18,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Centcom",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Central_Command",
+          "mid": "/m/01xsrd",
+          "salience": 0.010643248446285725,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Benjamin Netanyahu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Netanyahu",
+          "mid": "/m/0fm2h",
+          "salience": 0.008812966756522655,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Middle East",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Middle_East",
+          "mid": "/m/04wsz",
+          "salience": 0.006512384861707687,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Israel",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.005852014757692814,
+          "mention_count": 23,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Indian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.005022889468818903,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Strait of Hormuz",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Strait_of_Hormuz",
+          "mid": "/m/075t9",
+          "salience": 0.0024606985971331596,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Houthis",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houthis",
+          "mid": "/m/047vsxx",
+          "salience": 0.002204093150794506,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Palau",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Palau",
+          "mid": "/m/05tr7",
+          "salience": 0.0013538860948756337,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Mexico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.0011754481820389628,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Omani",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oman",
+          "mid": "/m/05l8y",
+          "salience": 0.0011626241030171514,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Gulf of Oman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gulf_of_Oman",
+          "mid": "/m/03cqb",
+          "salience": 0.0009598677279427648,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Lincoln",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lincoln,_Nebraska",
+          "mid": "/m/04gxf",
+          "salience": 0.0006330963806249201,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Super Hornet",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boeing_F/A-18E/F_Super_Hornet",
+          "mid": "/m/03ggkw",
+          "salience": 0.0006330963806249201,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Christian",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christianity",
+          "mid": "/m/01lp8",
+          "salience": 0.0005866648280061781,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "US Navy",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Navy",
+          "mid": "/g/11bwc46k0_",
+          "salience": 0.0005464950809255242,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Tyre",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tyre,_Lebanon",
+          "mid": "/m/07kx2",
+          "salience": 0.0005037646624259651,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Lebanon",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.0005037646624259651,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "World Cup",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA_World_Cup",
+          "mid": "/m/030q7",
+          "salience": 0.00045769193093292415,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Hezbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hezbollah",
+          "mid": "/m/03m7d",
+          "salience": 0.00044567370787262917,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Tehran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.00042775305337272584,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Red Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Red_Sea",
+          "mid": "/m/06jfd",
+          "salience": 0.0004275803512427956,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Yemen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yemen",
+          "mid": "/m/01z88t",
+          "salience": 0.0004275803512427956,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "PTI",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Press_Trust_of_India",
+          "mid": "/m/05r9lj",
+          "salience": 0.0004243773000780493,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.0004243773000780493,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "UNESCO World Heritage Site",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/World_Heritage_Site",
+          "mid": "/m/0c7g7",
+          "salience": 0.00039115455001592636,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "White House",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/White_House",
+          "mid": "/m/081sq",
+          "salience": 0.0002935502561740577,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Apache",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Apache",
+          "mid": "/m/01_5cg",
+          "salience": 0.0002934826770797372,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 0.0002049430040642619,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.00016575746121816337,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Tijuana",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tijuana",
+          "mid": "/m/0pswc",
+          "salience": 0.00012898170098196715,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "Minab",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Minab",
+          "mid": "/m/078wby",
+          "salience": 0.0001289443316636607,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.9212512969970703,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.7752668857574463,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.5993220210075378,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Executive Branch",
+          "confidence": 0.44259727001190186,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.238264262676239,
+          "analyzed_at": "2026-06-09T08:42:09.302407+00:00"
+        }
+      ]
     },
     {
-      "title": "Trump says US navy like ‘pirates’ while seizing a ship in Iranian blockade",
-      "description": "US president says ‘we took over the cargo, took over the oil. It’s a very profitable business’Middle East crisis – live updatesDonald Trump has said the US navy acted “like pirates” as he described an operation seizing a ship amid the tit-for-tat American blockade of Iranian ports.“We … land on top of it and we took over the ship. We took over the cargo, took over the oil. It’s a very profitable business,” said Trump at a rally in Florida on Friday. Continue reading...",
-      "url": "https://www.theguardian.com/world/2026/may/02/trump-us-navy-pirates-iran-blockade",
-      "image_url": "https://i.guim.co.uk/img/media/26c887e5d6119520e8dbb58c8b21edbae11ecbb5/0_0_4144_3316/master/4144.jpg?width=140&quality=85&auto=format&fit=max&s=52af9570620765831daf7267e69d225b",
-      "published_at": "2026-05-02T10:37:28+00:00",
+      "title": "French Open final LIVE: Alexander Zverev battles to break grand slam duck against Flavio Cobolli",
+      "description": "Second seed Alexander Zverev is yet to win a grand slam final but has the best opportunity of his career against first-time major finalist Flavio Cobolli, who advanced via walkover",
+      "url": "https://www.independent.co.uk/sport/tennis/french-open-final-live-zverev-v-cobolli-score-results-today-b2991290.html",
+      "image_url": "https://static.independent.co.uk/2026/06/06/13/2280152409..?width=1200&auto=webp&crop=3%3A2",
+      "published_at": "2026-06-07T12:10:01+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.30000001192092896,
+      "sentiment_magnitude": 34.29999923706055,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Flavio Cobolli",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flavio_Cobolli",
+          "mid": "/g/11f2cj2m4q",
+          "salience": 0.5545650720596313,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Alexander Zverev",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alexander_Zverev",
+          "mid": "/m/0w336lx",
+          "salience": 0.08615083247423172,
+          "mention_count": 17,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Grand Slam",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Grand_Slam_(tennis)",
+          "mid": "/m/01c2c1",
+          "salience": 0.022433938458561897,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "French Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/French_Open",
+          "mid": "/m/012xcl",
+          "salience": 0.0067431190982460976,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Germany",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.003961245995014906,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Stefano Cobolli",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stefano_Cobolli",
+          "mid": "/g/11h0md6j4h",
+          "salience": 0.003923716489225626,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Italy",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.0031744276639074087,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Matteo Arnaldi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Matteo_Arnaldi",
+          "mid": "/g/11gr4n781y",
+          "salience": 0.0031744276639074087,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Italian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.0031744276639074087,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "German",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 0.0019418285228312016,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Boris Becker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boris_Becker",
+          "mid": "/m/01ckb6",
+          "salience": 0.0017675691051408648,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "1996 Australian Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/1996_Australian_Open",
+          "mid": "/m/06b3h9",
+          "salience": 0.0006690256996080279,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "US Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/US_Open_(tennis)",
+          "mid": "/m/0l6c9",
+          "salience": 0.00046302619739435613,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Henner Henkel",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Henner_Henkel",
+          "mid": "/m/0f7z1z",
+          "salience": 0.0004157883522566408,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Dominic Thiem",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dominic_Thiem",
+          "mid": "/m/0j2012m",
+          "salience": 0.0002950772177428007,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Novak Djokovic",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Novak_Djokovic",
+          "mid": "/m/09n70c",
+          "salience": 0.0002608283539302647,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Jannik Sinner",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jannik_Sinner",
+          "mid": "/g/11fk09t6nz",
+          "salience": 0.0002608283539302647,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "Carlos Alcaraz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Carlos_Alcaraz",
+          "mid": "/g/11f50292yv",
+          "salience": 0.0002608283539302647,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Individual Sports/Racquet Sports",
+          "confidence": 0.9672186970710754,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.8475590348243713,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.8136362433433533,
+          "analyzed_at": "2026-06-09T08:30:15.660767+00:00"
+        }
+      ]
+    },
+    {
+      "title": "This West Papua cruise takes you to one of the most remote places in the world",
+      "description": "Far from the bright lights of Bali, Laura French takes the journey of a lifetime on an expedition cruise of Indonesia, taking in rarely visited Asmat villages and the Coral Triangle",
+      "url": "https://www.independent.co.uk/travel/asia/indonesia/west-papua-cruise-aqua-expeditions-b2982029.html",
+      "image_url": "https://static.independent.co.uk/2026/05/22/14/54/West-Papua-Triton-Bay.jpeg?width=1200&auto=webp&trim=0%2C85%2C0%2C83",
+      "published_at": "2026-06-06T13:10:40+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 24.299999237060547,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "West Papua",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/West_Papua_(province)",
+          "mid": "/m/02tc_5",
+          "salience": 0.0346127413213253,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Asmat",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asmat_people",
+          "mid": "/m/094nqr",
+          "salience": 0.02485320344567299,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Carl Hoffman",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Carl_Hoffman",
+          "mid": "/m/0c4cwmm",
+          "salience": 0.009634861722588539,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Indonesia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Indonesia",
+          "mid": "/m/03ryn",
+          "salience": 0.0045258100144565105,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Jakarta",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jakarta",
+          "mid": "/m/044rv",
+          "salience": 0.003077269531786442,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Michael Rockefeller",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michael_Rockefeller",
+          "mid": "/m/03f2wd",
+          "salience": 0.002910744631662965,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Coral Triangle",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Coral_Triangle",
+          "mid": "/m/04ldh17",
+          "salience": 0.0027709410060197115,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "New Guinea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Guinea",
+          "mid": "/m/05h3y",
+          "salience": 0.0023268982768058777,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Arafura Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arafura_Sea",
+          "mid": "/m/05zvfm",
+          "salience": 0.002039134968072176,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Papuan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Indigenous_people_of_New_Guinea",
+          "mid": "/m/03m3myf",
+          "salience": 0.0016852736007422209,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Ambon",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ambon,_Maluku",
+          "mid": "/m/02kstz",
+          "salience": 0.0012760094832628965,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Wood",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wood",
+          "mid": "/m/083vt",
+          "salience": 0.0010989460861310363,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Europe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0009852771181613207,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Dutch",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Netherlands",
+          "mid": "/m/059j2",
+          "salience": 0.0009830675553530455,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Benjamin Ross",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Ross",
+          "mid": "/m/04gnylx",
+          "salience": 0.0009419125271961093,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Danube",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Danube",
+          "mid": "/m/026zt",
+          "salience": 0.0008722691563889384,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Lower Danube",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lower_Danube_(Euroregion)",
+          "mid": "/m/03hkj1b",
+          "salience": 0.0008722691563889384,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Douro",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Douro",
+          "mid": "/m/0hyt3",
+          "salience": 0.0007660704432055354,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 0.0007651718333363533,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Wood carving",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wood_carving",
+          "mid": "/m/01p9z0",
+          "salience": 0.0007328560459427536,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Raja Ampat",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Raja_Ampat_Islands",
+          "mid": "/m/02pgv9k",
+          "salience": 0.0006071904208511114,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Unesco Intangible Cultural Heritage",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Intangible_cultural_heritage",
+          "mid": "/m/02p7dln",
+          "salience": 0.0005818598438054323,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Blue Curacao",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Curaçao_(liqueur)",
+          "mid": "/m/053rg4",
+          "salience": 0.00047178243403322995,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Garuda Indonesia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Garuda_Indonesia",
+          "mid": "/m/017tgb",
+          "salience": 0.0003846733889076859,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Spice Islands",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maluku_Islands",
+          "mid": "/m/0djdm",
+          "salience": 0.00035200119600631297,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Caribbean",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Caribbean",
+          "mid": "/m/0261m",
+          "salience": 0.0002476562513038516,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Malta",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Malta",
+          "mid": "/m/04v3q",
+          "salience": 0.0002476562513038516,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "Batik Air",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Batik_Air",
+          "mid": "/m/0k0xdqf",
+          "salience": 0.0002474383800290525,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Travel Guides & Travelogues",
+          "confidence": 0.8298790454864502,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Other",
+          "confidence": 0.6478666067123413,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Specialty Travel/Adventure Travel",
+          "confidence": 0.535521388053894,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Specialty Travel/Luxury Travel",
+          "confidence": 0.4561847448348999,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Transportation/Cruises & Charters",
+          "confidence": 0.45236968994140625,
+          "analyzed_at": "2026-06-10T08:04:25.398211+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Electrician jailed for life for stabbing partner to death and blowing up London home",
+      "description": "Clifton George murdered Annabel Rook after she said they should end their relationship",
+      "url": "https://www.independent.co.uk/news/uk/crime/annabel-rook-clifton-george-sentence-b2992401.html",
+      "image_url": "https://static.independent.co.uk/2026/06/09/12/01KTNPD38N0046XXZ48DDBJS6Y.jpg?width=1200&auto=webp&trim=935%2C0%2C644%2C0",
+      "published_at": "2026-06-09T12:48:11+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.4000000059604645,
+      "sentiment_magnitude": 16.299999237060547,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Stoke Newington",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stoke_Newington",
+          "mid": "/m/0nc8j",
+          "salience": 0.002800344256684184,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.0020688013173639774,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "Snaresbrook Crown Court",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Snaresbrook_Crown_Court",
+          "mid": "/g/11bvg1g7ds",
+          "salience": 0.0010645755100995302,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "Murdered",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Murder",
+          "mid": "/m/051_y",
+          "salience": 0.0005391084705479443,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "Old Bailey",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Old_Bailey",
+          "mid": "/m/01hbd0",
+          "salience": 0.0004343801410868764,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.00022710974735673517,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.9537853002548218,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.34798750281333923,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.3040955662727356,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.21790403127670288,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "/Law & Government/Legal/Other",
+          "confidence": 0.15137441456317902,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.14217983186244965,
+          "analyzed_at": "2026-06-09T16:02:24.430871+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Porter Airlines Joins International Air Transport Association",
+      "description": "Membership to facilitate the airline&#8217;s growth and international partnerships TORONTO &#8212; Porter Airlines has officially joined the International Air Transport Association (IATA) as a member. This significant milestone reflects the airline&#8217;s rapid growth and its deepening integration with the global aviation community. Full membership follows Porter&#8217;s successful completion of the IATA Operational Safety Audit (IOSA) [&#8230;]",
+      "url": "https://financialpost.com/pmn/business-wire-news-releases-pmn/porter-airlines-joins-international-air-transport-association",
+      "image_url": null,
+      "published_at": "2026-06-08T15:36:29+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.10000000149011612,
+      "sentiment_magnitude": 20.399999618530273,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "International Air Transport Association",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Air_Transport_Association",
+          "mid": "/m/0hg0k",
+          "salience": 0.023074623197317123,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Porter Airlines",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Porter_Airlines",
+          "mid": "/m/0bb1cp",
+          "salience": 0.020806223154067993,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Business Wire",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Business_Wire",
+          "mid": "/m/05l0qw",
+          "salience": 0.011322321370244026,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "North America",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_America",
+          "mid": "/m/059g4",
+          "salience": 0.0072366283275187016,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "TORONTO",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Toronto",
+          "mid": "/m/0h7h6",
+          "salience": 0.004014437086880207,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Willie Walsh",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Willie_Walsh_(businessman)",
+          "mid": "/m/06wxpr",
+          "salience": 0.0032145907171070576,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Postmedia",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.0030133097898215055,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Embraer",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Embraer",
+          "mid": "/m/03p216q",
+          "salience": 0.0027827024459838867,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "E195-E2",
+          "type": "OTHER",
+          "wikipedia_url": "https://fr.wikipedia.org/wiki/Embraer_195-E2",
+          "mid": "/g/11cnby6qy6",
+          "salience": 0.0027827024459838867,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.00257859006524086,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "IATA Operational Safety Audit",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/IATA_Operational_Safety_Audit",
+          "mid": "/m/04jkxxq",
+          "salience": 0.001352486084215343,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Central America",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Central_America",
+          "mid": "/m/01tzh",
+          "salience": 0.0011460648383945227,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Europe",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0009085179772228003,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Amazon",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amazon_(company)",
+          "mid": "/m/0mgkg",
+          "salience": 0.0008502818527631462,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "De Havilland Dash 8",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/De_Havilland_Canada_Dash_8",
+          "mid": "/m/02td9c",
+          "salience": 0.0008371940930373967,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Caribbean",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Caribbean",
+          "mid": "/m/0261m",
+          "salience": 0.0008371940930373967,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Skytrax",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Skytrax",
+          "mid": "/m/042ysm",
+          "salience": 0.0008330942946486175,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "WiFi",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wi-Fi",
+          "mid": "/m/0h4d9",
+          "salience": 0.0008320140186697245,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Star Airline",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Star_Air_(India)",
+          "mid": "/g/11gds0wsqh",
+          "salience": 0.0007332758395932615,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.0006255924818105996,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0006255924818105996,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "National Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Bank_of_Canada",
+          "mid": "/m/030z_n",
+          "salience": 0.0006251644808799028,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Doug Ford",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Doug_Ford",
+          "mid": "/m/0dsdr1x",
+          "salience": 0.0006175123853608966,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.00043711691978387535,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.00043711691978387535,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "IMF",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Monetary_Fund",
+          "mid": "/m/03y48",
+          "salience": 0.00043711691978387535,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "Mexico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.0002742999349720776,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Transportation/Air Travel",
+          "confidence": 0.8646019697189331,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Aerospace & Defense/Aviation Industry",
+          "confidence": 0.7174440026283264,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.4836179316043854,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.14373540878295898,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Other",
+          "confidence": 0.11501304060220718,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.10133756697177887,
+          "analyzed_at": "2026-06-09T06:21:01.453169+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Trump still hopes to revive $1.8B ‘weaponization fund’ and will be ‘disappointed’ if Republicans fail to approve it",
+      "description": "Trump urges lawmakers to pass payouts for allies after demand nearly derailed ICE funding legislation",
+      "url": "https://www.independent.co.uk/news/world/americas/us-politics/trump-weaponization-fund-jan-6-payouts-b2991324.html",
+      "image_url": "https://static.independent.co.uk/2026/06/07/13/52/trump_mtp_625.jpg?width=1200&auto=webp&trim=0%2C74%2C0%2C74",
+      "published_at": "2026-06-07T14:22:24+00:00",
+      "language": "en",
+      "country": "uk",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.4000000059604645,
+      "sentiment_magnitude": 33.900001525878906,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.25313588976860046,
+          "mention_count": 13,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Congress",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Congress",
+          "mid": "/m/07t31",
+          "salience": 0.044134486466646194,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Joe Biden",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joe_Biden",
+          "mid": "/m/012gx2",
+          "salience": 0.02841527760028839,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Republicans",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Republican_Party_(United_States)",
+          "mid": "/m/07wbk",
+          "salience": 0.02472832426428795,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "NBC",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/NBC",
+          "mid": "/m/05gnf",
+          "salience": 0.02029605209827423,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Kristen Welker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kristen_Welker",
+          "mid": "/m/0y55swv",
+          "salience": 0.011462777853012085,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Español",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spanish_language",
+          "mid": "/m/06nm1",
+          "salience": 0.005107917822897434,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Meet the Press",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Meet_the_Press",
+          "mid": "/m/0167_c",
+          "salience": 0.004484773147851229,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Capitol",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Capitol",
+          "mid": "/m/07vth",
+          "salience": 0.0036354484036564827,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Senate",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Senate",
+          "mid": "/m/07t58",
+          "salience": 0.0034949425607919693,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Todd Blanche",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Todd_Blanche",
+          "mid": "/g/11pxx8dgkw",
+          "salience": 0.003107264870777726,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Justice Department",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Department_of_Justice",
+          "mid": "/m/0dtj5",
+          "salience": 0.002791143488138914,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Chuck Schumer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chuck_Schumer",
+          "mid": "/m/01w74d",
+          "salience": 0.0026673951651901007,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "White House",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/White_House",
+          "mid": "/m/081sq",
+          "salience": 0.002065169159322977,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Mitch McConnell",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mitch_McConnell",
+          "mid": "/m/01z6ls",
+          "salience": 0.0018221125937998295,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Brian Fitzpatrick",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brian_Fitzpatrick_(American_politician)",
+          "mid": "/g/11c2l6lhlm",
+          "salience": 0.001820666017010808,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.0007926909020170569,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Mar-a-Lago",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mar-a-Lago",
+          "mid": "/m/052rh6",
+          "salience": 0.0007001188350841403,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Americans",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0006950119277462363,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "FBI",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Federal_Bureau_of_Investigation",
+          "mid": "/m/02_1m",
+          "salience": 0.0006148831453174353,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Memorial Day",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Memorial_Day",
+          "mid": "/m/0fklh",
+          "salience": 0.0004211001505609602,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Democratic",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Democratic_Party_(United_States)",
+          "mid": "/m/0d075m",
+          "salience": 0.00029409065609797835,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "Immigration and Customs Enforcement",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Immigration_and_Customs_Enforcement",
+          "mid": "/m/01fp_h",
+          "salience": 0.00023744582722429186,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.8347565531730652,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Executive Branch",
+          "confidence": 0.7277780175209045,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "/News/Politics/Campaigns & Elections",
+          "confidence": 0.26340094208717346,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.11524832248687744,
+          "analyzed_at": "2026-06-09T08:46:24.965800+00:00"
+        }
+      ]
+    },
+    {
+      "title": "The World Cup looms for Mexico – but is cartel violence under control?",
+      "description": "Cities in Mexico are preparing to host nearly 1 million people and 13 games in the world’s most-watched sporting competition. But just months after an eruption of violence, do authorities really have organised crime under control, asks Alex Croft",
+      "url": "https://www.independent.co.uk/news/world/americas/world-cup-mexico-cartel-violence-cjng-b2989859.html",
+      "image_url": "https://static.independent.co.uk/2026/02/23/9/17/TOPSHOT-MEXICO-CRIME-DRUG-TRAFFICKING-OPERATION-h4m9p6v3.jpeg?width=1200&auto=webp&trim=0%2C10%2C0%2C9",
+      "published_at": "2026-06-06T15:07:02+00:00",
+      "language": "en",
+      "country": "uk",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 22.600000381469727,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "World Cup",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA_World_Cup",
+          "mid": "/m/030q7",
+          "salience": 0.10548529028892517,
+          "mention_count": 14,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Mexico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.03554759547114372,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Rubén Oseguera Cervantes",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Nemesio_Oseguera",
+          "mid": "/g/11g6p62swm",
+          "salience": 0.011615142226219177,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Guadalajara",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Guadalajara",
+          "mid": "/m/0jp26",
+          "salience": 0.01106345932930708,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Mexico City",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico_City",
+          "mid": "/m/04sqj",
+          "salience": 0.011056684888899326,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Claudia Sheinbaum",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Claudia_Sheinbaum",
+          "mid": "/g/122dl1x2",
+          "salience": 0.006677525117993355,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Jalisco New Generation Cartel",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jalisco_New_Generation_Cartel",
+          "mid": "/m/0j63p_l",
+          "salience": 0.005428661592304707,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Jalisco",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jalisco",
+          "mid": "/m/01btyw",
+          "salience": 0.005001196172088385,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Akron Stadium",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Estadio_Akron",
+          "mid": "/m/0d0cn4",
+          "salience": 0.0036276886239647865,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "United States",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0016283077420666814,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "ACLED",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Armed_Conflict_Location_and_Event_Data",
+          "mid": "/m/010vqr48",
+          "salience": 0.0013723502634093165,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.001145529793575406,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Latin America",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Latin_America",
+          "mid": "/m/04pnx",
+          "salience": 0.0009440492722205818,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Chatham House",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chatham_House",
+          "mid": "/m/041cl4",
+          "salience": 0.0007710819481872022,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "CNTE",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Coordinadora_Nacional_de_Trabajadores_de_la_Educación",
+          "mid": "/m/0x2frdd",
+          "salience": 0.0007066390826366842,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "Monterrey",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Monterrey",
+          "mid": "/m/0b2h3",
+          "salience": 0.00037400866858661175,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.5730889439582825,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.569461464881897,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.5687114596366882,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.2801443338394165,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.23658424615859985,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Law Enforcement",
+          "confidence": 0.15710026025772095,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Recreational Drugs",
+          "confidence": 0.13377106189727783,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.12191171199083328,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.10892094671726227,
+          "analyzed_at": "2026-06-09T08:00:50.252552+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Somali referee Artan barred from entering US",
+      "description": "Omar Artan, who was set to be the first Somali to referee at the World Cup finals, is dropped from the list of officials after he was denied entry to the United States.",
+      "url": "https://www.bbc.com/sport/football/articles/cnv9drg0qzgo",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1c3c/live/7f657ff0-635e-11f1-8b15-6100cfbc3083.jpg",
+      "published_at": "2026-06-09T08:50:40+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 16.299999237060547,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Omar Abdulkadir Artan",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Omar_Artan",
+          "mid": "/g/11vdxpv1z3",
+          "salience": 0.30288615822792053,
+          "mention_count": 16,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "World Cup",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA_World_Cup",
+          "mid": "/m/030q7",
+          "salience": 0.14563153684139252,
+          "mention_count": 14,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Fifa",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA",
+          "mid": "/m/02zm3",
+          "salience": 0.07218503952026367,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Somali",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Somalia",
+          "mid": "/m/06tgw",
+          "salience": 0.030775533989071846,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "United States",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.02159140259027481,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "BBC News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC",
+          "mid": "/m/0ncl8zk",
+          "salience": 0.00946837104856968,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.0034978368785232306,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Confederation of African Football",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Confederation_of_African_Football",
+          "mid": "/m/0356lc",
+          "salience": 0.0024453431833535433,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Pierluigi Collina",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pierluigi_Collina",
+          "mid": "/m/035865",
+          "salience": 0.0023284165654331446,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Miami International Airport",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Miami_International_Airport",
+          "mid": "/m/0yt9j",
+          "salience": 0.0020306636579334736,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Somali Football Federation",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Somali_Football_Federation",
+          "mid": "/m/09s0bw",
+          "salience": 0.0010629845783114433,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.000957914104219526,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Ian Wright",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ian_Wright",
+          "mid": "/m/01j_ws",
+          "salience": 0.0007065851241350174,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Mexico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.0006183970253914595,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Nairobi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nairobi",
+          "mid": "/m/05d49",
+          "salience": 0.0006171262939460576,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Florida",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Florida",
+          "mid": "/m/02xry",
+          "salience": 0.0006115465075708926,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Canada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0006108292727731168,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "BBC World Service",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_World_Service",
+          "mid": "/m/09cz5",
+          "salience": 0.0005638977163471282,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Andrew Giuliani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Andrew_Giuliani",
+          "mid": "/m/0kvtnnk",
+          "salience": 0.0005638977163471282,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Africa Cup of Nations",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Africa_Cup_of_Nations",
+          "mid": "/m/01l5zn",
+          "salience": 0.00036178884329274297,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "JavaScript",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/JavaScript",
+          "mid": "/m/02p97",
+          "salience": 0.000254486600169912,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Qatar",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Qatar",
+          "mid": "/m/0697s",
+          "salience": 0.0002518807305023074,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.0001856785238487646,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "England",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/England_cricket_team",
+          "mid": "/m/038zh6",
+          "salience": 0.0001856785238487646,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.9782783389091492,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.9033869504928589,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.8184138536453247,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Visa & Immigration",
+          "confidence": 0.29094183444976807,
+          "analyzed_at": "2026-06-10T00:00:50.590879+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Starmer orders tech companies to block nude images of children within three months",
+      "description": "The prime minister warns he will change the law if tech companies refuse to comply",
+      "url": "https://www.independent.co.uk/news/uk/politics/keir-starmer-tech-companies-children-controls-b2991609.html",
+      "image_url": "https://static.independent.co.uk/2026/06/08/09/01KTK5RRH2RM062AJ649TP6C7A.jpg?width=1200&auto=webp&trim=0%2C1%2C0%2C0",
+      "published_at": "2026-06-08T08:49:12+00:00",
+      "language": "en",
+      "country": "uk",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.4000000059604645,
+      "sentiment_magnitude": 19.700000762939453,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.1758374571800232,
+          "mention_count": 18,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "Jess Phillips",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jess_Phillips",
+          "mid": "/m/0136_xq8",
+          "salience": 0.061481256037950516,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "Apple",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Apple_Inc.",
+          "mid": "/m/0k8z",
+          "salience": 0.00846198108047247,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "Sadiq Khan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sadiq_Khan",
+          "mid": "/m/060nzt",
+          "salience": 0.00489535229280591,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "Australia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Australia",
+          "mid": "/m/0chghy",
+          "salience": 0.002817333908751607,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0027463955339044333,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0007892465800978243,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "NSPCC",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/NSPCC",
+          "mid": "/m/026gt8",
+          "salience": 0.0006317174411378801,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.0006176024326123297,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "iOS",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/IOS",
+          "mid": "/m/03wbl14",
+          "salience": 0.000456265639513731,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "Android",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Android_(operating_system)",
+          "mid": "/m/02wxtgw",
+          "salience": 0.000456265639513731,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/People & Society/Family & Relationships/Family/Other",
+          "confidence": 0.7138381004333496,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "/News/Technology News",
+          "confidence": 0.6051117181777954,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Other",
+          "confidence": 0.2051279991865158,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Other",
+          "confidence": 0.19965554773807526,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.1262264847755432,
+          "analyzed_at": "2026-06-09T08:49:12.930688+00:00"
+        }
+      ]
+    },
+    {
+      "title": "How to visit one of the seven wonders of the world in 2026",
+      "description": "This is how to visit all seven modern wonders of the world – from monumental landmarks to great feats of innovation and cultural heritage",
+      "url": "https://www.independent.co.uk/travel/inspiration/seven-wonders-world-visit-where-best-holidays-b2990283.html",
+      "image_url": "https://static.independent.co.uk/2026/06/05/10/39/iStock-683011462.jpeg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-07T00:44:18+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 28.0,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Trailfinders",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trailfinders",
+          "mid": "/m/0bwdv1",
+          "salience": 0.03553567826747894,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Taj Mahal",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Taj_Mahal",
+          "mid": "/m/0l8cb",
+          "salience": 0.01431854348629713,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Great Pyramid of Giza",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Great_Pyramid_of_Giza",
+          "mid": "/m/036mk",
+          "salience": 0.013592916540801525,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "New Seven Wonders of the World",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_7_Wonders_of_the_World",
+          "mid": "/m/02636jl",
+          "salience": 0.01219378225505352,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "iStockphoto",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/IStock",
+          "mid": "/m/09h47q",
+          "salience": 0.011767289601266384,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Petra",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Petra",
+          "mid": "/m/0c7zy",
+          "salience": 0.008721166290342808,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.008066573180258274,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Italy",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.008026840165257454,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Great Wall of China",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Great_Wall_of_China",
+          "mid": "/m/0d2dq0",
+          "salience": 0.0061437031254172325,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Roman Colosseum",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Colosseum",
+          "mid": "/m/0d5qx",
+          "salience": 0.0046973866410553455,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Amman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amman",
+          "mid": "/m/0c7zf",
+          "salience": 0.0037420240696519613,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Agra",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Agra",
+          "mid": "/m/01zxx9",
+          "salience": 0.003584859659895301,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Carlos Oswald",
+          "type": "PERSON",
+          "wikipedia_url": "https://pt.wikipedia.org/wiki/Carlos_Oswald",
+          "mid": "/g/122v3wh8",
+          "salience": 0.0029516068752855062,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Colossus of Rhodes",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Colossus_of_Rhodes",
+          "mid": "/m/0hpb5",
+          "salience": 0.002852723700925708,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Machu Picchu",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Machu_Picchu",
+          "mid": "/m/0krfy",
+          "salience": 0.0028302259743213654,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Paul Landowski",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paul_Landowski",
+          "mid": "/m/096mcv",
+          "salience": 0.00259606447070837,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Brazil",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brazil",
+          "mid": "/m/015fr",
+          "salience": 0.002335683908313513,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Rio De Janeiro",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rio_de_Janeiro",
+          "mid": "/m/06gmr",
+          "salience": 0.002173713408410549,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Shah Jahan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Shah_Jahan",
+          "mid": "/m/073tr",
+          "salience": 0.002154730027541518,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "El Castillo",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/El_Castillo,_Chichen_Itza",
+          "mid": "/m/0667dy",
+          "salience": 0.0018683025846257806,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Lighthouse of Alexandria",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lighthouse_of_Alexandria",
+          "mid": "/m/04h6_",
+          "salience": 0.001830480294302106,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Greek",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greek_language",
+          "mid": "/m/0349s",
+          "salience": 0.001830480294302106,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Iraq",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iraq",
+          "mid": "/m/0d05q4",
+          "salience": 0.001830480294302106,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Hanging Gardens of Babylon",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hanging_Gardens_of_Babylon",
+          "mid": "/m/0hm8g",
+          "salience": 0.001830480294302106,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Middle East",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Middle_East",
+          "mid": "/m/04wsz",
+          "salience": 0.0017968958709388971,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0017968958709388971,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Albert Caquot",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Albert_Caquot",
+          "mid": "/m/02r_0pm",
+          "salience": 0.0017384948441758752,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Heitor da Silva Costa",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Heitor_da_Silva_Costa",
+          "mid": "/m/02613h0",
+          "salience": 0.0017384948441758752,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Egypt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Egypt",
+          "mid": "/m/02k54",
+          "salience": 0.0017304386710748076,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Mumtaz Mahal",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mumtaz_Mahal",
+          "mid": "/m/020753",
+          "salience": 0.001590301631949842,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.0010924371890723705,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Vatican Museums",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vatican_Museums",
+          "mid": "/m/01hfkb",
+          "salience": 0.0009938846342265606,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Christ the Redeemer",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christ_the_Redeemer_(statue)",
+          "mid": "/m/03gytw",
+          "salience": 0.0009169777622446418,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Rome",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rome,_Georgia",
+          "mid": "/m/0rwgm",
+          "salience": 0.0008696954464539886,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Flavian dynasty",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flavian_dynasty",
+          "mid": "/m/02m9h4",
+          "salience": 0.0008434596820734441,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Unesco World Heritage Site",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/World_Heritage_Site",
+          "mid": "/m/0c7g7",
+          "salience": 0.0008085271692834795,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Trevi Fountain",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trevi_Fountain",
+          "mid": "/m/01xgt5",
+          "salience": 0.0007673985091969371,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Lake Titicaca",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lake_Titicaca",
+          "mid": "/m/0152ln",
+          "salience": 0.0007081477087922394,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Trastevere",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Trastevere",
+          "mid": "/m/04b_tx",
+          "salience": 0.0006734883063472807,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Roman Holiday",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Roman_Holiday",
+          "mid": "/m/0k419",
+          "salience": 0.0006730399909429252,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Arabia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saudi_Arabia",
+          "mid": "/m/01z215",
+          "salience": 0.0006726149586029351,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Mexico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.0006458800053223968,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Corcovado Mountain",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Corcovado",
+          "mid": "/m/01ww2",
+          "salience": 0.0006124037317931652,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Sugarloaf Mountain",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sugarloaf_Mountain",
+          "mid": "/m/0634k2",
+          "salience": 0.0006117074517533183,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Jaipur",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jaipur",
+          "mid": "/m/016722",
+          "salience": 0.0005370022263377905,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Delhi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Delhi",
+          "mid": "/m/09f07",
+          "salience": 0.0005370022263377905,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Nabataeans",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nabataeans",
+          "mid": "/m/0215fw",
+          "salience": 0.0005319601623341441,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "City Palace",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/City_Palace,_Jaipur",
+          "mid": "/m/07kctys",
+          "salience": 0.0005211220122873783,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Akbar's Mausoleum",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Akbar's_tomb",
+          "mid": "/m/03c1kd9",
+          "salience": 0.0005209710216149688,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Ilha Grande",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ilha_Grande",
+          "mid": "/m/0gxngr",
+          "salience": 0.0005194020341150463,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Peru",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Peru",
+          "mid": "/m/016wzw",
+          "salience": 0.0004878908221144229,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Mughal",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mughal_Empire",
+          "mid": "/m/0q307",
+          "salience": 0.0004720563592854887,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Copacabana",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Copacabana,_Rio_de_Janeiro",
+          "mid": "/m/01z2r",
+          "salience": 0.0004561574023682624,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "African",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Africa",
+          "mid": "/m/0dg3n1",
+          "salience": 0.00045568260247819126,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Muslim",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islam",
+          "mid": "/m/0flw86",
+          "salience": 0.00045553295058198273,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Arab",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arabs",
+          "mid": "/m/0xff",
+          "salience": 0.0004532555176410824,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Byzantines",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantine_Empire",
+          "mid": "/m/017cw",
+          "salience": 0.0004532555176410824,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Hellenistic",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hellenistic_period",
+          "mid": "/m/02blmn",
+          "salience": 0.0004529958823695779,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Dead Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dead_Sea",
+          "mid": "/m/02cnp",
+          "salience": 0.00045274794683791697,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Wadi Rum",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wadi_Rum",
+          "mid": "/m/0577qx",
+          "salience": 0.0004525106924120337,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Christian",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christianity",
+          "mid": "/m/01lp8",
+          "salience": 0.00045145719195716083,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Mayan",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maya_peoples",
+          "mid": "/m/01zsjv",
+          "salience": 0.00044149169116280973,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Yamuna River",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yamuna",
+          "mid": "/m/01zp1h",
+          "salience": 0.0004177704977337271,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Islamic",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islam",
+          "mid": "/m/0flw86",
+          "salience": 0.0004177704977337271,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Jantar Mantar",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jantar_Mantar",
+          "mid": "/m/09k91g",
+          "salience": 0.0004173893539700657,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Chandni Chowk",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chandni_Chowk",
+          "mid": "/m/02r6kc",
+          "salience": 0.00041715026600286365,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Jama Masjid",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jama_Mosque,_Delhi",
+          "mid": "/m/04yzj5",
+          "salience": 0.00041715026600286365,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Kukulkan",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kukulkan",
+          "mid": "/m/02vk9w6",
+          "salience": 0.0003564470971468836,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "pre-Hispanic America",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hispanic_America",
+          "mid": "/m/02b75d",
+          "salience": 0.0003130427503492683,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Mesoamerican",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mesoamerica",
+          "mid": "/m/0ddf2f",
+          "salience": 0.0003130427503492683,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Toltec",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Toltec",
+          "mid": "/m/0ccg9",
+          "salience": 0.0003129163524135947,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Merida",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mérida,_Yucatán",
+          "mid": "/m/0hyqj",
+          "salience": 0.0003128546813968569,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Uxmal",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Uxmal",
+          "mid": "/m/017xs7",
+          "salience": 0.0003127342788502574,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Beijing",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beijing",
+          "mid": "/m/01914",
+          "salience": 0.0002809737343341112,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Chichén Itzá",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chichen_Itza",
+          "mid": "/m/017kpv",
+          "salience": 0.00027683956432156265,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Chinese",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chinese_language",
+          "mid": "/m/01r2l",
+          "salience": 0.00021863871370442212,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Shanghai",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Shanghai",
+          "mid": "/m/06wjf",
+          "salience": 0.00021845039736945182,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Silk Road",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Silk_Road",
+          "mid": "/m/0f5mq",
+          "salience": 0.00021841427951585501,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Xi'an",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Xi'an",
+          "mid": "/m/0kzd9",
+          "salience": 0.00021841427951585501,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Chengdu",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chengdu",
+          "mid": "/m/016v46",
+          "salience": 0.00021820732217747718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Lima",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lima",
+          "mid": "/m/0lpfh",
+          "salience": 0.00020575488451868296,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Inca Trail",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Inca_Trail_to_Machu_Picchu",
+          "mid": "/m/07k8db8",
+          "salience": 0.0001953274040715769,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Incan",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Inca_Empire",
+          "mid": "/m/03yp_",
+          "salience": 0.00017689134983811527,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Cusco 6",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cusco",
+          "mid": "/m/0jld3",
+          "salience": 0.00017667557403910905,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Spaniards",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spaniards",
+          "mid": "/m/03ttfc",
+          "salience": 0.00013749297067988664,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Amazon Basin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amazon_basin",
+          "mid": "/m/02bd12",
+          "salience": 0.00013745875912718475,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "Puno",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Puno",
+          "mid": "/m/02wpyw",
+          "salience": 0.00013729748025070876,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Historical Sites & Buildings",
+          "confidence": 0.9363642930984497,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Travel Guides & Travelogues",
+          "confidence": 0.4110275208950043,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "/Reference/Humanities/History",
+          "confidence": 0.21444185078144073,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "/Travel & Transportation/Tourist Destinations/Other",
+          "confidence": 0.1494246870279312,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Online Media/Online Image Galleries",
+          "confidence": 0.14297427237033844,
+          "analyzed_at": "2026-06-09T08:01:59.664299+00:00"
+        }
+      ]
+    },
+    {
+      "title": "UK’s fragile heirloom: ceramics sector calls for more help to save ‘vital industry’",
+      "description": "Brands such as Portmeirion in Stoke welcome £120m package but seek further support to avert fresh closuresOn the floor of Portmeirion’s factory in Staffordshire, staff are hard at work as clays are moulded, glazed and fired – an intricate process requiring precision and specialist skills honed over years of practice – to manufacture the company’s array of tableware.Portmeirion, a homeware brand founded in 1960 that employs 433 people, is based in Stoke-on-Trent, at the heart of British ceramics. The centuries-old craft is so integral to the area’s identity that the six federated...",
+      "url": "https://www.theguardian.com/business/2026/jun/06/uk-ceramics-industry-support-package-revival-portmeirion-stoke",
+      "image_url": "https://i.guim.co.uk/img/media/6ec1259ac890daadd68661e6be45880ad460c743/0_0_5583_4467/master/5583.jpg?width=140&quality=85&auto=format&fit=max&s=bab7b0f22df1d39b67caca020441f0a1",
+      "published_at": "2026-06-06T13:00:05+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.10000000149011612,
+      "sentiment_magnitude": 21.299999237060547,
+      "source_name": "guardian",
+      "entities": [
+        {
+          "name": "Andrew Fox",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Andrew_Fox_(author)",
+          "mid": "/g/11t2z85jmp",
+          "salience": 0.09046602994203568,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.07053341716527939,
+          "mention_count": 17,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Rob Flello",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rob_Flello",
+          "mid": "/m/062t8d",
+          "salience": 0.02231203205883503,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Stoke-on-Trent",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stoke-on-Trent",
+          "mid": "/m/017cjb",
+          "salience": 0.019734879955649376,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Wedgwood",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wedgwood",
+          "mid": "/m/09_41f",
+          "salience": 0.0068237571977078915,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Stoke-on-Trent Staffordshire",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Staffordshire",
+          "mid": "/m/0g14f",
+          "salience": 0.004421202465891838,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "The Guardian View",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian",
+          "mid": "/m/0cnn5",
+          "salience": 0.0031570165883749723,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "West Midlands",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/West_Midlands_(county)",
+          "mid": "/m/0dyjz",
+          "salience": 0.0027797389775514603,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Rachel Reeves",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rachel_Reeves",
+          "mid": "/m/07s7z0v",
+          "salience": 0.0021559451706707478,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Ed Miliband",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ed_Miliband",
+          "mid": "/m/04qdjv",
+          "salience": 0.002116664545610547,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.0016190267633646727,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Denby",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Denby_Pottery_Company",
+          "mid": "/m/03qdpf",
+          "salience": 0.0009336477378383279,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0008233864209614694,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Israeli",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.0008233864209614694,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 0.0008233864209614694,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Russia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 0.0008233864209614694,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Derbyshire",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Derbyshire",
+          "mid": "/m/0jcg8",
+          "salience": 0.0008199817966669798,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Reeves",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rachel_Reeves",
+          "mid": "/m/07s7z0v",
+          "salience": 0.0008176586125046015,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Tony Blair",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tony_Blair",
+          "mid": "/m/0948xk",
+          "salience": 0.0006811649654991925,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.0006334826466627419,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "North Sea",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_Sea",
+          "mid": "/m/059qw",
+          "salience": 0.0005560610443353653,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Italian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 0.0005550063797272742,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.000508525874465704,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "India",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.000508525874465704,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Labour",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Labour_Party_(UK)",
+          "mid": "/m/01c9x",
+          "salience": 0.000433740351581946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "Stoke-on-Trent North",
+          "type": "LOCATION",
+          "wikipedia_url": "https://fr.wikipedia.org/wiki/Stoke-on-Trent_North",
+          "mid": "/m/05zztl",
+          "salience": 0.000433740351581946,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Hobbies & Leisure/Crafts/Ceramics & Pottery",
+          "confidence": 0.7733525037765503,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.6558803915977478,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Manufacturing/Other",
+          "confidence": 0.3585267961025238,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.29750901460647583,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.22097069025039673,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/Home & Garden/Home & Interior Decor",
+          "confidence": 0.15062466263771057,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/Home & Garden/Kitchen & Dining/Cookware & Diningware",
+          "confidence": 0.14519937336444855,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/News/Business News/Economy News",
+          "confidence": 0.1268729418516159,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.10681251436471939,
+          "analyzed_at": "2026-06-10T08:04:36.676078+00:00"
+        }
+      ]
+    },
+    {
+      "title": "China's May shipments to U.S. clock 5-year high growth at 35% as overall exports jump on tech boost",
+      "description": "Exports to the U.S. surged the most since March 2021, extending a rebound following a long streak of double-digit declines for the most of last year.",
+      "url": "https://www.cnbc.com/2026/06/09/china-trade-exports-imports-iran-war.html",
+      "image_url": null,
+      "published_at": "2026-06-09T08:43:47+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 15.199999809265137,
+      "source_name": "cnbc",
+      "entities": [
+        {
+          "name": "CHINA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 0.0070961411111056805,
+          "mention_count": 18,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.004369588568806648,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "SHENZHEN",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Shenzhen",
+          "mid": "/m/0lbmv",
+          "salience": 0.004242410883307457,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Maersk",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maersk",
+          "mid": "/m/035r8l",
+          "salience": 0.0037264665588736534,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Hamburg Süd",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamburg_Süd",
+          "mid": "/m/09p9b4",
+          "salience": 0.0037264665588736534,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Guangdong Province",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Guangdong",
+          "mid": "/m/0h9vh",
+          "salience": 0.0037264665588736534,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.0014055436477065086,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "AI",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Artificial_intelligence",
+          "mid": "/m/0mkz",
+          "salience": 0.0012274414766579866,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Citi Bank",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Citigroup",
+          "mid": "/m/01dfb6",
+          "salience": 0.0010780217126011848,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Economist Intelligence Unit",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Economist_Intelligence_Unit",
+          "mid": "/m/07n2rh",
+          "salience": 0.0010676309466362,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Southeast Asia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Southeast_Asia",
+          "mid": "/m/073q1",
+          "salience": 0.0010676309466362,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Section 301",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Section_301_of_the_Trade_Act_of_1974",
+          "mid": "/m/0fddbm",
+          "salience": 0.0010665791342034936,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "BofA",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bank_of_America",
+          "mid": "/m/01yx7f",
+          "salience": 0.0009445485193282366,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Beijing",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beijing",
+          "mid": "/m/01914",
+          "salience": 0.0009445485193282366,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Middle East",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Middle_East",
+          "mid": "/m/04wsz",
+          "salience": 0.0008644016925245523,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "LSEG",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London_Stock_Exchange_Group",
+          "mid": "/m/03c7yyx",
+          "salience": 0.000648705696221441,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "CSI 300 index",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/CSI_300_Index",
+          "mid": "/m/03qn8cx",
+          "salience": 0.0006481903255917132,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Strait of Hormuz",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Strait_of_Hormuz",
+          "mid": "/m/075t9",
+          "salience": 0.0006474753608927131,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Fitch Ratings",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fitch_Ratings",
+          "mid": "/m/04grk2",
+          "salience": 0.0004525570257101208,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "HSBC Bank",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/HSBC",
+          "mid": "/m/01vq1f",
+          "salience": 0.0003551775589585304,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "Asia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asia",
+          "mid": "/m/0j0k",
+          "salience": 0.00032391888089478016,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Business News/Economy News",
+          "confidence": 0.8922271132469177,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "/News/Business News/Financial Markets News",
+          "confidence": 0.5952403545379639,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Shipping & Logistics/Import & Export",
+          "confidence": 0.4926649332046509,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Other",
+          "confidence": 0.17933697998523712,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Economics",
+          "confidence": 0.12032895535230637,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.11933322250843048,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.11673982441425323,
+          "analyzed_at": "2026-06-10T00:00:55.508253+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Korean Stocks Tumble as Investors Rush to Offload Tech Shares",
+      "description": "South Korean stocks dropped, led by steep losses in chipmaker shares on an intensifying rotation out of artificial intelligence beneficiaries.",
+      "url": "https://financialpost.com/pmn/business-pmn/korean-stocks-tumble-as-investors-rush-to-offload-tech-shares",
+      "image_url": null,
+      "published_at": "2026-06-08T00:35:40+00:00",
+      "language": "en",
+      "country": "us",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 19.700000762939453,
+      "source_name": "financialpost",
+      "entities": [
+        {
+          "name": "Lee Jae Myung",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lee_Jae_Myung",
+          "mid": "/g/120_gclc",
+          "salience": 0.010301605798304081,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "South Korean",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/South_Korea",
+          "mid": "/m/06qd3",
+          "salience": 0.008439204655587673,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Kosdaq",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/KOSDAQ",
+          "mid": "/m/03k1tk",
+          "salience": 0.0053230891935527325,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "SK Hynix Inc.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/SK_Hynix",
+          "mid": "/m/083w62",
+          "salience": 0.004746417980641127,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Postmedia Network Inc.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Postmedia_Network",
+          "mid": "/m/0cmcy_k",
+          "salience": 0.0037110422272235155,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Kospi",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/KOSPI",
+          "mid": "/m/04w0nf",
+          "salience": 0.0030304898973554373,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Samsung Electronics Co.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Samsung_Electronics",
+          "mid": "/m/01nn79",
+          "salience": 0.002631786046549678,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "AI",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Artificial_intelligence",
+          "mid": "/m/0mkz",
+          "salience": 0.001773835625499487,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Asia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asia",
+          "mid": "/m/0j0k",
+          "salience": 0.0017471648752689362,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "ETFs",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Exchange-traded_fund",
+          "mid": "/m/02mxjp",
+          "salience": 0.0017161783762276173,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Seoul",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Seoul",
+          "mid": "/m/0hsqf",
+          "salience": 0.0015244792448356748,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0013229046016931534,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Asset Management",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Asset_management",
+          "mid": "/m/0gh77b6",
+          "salience": 0.0011107645696029067,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Cboe Volatility Index",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/VIX",
+          "mid": "/m/09fld6",
+          "salience": 0.001110267243348062,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Korea Exchange",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Korea_Exchange",
+          "mid": "/g/121b1v_1",
+          "salience": 0.000926290696952492,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Hong Kong",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hong_Kong",
+          "mid": "/m/03h64",
+          "salience": 0.0008901107357814908,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Canadian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 0.0008182733436115086,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Singapore",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Singapore",
+          "mid": "/m/06t2t",
+          "salience": 0.0008151570800691843,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "National Bank of Canada",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Bank_of_Canada",
+          "mid": "/m/030z_n",
+          "salience": 0.0008139015990309417,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Doug Ford",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Doug_Ford",
+          "mid": "/m/0dsdr1x",
+          "salience": 0.0008039399981498718,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Nvidia Corp.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nvidia",
+          "mid": "/m/09rh_",
+          "salience": 0.0005864805425517261,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.00042762563680298626,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Tumblr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tumblr",
+          "mid": "/m/05pdgbz",
+          "salience": 0.000427278399001807,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "IMF",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Monetary_Fund",
+          "mid": "/m/03y48",
+          "salience": 0.00026854840689338744,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Amazon",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amazon_(company)",
+          "mid": "/m/0mgkg",
+          "salience": 0.00026854840689338744,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Real Estate",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Real_estate",
+          "mid": "/m/06k1r",
+          "salience": 0.00026845524553209543,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "Goldman Sachs",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Goldman_Sachs",
+          "mid": "/m/01xdn1",
+          "salience": 0.0002683646744117141,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Business News/Financial Markets News",
+          "confidence": 0.8005186319351196,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Stocks & Bonds",
+          "confidence": 0.5725563168525696,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Other",
+          "confidence": 0.240066260099411,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.23337338864803314,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "/News/Business News/Economy News",
+          "confidence": 0.11659598350524902,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.10062146186828613,
+          "analyzed_at": "2026-06-09T08:43:17.224789+00:00"
+        }
+      ]
+    },
+    {
+      "title": "'My great-grandad saved your life' - Aberfan survivor left stunned on school visit",
+      "description": "An Aberfan disaster survivor met the great-grandson of the caretaker who pulled him from the rubble.",
+      "url": "https://www.bbc.com/news/articles/clyp3kmjy3no",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8ffd/live/3ce05c60-5f38-11f1-b682-cf91850925ea.jpg",
+      "published_at": "2026-06-07T06:21:51+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.0,
+      "sentiment_magnitude": 27.600000381469727,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Gareth Jones",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gareth_Jones_(journalist)",
+          "mid": "/m/0cyrlt",
+          "salience": 0.24005186557769775,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Aberfan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aberfan",
+          "mid": "/m/02ygsx",
+          "salience": 0.046548351645469666,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "BBC Wales",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/BBC_Cymru_Wales",
+          "mid": "/m/09k6lgj",
+          "salience": 0.008007057011127472,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Aberfan Wales",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wales",
+          "mid": "/m/0j5g9",
+          "salience": 0.007449170108884573,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.00475181732326746,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Hannah James",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hannah_James_(actress)",
+          "mid": "/g/11csp8ykg9",
+          "salience": 0.0021655166056007147,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Merthyr Tydfil",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Merthyr_Tydfil_County_Borough",
+          "mid": "/m/0vzs8zg",
+          "salience": 0.0008424680563621223,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Troedyrhiw",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Troed-y-rhiw",
+          "mid": "/m/0b5wlf",
+          "salience": 0.0007796371355652809,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0006949001690372825,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "PTSD",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Post-traumatic_stress_disorder",
+          "mid": "/m/0l8bg",
+          "salience": 0.00027301066438667476,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Paddleboard",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paddleboarding",
+          "mid": "/m/02r3dh_",
+          "salience": 0.0002726798702497035,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Gap",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gap_Inc.",
+          "mid": "/m/01yfp7",
+          "salience": 0.0002726798702497035,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "Goa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Goa",
+          "mid": "/m/01c1nm",
+          "salience": 0.0002726798702497035,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "New Hampshire",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Hampshire",
+          "mid": "/m/059f4",
+          "salience": 0.00021443744481075555,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Accidents & Disasters",
+          "confidence": 0.7944502234458923,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.7913980484008789,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.3954482674598694,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "/Reference/Humanities/History",
+          "confidence": 0.231946662068367,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.21934449672698975,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        },
+        {
+          "name": "/Jobs & Education/Education/Primary & Secondary Schooling (K-12)",
+          "confidence": 0.11071321368217468,
+          "analyzed_at": "2026-06-09T08:24:08.489290+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Mirra Andreeva comes of age to win French Open and end Maja Chwalinska fairytale run",
+      "description": "The 19-year-old has long been tipped as a future major winner and she fulfilled her potential with an impressively composed performance",
+      "url": "https://www.independent.co.uk/sport/tennis/french-open-final-mirra-andreeva-maja-chwalinska-b2991003.html",
+      "image_url": "https://static.independent.co.uk/2026/06/06/16/download.-3.?width=1200&auto=webp&crop=3%3A2",
+      "published_at": "2026-06-06T15:32:12+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.10000000149011612,
+      "sentiment_magnitude": 19.399999618530273,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Maja Chwalinska",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maja_Chwalińska",
+          "mid": "/g/11c6rj47p0",
+          "salience": 0.5619710683822632,
+          "mention_count": 19,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Mirra Andreeva",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mirra_Andreeva",
+          "mid": "/g/11sn2g2q95",
+          "salience": 0.16242392361164093,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "French Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/French_Open",
+          "mid": "/m/012xcl",
+          "salience": 0.0040266369469463825,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Monica Seles",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Monica_Seles",
+          "mid": "/m/01rv05",
+          "salience": 0.002698425902053714,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "US Open",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/US_Open_(tennis)",
+          "mid": "/m/0l6c9",
+          "salience": 0.0019114597234874964,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Harri Heliovaara",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Harri_Heliövaara",
+          "mid": "/m/0gtwb51",
+          "salience": 0.0018334323540329933,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Conchita Martinez",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Conchita_Martínez",
+          "mid": "/m/03c30n",
+          "salience": 0.0017238573636859655,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Emma Raducanu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emma_Raducanu",
+          "mid": "/g/11h4d6wf2q",
+          "salience": 0.0012803070712834597,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Lois Boisson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Loïs_Boisson",
+          "mid": "/g/11g1q7bmd5",
+          "salience": 0.0012261889642104506,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Coupe Suzanne-Lenglen",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Coupe_Suzanne_Lenglen",
+          "mid": "/g/124xvrmhs",
+          "salience": 0.0010534515604376793,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Matteo Arnaldi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Matteo_Arnaldi",
+          "mid": "/g/11gr4n781y",
+          "salience": 0.0004821027396246791,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Britain",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0004821027396246791,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Marta Kostyuk",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Marta_Kostyuk",
+          "mid": "/g/11c31q2rkh",
+          "salience": 0.0003677046042867005,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "Russian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 0.0002973843365907669,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Individual Sports/Racquet Sports",
+          "confidence": 0.9920699596405029,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.8732780814170837,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.849143922328949,
+          "analyzed_at": "2026-06-09T08:01:09.594853+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Starmer condemns ‘sickening’ Belfast attack after man seriously injured in stabbing",
+      "description": "Bystanders bravely fought off the attacker after he left a man in serious condition with injuries to head, neck and back",
+      "url": "https://www.independent.co.uk/news/uk/crime/north-belfast-stabbing-kinnaird-avenue-man-injured-b2992284.html",
+      "image_url": "https://static.independent.co.uk/2026/06/09/12/53/ewrtnrgwf.jpeg?width=1200&auto=webp&trim=0%2C0%2C0%2C0",
+      "published_at": "2026-06-09T13:50:19+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 14.399999618530273,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "North Belfast",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belfast_North_(UK_Parliament_constituency)",
+          "mid": "/m/03jjv8",
+          "salience": 0.048786308616399765,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "Police Service of Northern Ireland",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Police_Service_of_Northern_Ireland",
+          "mid": "/m/01qzpl",
+          "salience": 0.015190129168331623,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "John Finucane",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/John_Finucane",
+          "mid": "/g/11f75ymq7y",
+          "salience": 0.014563842676579952,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "Keir Starmer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keir_Starmer",
+          "mid": "/m/04glwhb",
+          "salience": 0.01343565434217453,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "Somalian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Somalia",
+          "mid": "/m/06tgw",
+          "salience": 0.006755226757377386,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "Rebecca Black",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rebecca_Black",
+          "mid": "/m/0gjd8f0",
+          "salience": 0.004168185405433178,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "Antrim Road",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Antrim_Road",
+          "mid": "/m/0j63g41",
+          "salience": 0.0025468640960752964,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "DUP",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Democratic_Unionist_Party",
+          "mid": "/m/01gb1c",
+          "salience": 0.0011762239737436175,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "CCTV",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Closed-circuit_television",
+          "mid": "/g/11b6gh5xb3",
+          "salience": 0.0008206424536183476,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.966468095779419,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.49335429072380066,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Law Enforcement",
+          "confidence": 0.23402109742164612,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.18892285227775574,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.11234592646360397,
+          "analyzed_at": "2026-06-09T16:02:12.838265+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Stormzy and Wretch 32 lead tributes to Talay Riley after singer-songwriter stabbed to death",
+      "description": "The musician, real name Mark Orabiyi, 35, was found with stab wounds by paramedics on the morning of June 5 and was pronounced dead at the scene",
+      "url": "https://www.independent.co.uk/arts-entertainment/music/talay-riley-death-stabbed-chipmunk-singer-songwriter-b2991618.html",
+      "image_url": "https://static.independent.co.uk/2026/06/08/09/08083723-10e5ae1c-92e8-4cf9-a04c-41fa4909f73c.jpg?width=1200&auto=webp&crop=3%3A2",
+      "published_at": "2026-06-08T08:48:55+00:00",
       "language": "en",
       "country": "uk",
       "category": "general",
       "sentiment_label": "neutral",
       "sentiment_score": 0.0,
-      "source_name": "guardian"
+      "sentiment_magnitude": 19.600000381469727,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "Talay Riley",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Talay_Riley",
+          "mid": "/m/0h22t74",
+          "salience": 0.293735146522522,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Oritse Williams",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oritsé_Williams",
+          "mid": "/m/0b6ng4l",
+          "salience": 0.032406099140644073,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Michael Orabiyi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Scribz_Riley",
+          "mid": "/g/11g4cdq71s",
+          "salience": 0.02569962851703167,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Wretch 32",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wretch_32",
+          "mid": "/m/076zx_r",
+          "salience": 0.024773886427283287,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Khalid",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Khalid_(disambiguation)",
+          "mid": "/g/11g6njbbfb",
+          "salience": 0.018548931926488876,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Stormzy",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stormzy",
+          "mid": "/m/0126jk8t",
+          "salience": 0.01303844153881073,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "London",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/London",
+          "mid": "/m/04jpl",
+          "salience": 0.011741066351532936,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Grammy",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Grammy_Awards",
+          "mid": "/m/0c4ys",
+          "salience": 0.010384799912571907,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Flo",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Flo_(group)",
+          "mid": "/g/11sy_bdj0_",
+          "salience": 0.007994952611625195,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Chipmunk",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chipmunk",
+          "mid": "/m/02021",
+          "salience": 0.004748933017253876,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Zendaya",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Zendaya",
+          "mid": "/m/0ddf18x",
+          "salience": 0.004748933017253876,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Kehlani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kehlani",
+          "mid": "/g/11b6fk48sx",
+          "salience": 0.0033401488326489925,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.0021152603439986706,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Dua Lipa",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dua_Lipa",
+          "mid": "/g/11bxfyskcg",
+          "salience": 0.002108051674440503,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Keisha Buchanan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Keisha_Buchanan",
+          "mid": "/m/08xwm3",
+          "salience": 0.0014700117753818631,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Jesus",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jesus",
+          "mid": "/m/045m1_",
+          "salience": 0.0014220583252608776,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "JLS",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/JLS",
+          "mid": "/m/053wg7p",
+          "salience": 0.0014220583252608776,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "British",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.0012953444384038448,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "CCTV",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Closed-circuit_television",
+          "mid": "/g/11b6gh5xb3",
+          "salience": 0.0006703350227326155,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "The Chainsmokers",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Chainsmokers",
+          "mid": "/m/0ndjfmd",
+          "salience": 0.0004269996425136924,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "Sugababes",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sugababes",
+          "mid": "/m/02vbmw",
+          "salience": 0.000426297978265211,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Arts & Entertainment/Music & Audio/Urban & Hip-Hop",
+          "confidence": 0.7916246652603149,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.6556835770606995,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Celebrities & Entertainment News",
+          "confidence": 0.5855245590209961,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.3447124660015106,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Entertainment Industry/Recording Industry",
+          "confidence": 0.12205974757671356,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        },
+        {
+          "name": "/Arts & Entertainment/Music & Audio/Pop Music",
+          "confidence": 0.11019564419984818,
+          "analyzed_at": "2026-06-09T08:49:29.775555+00:00"
+        }
+      ]
     },
     {
-      "title": "Germany says it expected Trump’s withdrawal of US troops as row over Iran comments grows – live",
-      "description": "German defence minister responds to US president’s announcement that 5,000 US troops will leave bases in GermanyA senior Iranian military officer said renewed fighting between the US and Iran was “likely”, according to the Iran’s semi-official Fars news agency.The statement followed reports that Donald Trump was “not satisfied” with a new Iranian proposal to end the war. Iran delivered the proposal to mediator Pakistan on Thursday evening, Iranian state media reported, without detailing its contents. Continue reading...",
-      "url": "https://www.theguardian.com/world/live/2026/may/02/us-israel-war-iran-germany-american-troops-donald-trump-middle-east-latest-news-updates",
-      "image_url": "https://i.guim.co.uk/img/media/c259c4209273e1d883e5cacea14c50cd6c072b90/452_0_6111_4888/master/6111.jpg?width=140&quality=85&auto=format&fit=max&s=9eb36af8d9f5d55c98dbdbeef6bfc534",
-      "published_at": "2026-05-02T08:35:33+00:00",
+      "title": "‘Racist mindsets’: Africans in Ireland feel fear in wake of Yves Sakila’s death",
+      "description": "After an incident on a Dublin street with echoes of George Floyd, people of colour sense rising hostilityWhen Kembetia Bissa fled the Democratic Republic of the Congo and moved to Ireland in 2003 he found not only sanctuary but beauty, friendship and a home.The asylum seeker settled in Bandon, west Cork, and found work as a landscaper. He opened an African dance school with Congolese drumming and taught local people the rhythms of his homeland. “It was very positive, very welcoming. I felt like I was in my own country,” Bissa, 55, said this week in Dublin. Continue reading...",
+      "url": "https://www.theguardian.com/world/2026/jun/07/ireland-yves-sakila-death-africans-fear",
+      "image_url": "https://i.guim.co.uk/img/media/1843c9051c54a721bca4d53aacc45e29b2fada51/509_0_5031_4024/master/5031.jpg?width=140&quality=85&auto=format&fit=max&s=4b090c7f6412798662b38b3b02cd1581",
+      "published_at": "2026-06-07T08:00:28+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "negative",
+      "sentiment_score": -0.30000001192092896,
+      "sentiment_magnitude": 27.299999237060547,
+      "source_name": "guardian",
+      "entities": [
+        {
+          "name": "Dublin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dublin",
+          "mid": "/m/02cft",
+          "salience": 0.03270561248064041,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Congolese",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Democratic_Republic_of_the_Congo",
+          "mid": "/m/088xp",
+          "salience": 0.011545736342668533,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Ireland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ireland",
+          "mid": "/m/012wgb",
+          "salience": 0.011310085654258728,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "George Floyd",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/George_Floyd",
+          "mid": "/m/02qxc9m",
+          "salience": 0.007946127094328403,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Henry Street",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Henry_Street,_Dublin",
+          "mid": "/m/02phrc9",
+          "salience": 0.002337685087695718,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Muslims",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Muslims",
+          "mid": "/m/04y29",
+          "salience": 0.002112652873620391,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Tallaght",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tallaght",
+          "mid": "/m/02xtmd",
+          "salience": 0.0015410262858495116,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Racist",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Racism",
+          "mid": "/m/06d4h",
+          "salience": 0.0013559343060478568,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Bertie Ahern",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bertie_Ahern",
+          "mid": "/m/09_9nl",
+          "salience": 0.0012734029442071915,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Cork",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/County_Cork",
+          "mid": "/m/0clzr",
+          "salience": 0.0010823906632140279,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Bandon",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bandon,_County_Cork",
+          "mid": "/m/03gq0y",
+          "salience": 0.0010823906632140279,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "African",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Africa",
+          "mid": "/m/0dg3n1",
+          "salience": 0.0007318967836908996,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Bulelani Mfaco",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bulelani_Mfaco",
+          "mid": "/g/11jclzbj8h",
+          "salience": 0.0006353623466566205,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0005182923632673919,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Rory Carroll",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rory_Carroll",
+          "mid": "/m/08fs6l",
+          "salience": 0.0004858400207012892,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "UK",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Kingdom",
+          "mid": "/m/07ssc",
+          "salience": 0.00033166466164402664,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Minneapolis",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Minneapolis",
+          "mid": "/m/0fpzwf",
+          "salience": 0.00027357813087292016,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Indian",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 0.0002728890103753656,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Arnotts",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arnotts_(Irish_department_store)",
+          "mid": "/m/06g3wf",
+          "salience": 0.0001306840858887881,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "Achill Island",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Achill_Island",
+          "mid": "/m/0lr1",
+          "salience": 0.00013065703387837857,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "County Mayo",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/County_Mayo",
+          "mid": "/m/01rng",
+          "salience": 0.00013065703387837857,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.8134298324584961,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Discrimination & Identity Relations",
+          "confidence": 0.5709841847419739,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Violence & Abuse",
+          "confidence": 0.46127626299858093,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.3353721797466278,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/People & Society/Other",
+          "confidence": 0.3087715804576874,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.2857603430747986,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Other",
+          "confidence": 0.1767680048942566,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        },
+        {
+          "name": "/Law & Government/Public Safety/Crime & Justice",
+          "confidence": 0.10808005183935165,
+          "analyzed_at": "2026-06-09T06:26:26.896993+00:00"
+        }
+      ]
+    },
+    {
+      "title": "The simple rule that experts say can help you stop impulse spending",
+      "description": "Here’s how to avoid unnecessarily spending",
+      "url": "https://www.independent.co.uk/money/stop-impulse-spending-48-hour-rule-b2991000.html",
+      "image_url": "https://static.independent.co.uk/2025/11/14/15/24/iStock-2228695359.jpg?width=1200&auto=webp&crop=3%3A2",
+      "published_at": "2026-06-06T13:06:01+00:00",
       "language": "en",
       "country": "gb",
       "category": "general",
       "sentiment_label": "neutral",
       "sentiment_score": 0.0,
-      "source_name": "guardian"
+      "sentiment_magnitude": 18.100000381469727,
+      "source_name": "independent",
+      "entities": [
+        {
+          "name": "iStock",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/IStock",
+          "mid": "/m/09h47q",
+          "salience": 0.0008544529555365443,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:34.399374+00:00"
+        },
+        {
+          "name": "Deliveroo",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deliveroo",
+          "mid": "/g/11b8b45ypp",
+          "salience": 0.00044721615267917514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:34.399374+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Finance/Financial Planning & Management/Other",
+          "confidence": 0.7930602431297302,
+          "analyzed_at": "2026-06-10T08:04:34.399374+00:00"
+        },
+        {
+          "name": "/Reference/General Reference/How-To, DIY & Expert Content",
+          "confidence": 0.3375362157821655,
+          "analyzed_at": "2026-06-10T08:04:34.399374+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Other",
+          "confidence": 0.24234884977340698,
+          "analyzed_at": "2026-06-10T08:04:34.399374+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Hundreds of aftershocks jolt Philippines as officials say death toll could rise",
+      "description": "Dozens of people are dead and hundreds more injured following an earthquake in the country's south.",
+      "url": "https://www.bbc.com/news/articles/ckg50pypn2eo",
+      "image_url": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1fbe/live/241860b0-63d4-11f1-8546-8f19e4fe30f4.jpg",
+      "published_at": "2026-06-09T07:36:15+00:00",
+      "language": "en",
+      "country": "gb",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": -0.20000000298023224,
+      "sentiment_magnitude": 13.5,
+      "source_name": "bbc",
+      "entities": [
+        {
+          "name": "Philippines",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Philippines",
+          "mid": "/m/05v8c",
+          "salience": 0.13226783275604248,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "DZMM",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/DZMM",
+          "mid": "/m/07dfjb",
+          "salience": 0.020777815952897072,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Mindanao island",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mindanao",
+          "mid": "/m/05502",
+          "salience": 0.013145135715603828,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Manila",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manila",
+          "mid": "/m/0195pd",
+          "salience": 0.010790876112878323,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.010094632394611835,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Ferdinand Marcos Jr",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bongbong_Marcos",
+          "mid": "/m/02rbl1",
+          "salience": 0.00978493969887495,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Pacific Ring of Fire",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ring_of_Fire",
+          "mid": "/m/01br_q",
+          "salience": 0.006167735904455185,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Jollibee",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jollibee",
+          "mid": "/g/11bwccwfq_",
+          "salience": 0.005374985747039318,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Teodoro Herbosa",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ted_Herbosa",
+          "mid": "/g/11kq5gmdzx",
+          "salience": 0.002065632725134492,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Japan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Japan",
+          "mid": "/m/03_3d",
+          "salience": 0.0018094568513333797,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Indonesia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Indonesia",
+          "mid": "/m/03ryn",
+          "salience": 0.0018094568513333797,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Cotabato Trench",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cotabato_Trench",
+          "mid": "/g/11h57xzwn3",
+          "salience": 0.0013790501980111003,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "CCTV",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Closed-circuit_television",
+          "mid": "/g/11b6gh5xb3",
+          "salience": 0.0012225518003106117,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Polomolok",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Polomolok",
+          "mid": "/m/06rd1g",
+          "salience": 0.001221513724885881,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Lebak",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebak,_Sultan_Kudarat",
+          "mid": "/m/06jrdf",
+          "salience": 0.0011160074500367045,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "General Santos City",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/General_Santos",
+          "mid": "/m/01stll",
+          "salience": 0.000952715752646327,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Jose Abad Santos",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jose_Abad_Santos,_Davao_Occidental",
+          "mid": "/m/06qtpz",
+          "salience": 0.0006653768359683454,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Davao Occidental",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Davao_Occidental",
+          "mid": "/m/0q4157k",
+          "salience": 0.0005843641120009124,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "Renato Solidum",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Renato_Solidum_Jr.",
+          "mid": "/g/11f0s7rvx8",
+          "salience": 0.00047257947153411806,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/Accidents & Disasters",
+          "confidence": 1.0,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "/Science/Earth Sciences/Geology",
+          "confidence": 0.5314344167709351,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.5168749690055847,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.2281566560268402,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.1684456169605255,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.1569962352514267,
+          "analyzed_at": "2026-06-09T08:01:34.752648+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Gräbt Red Bull einer Kleinstadt das Wasser ab?",
+      "description": "In Baruth haben Red Bull und ein Partnerunternehmen die Brandenburger Urstromquelle gekauft. Der Konzern produziert dort Energydrinks, will eine Dosenfabrik bauen.",
+      "url": "https://www.focus.de/perspektiven/constructive-world-award/graebt-red-bull-einer-kleinstadt-das-wasser-ab_17fc7b47-e11f-42e6-ae71-2216111bed30.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/aa28d660-b788-4335-b290-5095c8e79890.8cb013f3-3542-4520-8d7e-618cfe23ce8a.jpg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(960,715)&hash=f712dd5cf08c99795622b6eca8f0d725981253ccce3d2aabfc90049cff84935d",
+      "published_at": "2026-06-10T04:45:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 93.30000305175781,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "Red Bull",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Red_Bull_Racing",
+          "mid": "/m/04dd5t",
+          "salience": 0.05088267847895622,
+          "mention_count": 43,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Baruth",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Baruth/Mark",
+          "mid": "/m/0f7zc2",
+          "salience": 0.04637468606233597,
+          "mention_count": 37,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Brandenburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brandenburg",
+          "mid": "/m/017wh",
+          "salience": 0.0022728589829057455,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.002183829667046666,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Grünheide",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Grünheide_(Mark)",
+          "mid": "/m/02rnsr1",
+          "salience": 0.0009255508775822818,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.0006845138850621879,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "FOCUS online",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Focus_(German_magazine)",
+          "mid": "/m/026nk8f",
+          "salience": 0.0005406094714999199,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "SZ",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Süddeutsche_Zeitung",
+          "mid": "/m/03lmmd",
+          "salience": 0.0002831957826856524,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Schäff",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Schaeff_(Baumaschinenhersteller)",
+          "mid": "/g/120lw7z0",
+          "salience": 0.00019753248488996178,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Dietrich Mateschitz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dietrich_Mateschitz",
+          "mid": "/m/04qkd_",
+          "salience": 0.00015583458298351616,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Krombacher",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Krombacher_Brauerei",
+          "mid": "/m/08kww6",
+          "salience": 0.00013040129852015525,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Servus TV",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/ServusTV",
+          "mid": "/m/0j_4dhs",
+          "salience": 0.00010537738126004115,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Radeland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Radeland_(Baruth/Mark)",
+          "mid": "/g/124xvv6y7",
+          "salience": 4.549738150672056e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "europäischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 3.4364478779025376e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Nordosteuropa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Nordosteuropa",
+          "mid": "/g/123b8tb1",
+          "salience": 2.328254413441755e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Teltow-Fläming",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Teltow-Fläming",
+          "mid": "/m/016936",
+          "salience": 2.1577605366474018e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 2.151946864614729e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 1.535823139420245e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Lüneburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lüneburg",
+          "mid": "/m/0135kl",
+          "salience": 1.5044245628814679e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "DDR",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/East_Germany",
+          "mid": "/m/03f2w",
+          "salience": 1.473624161008047e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Puhdys",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Puhdys",
+          "mid": "/m/0972nr",
+          "salience": 1.473624161008047e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Ludwigsfelde",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ludwigsfelde",
+          "mid": "/m/0bnmmb",
+          "salience": 1.3900953490519896e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Yoovidhya",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chaleo_Yoovidhya",
+          "mid": "/m/09gghsn",
+          "salience": 1.2956334103364497e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Hongkong",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hong_Kong",
+          "mid": "/m/03h64",
+          "salience": 1.2889706340502016e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Heinrich-Böll-Stiftung",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Heinrich_Böll_Foundation",
+          "mid": "/m/0dd23j",
+          "salience": 1.2140565559093375e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Vio",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/ViO_(Getränk)",
+          "mid": "/g/11c75w3q93",
+          "salience": 1.196670564240776e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "Coca-Cola",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Coca-Cola_Company",
+          "mid": "/m/03phgz",
+          "salience": 1.196670564240776e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Food & Drink/Beverages/Energy Drinks",
+          "confidence": 0.5055060982704163,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "/News/Business News/Company News",
+          "confidence": 0.476088285446167,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Green Living & Environmental Issues",
+          "confidence": 0.30481383204460144,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Energy & Utilities/Other",
+          "confidence": 0.15402154624462128,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "/News/Local News",
+          "confidence": 0.13220542669296265,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "/Food & Drink/Beverages/Soft Drinks",
+          "confidence": 0.12540607154369354,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.1189851313829422,
+          "analyzed_at": "2026-06-10T08:01:32.302526+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Ashoka-Changemaker: 3 Beispiele zeigen, wie wir Gesellschaft besser machen",
+      "description": "Viele Menschen glauben an die Demokratie, zweifeln aber an ihrer Praxis. Drei Sozialunternehmer zeigen Wege aus der Ohnmacht.",
+      "url": "https://www.focus.de/perspektiven/constructive-world-award/ashoka-changemaker-3-beispiele-zeigen-wie-wir-gesellschaft-besser-machen_5780e918-30d2-4a4f-8c21-e28e90ec1fc5.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/b0278cfb-5760-40d1-b4aa-d62993a0e4b4.07129d2b-00fd-4632-92c1-b1d06059a3a3.jpg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(1218,807)&hash=c9295cb00bcadfb91f4133fa6f2656202f57a80c125edaa22516925f097e6d12",
+      "published_at": "2026-06-09T12:48:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 34.099998474121094,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.008059777319431305,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.004337909631431103,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Bertelsmann Stiftung",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bertelsmann_Stiftung",
+          "mid": "/m/0288rlj",
+          "salience": 0.0026066377758979797,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Ashoka",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ashoka_(non-profit_organization)",
+          "mid": "/g/1215ppk5",
+          "salience": 0.001694520702585578,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Niedersachsen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lower_Saxony",
+          "mid": "/m/04p0c",
+          "salience": 0.0009305696003139019,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 0.000429128878749907,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Bundestag",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bundestag",
+          "mid": "/m/017xh",
+          "salience": 0.00037730264011770487,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Maximilian Oehl",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Maximilian_Oehl",
+          "mid": "/g/11lfqf36pg",
+          "salience": 0.00011432964674895629,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Brand New Bundestag",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brand_New_Bundestag",
+          "mid": "/g/11r_qqc14n",
+          "salience": 0.00011432964674895629,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Dresden",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dresden",
+          "mid": "/m/09b9m",
+          "salience": 9.506573405815288e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "Leipzig",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leipzig",
+          "mid": "/m/04kf4",
+          "salience": 7.171141623985022e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.5529703497886658,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Other",
+          "confidence": 0.4985133707523346,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Other",
+          "confidence": 0.19610369205474854,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "/Finance/Investing/Socially Responsible Investing",
+          "confidence": 0.1716252565383911,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Other",
+          "confidence": 0.11674625426530838,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.10724307596683502,
+          "analyzed_at": "2026-06-09T16:02:27.652636+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Iran-Liveblog: Israels Militär meldet Rakete aus dem Jemen",
+      "description": "Die mit Iran verbündete Huthi-Miliz im Jemen hat eine Rakete auf Israel abgefeuert, wie das dortige Militär mitteilte. Auch von iranischer Seite sei Israel am Morgen erneut angegriffen worden.",
+      "url": "https://www.tagesschau.de/newsticker/liveblog-iran-montag-124.html",
+      "image_url": null,
+      "published_at": "2026-06-08T04:51:27+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.10000000149011612,
+      "sentiment_magnitude": 81.30000305175781,
+      "source_name": "tagesschau",
+      "entities": [
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.019872024655342102,
+          "mention_count": 51,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "iranischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.009611127898097038,
+          "mention_count": 102,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Israel",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.009335705079138279,
+          "mention_count": 108,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Nahost",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Near_East",
+          "mid": "/m/01ffbn",
+          "salience": 0.006157262716442347,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Jemen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yemen",
+          "mid": "/m/01z88t",
+          "salience": 0.002734983107075095,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Sophie von der Tann",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Sophie_von_der_Tann",
+          "mid": "/g/11mvsx7z69",
+          "salience": 0.0022900912445038557,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Oman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oman",
+          "mid": "/m/05l8y",
+          "salience": 0.0021193132270127535,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Tel Aviv",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tel_Aviv",
+          "mid": "/m/07qzv",
+          "salience": 0.0011425619013607502,
+          "mention_count": 13,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Joseph Aoun",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joseph_Aoun",
+          "mid": "/g/11f3f1r9l1",
+          "salience": 0.000876785081345588,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Istanbul",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Istanbul",
+          "mid": "/m/09949m",
+          "salience": 0.0007537276251241565,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Das Erste",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Das_Erste",
+          "mid": "/m/02vsc6",
+          "salience": 0.0007052518194541335,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Katharina Willinger",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Katharina_Willinger",
+          "mid": "/g/11qjx0vn6b",
+          "salience": 0.0005995544488541782,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Spirit Airlines",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spirit_Airlines",
+          "mid": "/m/029g4f",
+          "salience": 0.0003649361606221646,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Europas",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.00021420227130874991,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Tasnim",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tasnim_News_Agency",
+          "mid": "/m/010pczvr",
+          "salience": 0.00021115815616212785,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Centcom",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Central_Command",
+          "mid": "/m/01xsrd",
+          "salience": 0.0002098426630254835,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.00016548382700420916,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Dax",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/DAX",
+          "mid": "/m/0877z",
+          "salience": 0.00015759019879624248,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Teheran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.00015725403500255197,
+          "mention_count": 14,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.00014607862976845354,
+          "mention_count": 17,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Luftwaffe",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Luftwaffe",
+          "mid": "/m/04jtj",
+          "salience": 0.0001451418938813731,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Netanjahu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Netanyahu",
+          "mid": "/m/0fm2h",
+          "salience": 0.00012753256305586547,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Hisbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hezbollah",
+          "mid": "/m/03m7d",
+          "salience": 0.00012712189345620573,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Irak",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iraq",
+          "mid": "/m/0d05q4",
+          "salience": 0.00011945023288717493,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Türkei",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Turkey",
+          "mid": "/m/01znc_",
+          "salience": 0.00010989184374921024,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Ankara",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ankara",
+          "mid": "/m/0jyw",
+          "salience": 0.00010526476398808882,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "saudisch",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Saudi_Arabia",
+          "mid": "/m/01z215",
+          "salience": 8.90269220690243e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Syrien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Syria",
+          "mid": "/m/06vbd",
+          "salience": 8.427732973359525e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Hakan Fidan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hakan_Fidan",
+          "mid": "/m/0v0hyfg",
+          "salience": 8.036090002860874e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Georgien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Georgia_(country)",
+          "mid": "/m/0d0kn",
+          "salience": 6.392194336513057e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Aserbaidschan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Azerbaijan",
+          "mid": "/m/0jhd",
+          "salience": 6.392194336513057e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Ägypten",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Egypt",
+          "mid": "/m/02k54",
+          "salience": 5.957356916042045e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Pakistans",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pakistan",
+          "mid": "/m/05sb1",
+          "salience": 5.957356916042045e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Wadephul",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Johann_Wadephul",
+          "mid": "/m/0c32yxw",
+          "salience": 5.6853477872209623e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "libanesischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 5.543500083149411e-05,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "CDU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Democratic_Union_of_Germany",
+          "mid": "/m/0gg68",
+          "salience": 4.3719315726775676e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "UNESCO",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UNESCO",
+          "mid": "/m/05yg8kx",
+          "salience": 2.981751094921492e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Tyrus",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tyre,_Lebanon",
+          "mid": "/m/07kx2",
+          "salience": 2.981751094921492e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Bergen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bergen",
+          "mid": "/m/0fm7s",
+          "salience": 2.7489682906889357e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Beirut",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beirut",
+          "mid": "/m/09bjv",
+          "salience": 2.6714842533692718e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Irna",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islamic_Republic_News_Agency",
+          "mid": "/m/03g2w_",
+          "salience": 2.2833928596810438e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Telegram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Telegram_(software)",
+          "mid": "/m/0zwk75g",
+          "salience": 2.089957160933409e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Kataib Hisbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kata'ib_Hezbollah",
+          "mid": "/m/06zsmt7",
+          "salience": 1.5467056073248386e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 1.1566366083570756e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Kaja Kallas",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kaja_Kallas",
+          "mid": "/m/012tvcbp",
+          "salience": 1.1330866982461885e-05,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Truth Social",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Truth_Social",
+          "mid": "/g/11p6w0djqy",
+          "salience": 1.113222424464766e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Huthi",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houthis",
+          "mid": "/m/047vsxx",
+          "salience": 1.1047502084693406e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Roten Meer",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Red_Sea",
+          "mid": "/m/06jfd",
+          "salience": 9.391645107825752e-06,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Haifa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Haifa",
+          "mid": "/m/0fg1g",
+          "salience": 8.91046420292696e-06,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Jasd",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jásd",
+          "mid": "/m/0dj593",
+          "salience": 8.628428076917771e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Riad",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Riyadh",
+          "mid": "/m/0dlm_",
+          "salience": 8.12243979453342e-06,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Nabatija",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nabatieh",
+          "mid": "/m/0b9c9c",
+          "salience": 7.564344741695095e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Al-Manar",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Al-Manar",
+          "mid": "/m/04pgy_",
+          "salience": 7.4392642090970185e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Nawaf Salam",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nawaf_Salam",
+          "mid": "/m/05c0ylw",
+          "salience": 7.222220574476523e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Washington",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Washington,_D.C.",
+          "mid": "/m/0rh6k",
+          "salience": 7.1313270382233895e-06,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Kairo",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cairo",
+          "mid": "/m/01w2v",
+          "salience": 6.053839570085984e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Tel Nof",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tel_Nof_Airbase",
+          "mid": "/g/11h781502d",
+          "salience": 5.980482001177734e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Nikosia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nicosia",
+          "mid": "/m/0fqg8",
+          "salience": 5.748316652898211e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Al-Chardsch",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Al-Chardsch",
+          "mid": "/g/11fpr9y0pp",
+          "salience": 5.661815066559939e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Bandar-e-Mahschahr",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bandar-e_Mahshahr",
+          "mid": "/m/060_by",
+          "salience": 5.617481747322017e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Sultan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sultan",
+          "mid": "/m/0h7hq",
+          "salience": 5.3924823077977635e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Mehrabad",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mehrabad_International_Airport",
+          "mid": "/m/06fzzb",
+          "salience": 5.204959506954765e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Esmail Baghaei",
+          "type": "PERSON",
+          "wikipedia_url": "https://fa.wikipedia.org/wiki/اسماعیل_بقایی",
+          "mid": "/g/11y6kkchjc",
+          "salience": 5.204127319302643e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Kermanschah",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kermanshah",
+          "mid": "/m/055d0y",
+          "salience": 5.160195087228203e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Tabris",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tabriz",
+          "mid": "/m/028q7m",
+          "salience": 5.116193278809078e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Nournews",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://fa.wikipedia.org/wiki/نورنیوز",
+          "mid": "/g/11rhxllsxx",
+          "salience": 4.926186193188187e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "Financial Times",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Financial_Times",
+          "mid": "/m/0108kc",
+          "salience": 4.767645805259235e-06,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.9682090282440186,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.6730403900146484,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.4765072166919708,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.29660937190055847,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Other",
+          "confidence": 0.28361499309539795,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.16909541189670563,
+          "analyzed_at": "2026-06-09T08:17:55.458613+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Fußball-WM 2026: Baumann und die Neuer-Rückkehr: „Das war nicht ganz cool“",
+      "description": "Über einen Rücktritt aus der Nationalmannschaft habe er aber trotzdem nie nachgedacht, erklärt der Hoffenheimer Torhüter. Manuel Neuer soll zum WM-Auftakt am 14. Juni gegen Curacao im DFB-Tor stehen.",
+      "url": "https://www.sueddeutsche.de/sport/fussball-wm-2026-liveblog-news-dfb-oliver-baumann-manuek-neuer-kader-nationalelf-li.3492650",
+      "image_url": null,
+      "published_at": "2026-06-07T07:24:58+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.30000001192092896,
+      "sentiment_magnitude": 54.29999923706055,
+      "source_name": "sueddeutsche",
+      "entities": [
+        {
+          "name": "USA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.01916111633181572,
+          "mention_count": 22,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Omar Abdulkadir Artan",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Omar_Artan",
+          "mid": "/g/11vdxpv1z3",
+          "salience": 0.012138323858380318,
+          "mention_count": 13,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Somalia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Somalia",
+          "mid": "/m/06tgw",
+          "salience": 0.006503330077975988,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Miami",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Miami",
+          "mid": "/m/0f2v0",
+          "salience": 0.004668567795306444,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.0030684159137308598,
+          "mention_count": 14,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "DFB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Football_Association",
+          "mid": "/m/03308v",
+          "salience": 0.0026087129954248667,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "SID",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sport-Informations-Dienst",
+          "mid": "/m/0q3b221",
+          "salience": 0.00233592395670712,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0018582269549369812,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Julia Bergmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Júlia_Bergmann",
+          "mid": "/g/11jb3w01vl",
+          "salience": 0.0014034685445949435,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Istanbul",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Istanbul",
+          "mid": "/m/09949m",
+          "salience": 0.0013385906349867582,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Mexiko",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 0.0010063081281259656,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Mexiko-Stadt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico_City",
+          "mid": "/m/04sqj",
+          "salience": 0.000872086500748992,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "CBP",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/United_States_Customs_and_Border_Protection",
+          "mid": "/m/038r8p",
+          "salience": 0.0006364833097904921,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Afrikas",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Africa",
+          "mid": "/m/0dg3n1",
+          "salience": 0.0005860686651431024,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Aztekenstadion",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Estadio_Azteca",
+          "mid": "/m/05_q0_",
+          "salience": 0.000469110906124115,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.00039973988896235824,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Südafrika",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/South_Africa",
+          "mid": "/m/0hzlz",
+          "salience": 0.00034988546394743025,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Claudia Sheinbaum",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Claudia_Sheinbaum",
+          "mid": "/g/122dl1x2",
+          "salience": 0.0002438169321976602,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 0.00018912936502601951,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Paris Saint-Germain",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paris_Saint-Germain_FC",
+          "mid": "/m/01_1kk",
+          "salience": 0.00018298857321497053,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Champions-League",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UEFA_Champions_League",
+          "mid": "/m/0c1q0",
+          "salience": 0.00018298857321497053,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Clermont-Ferrand",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Clermont-Ferrand",
+          "mid": "/m/0lbcg",
+          "salience": 0.00015186940436251462,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "East Rutherford",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/East_Rutherford,_New_Jersey",
+          "mid": "/m/0206mwr",
+          "salience": 0.00013733554806094617,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "DFB-Elf",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.00012559068272821605,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Ecuador",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ecuador_national_football_team",
+          "mid": "/m/03zj_3",
+          "salience": 0.00010924188245553523,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "New Jersey",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Jersey",
+          "mid": "/m/05fjf",
+          "salience": 0.00010924188245553523,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Joshua Kimmich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joshua_Kimmich",
+          "mid": "/m/0y4n_rn",
+          "salience": 0.00010924188245553523,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "NJ Transit",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/NJ_Transit",
+          "mid": "/m/01t0sn",
+          "salience": 9.713103645481169e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Kanada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 7.513777381973341e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Grenada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Grenada",
+          "mid": "/m/035yg",
+          "salience": 7.350817759288475e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Rudi Völler",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rudi_Völler",
+          "mid": "/m/01zn9q",
+          "salience": 7.096590707078576e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Winston-Salem",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Winston-Salem,_North_Carolina",
+          "mid": "/m/0ygbf",
+          "salience": 7.096590707078576e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "München",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Munich",
+          "mid": "/m/02h6_6p",
+          "salience": 7.073870801832527e-05,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Curaçao",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Curaçao",
+          "mid": "/m/0hbgh",
+          "salience": 6.398360710591078e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Los Angeles",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Los_Angeles",
+          "mid": "/m/030qb3t",
+          "salience": 5.8469377108849585e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Fifa",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA",
+          "mid": "/m/02zm3",
+          "salience": 5.201364547247067e-05,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Neuseeland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Zealand",
+          "mid": "/m/0ctw_b",
+          "salience": 4.970574809703976e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Belgien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belgium",
+          "mid": "/m/0154j",
+          "salience": 4.970574809703976e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Ägypten",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Egypt",
+          "mid": "/m/02k54",
+          "salience": 4.875211016042158e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Tijuana",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tijuana",
+          "mid": "/m/0pswc",
+          "salience": 4.38245951954741e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "INSA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/INSA_(Germany)",
+          "mid": "/g/11cr_rlzv3",
+          "salience": 4.289434218662791e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Puerto Rico",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Puerto_Rico",
+          "mid": "/m/05r7t",
+          "salience": 4.11476066801697e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Spanien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spain",
+          "mid": "/m/06mkj",
+          "salience": 3.955412103096023e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Seattle",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Seattle",
+          "mid": "/m/0d9jr",
+          "salience": 3.8779147871537134e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "NBA",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Basketball_Association",
+          "mid": "/m/05jvx",
+          "salience": 3.804917650995776e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "NFL",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Football_League",
+          "mid": "/m/059yj",
+          "salience": 3.804917650995776e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Argentinien",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Argentina_national_football_team",
+          "mid": "/m/02bh_v",
+          "salience": 3.666877091745846e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Backstage",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Kulturzentrum_Backstage",
+          "mid": "/g/120vzbtl",
+          "salience": 3.601551361498423e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Neuhausen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Neuhausen-Nymphenburg",
+          "mid": "/m/0h9460m",
+          "salience": 3.601551361498423e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Manuel Neuer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manuel_Neuer",
+          "mid": "/m/02899ft",
+          "salience": 3.557452146196738e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "SZ",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Süddeutsche_Zeitung",
+          "mid": "/m/03lmmd",
+          "salience": 3.299970558146015e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Nico Williams",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nico_Williams",
+          "mid": "/g/11h_1l9gzd",
+          "salience": 3.271216701250523e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Lamine Yamal",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lamine_Yamal",
+          "mid": "/g/11s7l7bjz_",
+          "salience": 3.271216701250523e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Julian Nagelsmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Julian_Nagelsmann",
+          "mid": "/g/11bwjbhzf8",
+          "salience": 2.8072958230040967e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Olise Dank",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michael_Olise",
+          "mid": "/g/11fk4srkjx",
+          "salience": 2.7291509468341246e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Hendrik Streeck",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hendrik_Streeck",
+          "mid": "/g/11c2nkstzx",
+          "salience": 2.598280116217211e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Luis de la Fuente",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Luis_de_la_Fuente_(footballer,_born_1961)",
+          "mid": "/g/120_rrs7",
+          "salience": 2.40616991504794e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Nordamerika",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_America",
+          "mid": "/m/059g4",
+          "salience": 2.40616991504794e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Didier Deschamps Nordirland",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Didier_Deschamps",
+          "mid": "/m/02wxl9",
+          "salience": 2.3819222406018525e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Afrika-Cup",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Africa_Cup_of_Nations",
+          "mid": "/m/01l5zn",
+          "salience": 2.1874919184483588e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Paul Pizzera",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Paul_Pizzera",
+          "mid": "/g/1q677qtlm",
+          "salience": 2.094644878525287e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Frankreich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 2.045521432592068e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Curaçao",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Curaçao",
+          "mid": "/m/0hbgh",
+          "salience": 2.0117433450650424e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Manu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manchester_United_F.C.",
+          "mid": "/m/050fh",
+          "salience": 1.995557795453351e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Puebla",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Puebla_(city)",
+          "mid": "/m/0183z_",
+          "salience": 1.9502502254908904e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Kap Verde",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cape_Verde",
+          "mid": "/m/01nqj",
+          "salience": 1.9293291188660078e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Peru",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Peru",
+          "mid": "/m/016wzw",
+          "salience": 1.9293291188660078e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Desiré Doué",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Désiré_Doué",
+          "mid": "/g/11rxk_r3y0",
+          "salience": 1.9036593585042283e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "FC Augsburg",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FC_Augsburg",
+          "mid": "/m/09cvbq",
+          "salience": 1.780689308361616e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Arizona",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arizona",
+          "mid": "/m/0vmt",
+          "salience": 1.681224603089504e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Atlanta",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Atlanta",
+          "mid": "/m/013yq",
+          "salience": 1.6783367755124345e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Pedro Gallese",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pedro_Gallese",
+          "mid": "/m/010qcq9w",
+          "salience": 1.6608950318186544e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Mikel Oyarzabal",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mikel_Oyarzabal",
+          "mid": "/g/11bwhbhtzz",
+          "salience": 1.6608950318186544e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Jairo Velez",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jairo_Vélez",
+          "mid": "/m/011smwjk",
+          "salience": 1.6438129023299553e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Hamburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hamburg",
+          "mid": "/m/03hrz",
+          "salience": 1.6265967133222148e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Lille",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lille",
+          "mid": "/m/0d8r8",
+          "salience": 1.6106816474348307e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Patrick Kelly",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michael_Patrick_Kelly",
+          "mid": "/m/01qbzn4",
+          "salience": 1.5788618838996626e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Houston",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houston",
+          "mid": "/m/03l2n",
+          "salience": 1.574666384840384e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "FC Arsenal",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arsenal_F.C.",
+          "mid": "/m/0xbm",
+          "salience": 1.563419027661439e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "William Saliba",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/William_Saliba",
+          "mid": "/g/11fd6dg7g3",
+          "salience": 1.563419027661439e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Ousmane Dembelé",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ousmane_Dembélé",
+          "mid": "/g/11bwyxlxjs",
+          "salience": 1.563419027661439e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Wake Forest University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wake_Forest_University",
+          "mid": "/m/01jq4b",
+          "salience": 1.5621986676706e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Aleksandar Pavlovic",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aleksandar_Pavlović_(footballer)",
+          "mid": "/g/11hsv4dwq1",
+          "salience": 1.5027103472675662e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Felix Nmecha",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Felix_Nmecha",
+          "mid": "/g/11fk8f4p23",
+          "salience": 1.5027103472675662e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Helene Fischer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Helene_Fischer",
+          "mid": "/m/0drzqbb",
+          "salience": 1.4582889889425132e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Wien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Vienna",
+          "mid": "/m/0fhp9",
+          "salience": 1.4266611287894193e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Österreich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Austria",
+          "mid": "/m/0h7x",
+          "salience": 1.4266611287894193e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Reims",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Reims",
+          "mid": "/m/0d117",
+          "salience": 1.4164214007905684e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Gregoritsch",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Michael_Gregoritsch",
+          "mid": "/m/0brzpyg",
+          "salience": 1.4164214007905684e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Taylor Swift",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Taylor_Swift",
+          "mid": "/m/0dl567",
+          "salience": 1.4164214007905684e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Macintosh",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mac_(computer)",
+          "mid": "/m/0zd6",
+          "salience": 1.4063281923881732e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Stefan Posch",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stefan_Posch",
+          "mid": "/g/11f15hk7wl",
+          "salience": 1.3963772289571352e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Kendrick Lamar",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kendrick_Lamar",
+          "mid": "/m/0g9x698",
+          "salience": 1.386566691508051e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "Daniel Fellner",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Daniel_Fellner_(Musiker)",
+          "mid": "/g/11lcj5k5kg",
+          "salience": 1.3837685401085764e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "David Alaba",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/David_Alaba",
+          "mid": "/m/05zlgbs",
+          "salience": 1.3768931239610538e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "ÖFB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Austrian_Football_Association",
+          "mid": "/m/04nnky",
+          "salience": 1.3579463484347798e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "https://www.oefb.tv",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Television",
+          "mid": "/m/07c52",
+          "salience": 1.3579463484347798e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "CDU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Democratic_Union_of_Germany",
+          "mid": "/m/0gg68",
+          "salience": 1.2821709788113367e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.9831560850143433,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.949303388595581,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.7261443138122559,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Visa & Immigration",
+          "confidence": 0.2567201852798462,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Other",
+          "confidence": 0.12601809203624725,
+          "analyzed_at": "2026-06-10T00:05:27.688622+00:00"
+        }
+      ]
+    },
+    {
+      "title": "USA unter Trump: Hegseth bringt D-Day in Zusammenhang mit europäischer Migrationspolitik",
+      "description": "Liveticker zur US-Politik unter Donald Trump aktuell: Aktuelle News & Nachrichten von heute ► Jetzt lesen im Liveticker der FAZ",
+      "url": "https://www.faz.net/aktuell/politik/usa-unter-trump/liveticker-usa-unter-trump-hegseth-bringt-d-day-in-zusammenhang-mit-europaeischer-migrationspolitik-faz-19444916.html",
+      "image_url": "https://media0.faz.net/image/ee48237e01e2/w5221h2937x0y272/202606/43601.0.2187523469/us-verteidigungsminister-pete.webp",
+      "published_at": "2026-06-06T19:41:28+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 59.099998474121094,
+      "source_name": "faz",
+      "entities": [
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.035283204168081284,
+          "mention_count": 34,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.014804511331021786,
+          "mention_count": 41,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Washington",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Washington,_D.C.",
+          "mid": "/m/0rh6k",
+          "salience": 0.007685631979256868,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "US-Senat",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Senate",
+          "mid": "/m/07t58",
+          "salience": 0.005198859144002199,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Republikaner",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Republican_Party_(United_States)",
+          "mid": "/m/07wbk",
+          "salience": 0.004195403773337603,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.003652820596471429,
+          "mention_count": 30,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Mike Johnson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mike_Johnson",
+          "mid": "/m/0131jn2m",
+          "salience": 0.0026011234149336815,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Platner",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Graham_Platner",
+          "mid": "/g/11xvz_968d",
+          "salience": 0.0024251819122582674,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Janet Mills",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Janet_Mills",
+          "mid": "/m/05f6gcw",
+          "salience": 0.0014042089460417628,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Maine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maine",
+          "mid": "/m/050ks",
+          "salience": 0.0011502804700285196,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Uli Putz",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Ulrike_Putz",
+          "mid": "/m/04p6gsb",
+          "salience": 0.0009778931271284819,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 0.0005833706236444414,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "New York Knicks",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_Knicks",
+          "mid": "/m/0jm3v",
+          "salience": 0.0005546296597458422,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "NBA",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/National_Basketball_Association",
+          "mid": "/m/05jvx",
+          "salience": 0.0005458500818349421,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Susan Collins",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Susan_Collins",
+          "mid": "/m/020y8m",
+          "salience": 0.00046103514614515007,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "NBA Finals",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/NBA_Finals",
+          "mid": "/m/03m5x4",
+          "salience": 0.00029970609466545284,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Madison Square Garden",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Madison_Square_Garden",
+          "mid": "/m/0j_66",
+          "salience": 0.00019184354459866881,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "San Antonio Spurs",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/San_Antonio_Spurs",
+          "mid": "/m/0jmh7",
+          "salience": 0.00018116530554834753,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Biden",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joe_Biden",
+          "mid": "/m/012gx2",
+          "salience": 0.00018101936439052224,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "James Dolan",
+          "type": "PERSON",
+          "wikipedia_url": "https://fr.wikipedia.org/wiki/James_L._Dolan",
+          "mid": "/m/0469ts",
+          "salience": 0.0001747102360241115,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Instagram",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Instagram",
+          "mid": "/m/0glpjll",
+          "salience": 0.00016932416474446654,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "nordamerikanischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_America",
+          "mid": "/m/059g4",
+          "salience": 0.00016869984392542392,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "San Antonio",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/San_Antonio",
+          "mid": "/m/0f2w0",
+          "salience": 0.00014766409003641456,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "H-1B",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/H-1B_visa",
+          "mid": "/m/026375",
+          "salience": 0.00013903834042139351,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "ICE",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Immigration_and_Customs_Enforcement",
+          "mid": "/m/01fp_h",
+          "salience": 0.000129997861222364,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Adam Silver",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Adam_Silver",
+          "mid": "/m/0gkvhdv",
+          "salience": 0.000129727617604658,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Indien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/India",
+          "mid": "/m/03rk0",
+          "salience": 7.494044984923676e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Joe Biden",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joe_Biden",
+          "mid": "/m/012gx2",
+          "salience": 5.7229444792028517e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "FIFA",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA",
+          "mid": "/m/02zm3",
+          "salience": 5.535983291338198e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Gianni Infantino",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gianni_Infantino",
+          "mid": "/m/02831hz",
+          "salience": 5.4454434575745836e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Kristen Welker",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kristen_Welker",
+          "mid": "/m/0y55swv",
+          "salience": 4.153779809712432e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "NBC",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/NBC",
+          "mid": "/m/05gnf",
+          "salience": 4.153779809712432e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Taiwan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Taiwan",
+          "mid": "/m/06f32",
+          "salience": 4.13427478633821e-05,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Kanada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 3.806794120464474e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Mexiko",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mexico",
+          "mid": "/m/0b90_r",
+          "salience": 3.806794120464474e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Majid Sattar",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Majid_Sattar",
+          "mid": "/g/11bwp1vc34",
+          "salience": 3.623019074439071e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Kalifornien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/California",
+          "mid": "/m/01n7q",
+          "salience": 3.585741069400683e-05,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Hegseth",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pete_Hegseth",
+          "mid": "/m/0hr0_bn",
+          "salience": 3.4130960557376966e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Normandie",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Normandy_(administrative_region)",
+          "mid": "/g/121c9r7n",
+          "salience": 3.4130960557376966e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "China",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/China",
+          "mid": "/m/0d05w3",
+          "salience": 2.9669463401660323e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Demokratischen Partei",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Democratic_Party_(United_States)",
+          "mid": "/m/0d075m",
+          "salience": 2.909048089350108e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Hilton",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hilton_Worldwide",
+          "mid": "/m/0n0_1",
+          "salience": 2.7992167815682478e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Newsoms",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Newsoms,_Virginia",
+          "mid": "/m/010p6z",
+          "salience": 2.6869933208217844e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Taipeh",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Taipei",
+          "mid": "/m/0ftkx",
+          "salience": 2.6158231776207685e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Washington Post",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/The_Washington_Post",
+          "mid": "/m/0px38",
+          "salience": 2.516766107873991e-05,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Kennedy Center",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/John_F._Kennedy_Center_for_the_Performing_Arts",
+          "mid": "/m/021jng",
+          "salience": 2.4716200641705655e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Xavier Becerra",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Xavier_Becerra",
+          "mid": "/m/024trk",
+          "salience": 2.424717604299076e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Meet the Press",
+          "type": "WORK_OF_ART",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Meet_the_Press",
+          "mid": "/m/0167_c",
+          "salience": 2.411159766779747e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Arnold Schwarzenegger",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arnold_Schwarzenegger",
+          "mid": "/m/0tc7",
+          "salience": 2.2842534235678613e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Green Cards",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Green_card",
+          "mid": "/m/01rt7d",
+          "salience": 2.1616839148919098e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Gavin Newsom",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gavin_Newsom",
+          "mid": "/m/0264nv",
+          "salience": 2.1377642042352818e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Silicon Valley",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Silicon_Valley",
+          "mid": "/m/06pw6",
+          "salience": 1.867795617727097e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "europäische",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 1.8576345610199496e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Hollywood",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hollywood,_Los_Angeles",
+          "mid": "/m/0f2wj",
+          "salience": 1.8169737813877873e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Steve Hilton",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Steve_Hilton",
+          "mid": "/m/0ksnz8",
+          "salience": 1.7600888895685785e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Ukraine",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ukraine",
+          "mid": "/m/07t21",
+          "salience": 1.7533680875203572e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Weiße Haus",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/White_House",
+          "mid": "/m/081sq",
+          "salience": 1.6951442376011983e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "D-Day",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/D-Day_(military_term)",
+          "mid": "/m/0hs4m",
+          "salience": 1.6828547813929617e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Lai Ching-te",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lai_Ching-te",
+          "mid": "/m/05z_6g6",
+          "salience": 1.6798674550955184e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Xi ⁠Jinping",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Xi_Jinping",
+          "mid": "/m/06ff60",
+          "salience": 1.6386555216740817e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "June 2",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/June_2",
+          "mid": "/m/0419n",
+          "salience": 1.5405968952109106e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Catherine Vautrin",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Catherine_Vautrin",
+          "mid": "/m/04zzwzv",
+          "salience": 1.5111285392777063e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 1.4941892914066557e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Spaniens",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spain",
+          "mid": "/m/06mkj",
+          "salience": 1.4776262105442584e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Italiens",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Italy",
+          "mid": "/m/03rjj",
+          "salience": 1.4776262105442584e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Griechenlands",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Greece",
+          "mid": "/m/035qy",
+          "salience": 1.4776262105442584e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Bulgariens",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bulgaria",
+          "mid": "/m/015qh",
+          "salience": 1.4776262105442584e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Tom Steyer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tom_Steyer",
+          "mid": "/m/0cm9pg5",
+          "salience": 1.3712357940676156e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Ronald Reagan",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ronald_Reagan",
+          "mid": "/m/06c0j",
+          "salience": 1.2417143807397224e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Twitter",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Twitter",
+          "mid": "/m/0289n8t",
+          "salience": 1.2323118426138535e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "Richard Grenell",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Richard_Grenell",
+          "mid": "/m/0405f2n",
+          "salience": 1.1669136256386992e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.8179413676261902,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "/News/Politics/Campaigns & Elections",
+          "confidence": 0.45877593755722046,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Executive Branch",
+          "confidence": 0.37388208508491516,
+          "analyzed_at": "2026-06-10T08:02:14.545863+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Sexspielzeug für Frauen: Druckwellenvibrator mit Orgasmusgarantie? Was wirklich dahintersteckt",
+      "description": "Manche Hersteller von Druckwellenvibratoren werben mit \"Orgasmusgarantie\". Kann man den aber wirklich garantieren? Eine Sexologin erklärt, was man zum Thema wissen sollte.",
+      "url": "https://www.stern.de/gesundheit/sexualitaet/druckwellenvibrator-fuer-mehr-orgasmen--das-sollten-sie-wissen-30447458.html",
+      "image_url": "https://image.stern.de/30447460/t/ar/v8/w1440/r1.7778/-/druckwellenvibrator.jpg",
+      "published_at": "2026-06-10T07:36:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.4000000059604645,
+      "sentiment_magnitude": 31.299999237060547,
+      "source_name": "stern",
+      "entities": [
+        {
+          "name": "Getty Images Kopiere",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Getty_Images",
+          "mid": "/m/01wxvs",
+          "salience": 0.002023707376793027,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        },
+        {
+          "name": "Lelo",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/LELO",
+          "mid": "/m/02vpxr3",
+          "salience": 0.00010466280218679458,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        },
+        {
+          "name": "auchÂ",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aucha",
+          "mid": "/m/05q4j7_",
+          "salience": 6.038710125721991e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Adult",
+          "confidence": 1.0,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        },
+        {
+          "name": "/Health/Reproductive Health/Sex Education & Counseling",
+          "confidence": 0.943281352519989,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        },
+        {
+          "name": "/Shopping/Consumer Resources/Product Reviews & Price Comparisons",
+          "confidence": 0.1251712292432785,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        },
+        {
+          "name": "/Health/Reproductive Health/Other",
+          "confidence": 0.10860973596572876,
+          "analyzed_at": "2026-06-10T08:00:56.247066+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Wal-Newsblog: Er hat sich das nicht ausgesucht: So wird „Timmys\" Kadaver jetzt verwertet",
+      "description": "Nachdem der mehrfach gestrandete Buckelwal vergangene Woche obduziert wurde, steht nun auch fest, was mit seinen Überresten geschieht. Die Entwicklung im stern-Newsblog.",
+      "url": "https://www.stern.de/panorama/weltgeschehen/buckelwal-endet-in-daenischer-fabrik---was-dort-nun-mit-ihm-geschieht-37250004.html",
+      "image_url": "https://image.stern.de/37517008/t/xk/v1/w1440/r1.7778/-/buckelwal-timmy-fabrik.jpg",
+      "published_at": "2026-06-09T14:39:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.30000001192092896,
+      "sentiment_magnitude": 26.600000381469727,
+      "source_name": "stern",
+      "entities": [
+        {
+          "name": "Wal",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Wale",
+          "mid": "/m/084zz",
+          "salience": 0.025120249018073082,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Timmys",
+          "type": "PERSON",
+          "wikipedia_url": "https://pt.wikipedia.org/wiki/Timmy",
+          "mid": "/g/11z43bstr7",
+          "salience": 0.023035721853375435,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Anholt",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Anholt_(Denmark)",
+          "mid": "/m/060g95",
+          "salience": 0.009831308387219906,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Timmendorfer Strand",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Timmendorfer_Strand",
+          "mid": "/m/0cn70l",
+          "salience": 0.0033179190941154957,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Poel",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Poel",
+          "mid": "/m/01wszz",
+          "salience": 0.001785144442692399,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Mecklenburg-Vorpommern",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mecklenburg-Vorpommern",
+          "mid": "/m/09hzw",
+          "salience": 0.001785144442692399,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Schleswig-Holstein",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Schleswig-Holstein",
+          "mid": "/m/06rf7",
+          "salience": 0.0012072601821273565,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Wismarer Bucht",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bay_of_Wismar",
+          "mid": "/m/043tvh3",
+          "salience": 0.0012072601821273565,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0009548713569529355,
+          "mention_count": 30,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Robert Lehmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Robert_Marc_Lehmann",
+          "mid": "/g/11gdknlq81",
+          "salience": 0.00037793253432027996,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Randers",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Randers",
+          "mid": "/m/0ghtdr",
+          "salience": 0.0003519016900099814,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Youtube",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/YouTube",
+          "mid": "/m/09jcvs",
+          "salience": 0.00019577739294618368,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Till Backhaus",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Till_Backhaus",
+          "mid": "/m/0cg1vld",
+          "salience": 0.00010496564937056974,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Deutschen Meeresmuseums Stralsund",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Meeresmuseum_Stralsund",
+          "mid": "/m/0k0rmdk",
+          "salience": 8.53412930155173e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "SPD",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Social_Democratic_Party_of_Germany",
+          "mid": "/m/0gg6s",
+          "salience": 5.645945930154994e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "Fluke",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fluke_Corporation",
+          "mid": "/m/0dzgfq",
+          "salience": 3.2996544177876785e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Pets & Animals/Wildlife",
+          "confidence": 0.7398309111595154,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "/Science/Earth Sciences/Other",
+          "confidence": 0.42923468351364136,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.41017860174179077,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Green Living & Environmental Issues",
+          "confidence": 0.14805807173252106,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.11926818639039993,
+          "analyzed_at": "2026-06-09T16:01:50.009086+00:00"
+        }
+      ]
+    },
+    {
+      "title": "+++ Iran-Krieg +++: Israels Militär stellt sich auf mehrtägige Kämpfe ein – USA vollständig eingeweiht",
+      "description": "Iran meldet Raketenangriff auf Öl-Anlage in Haifa +++ Teheran warnt USA vor Folgen israelischer Angriffe +++ Huthi-Miliz bestätigt Angriffe auf Israel +++ Der Newsblog.",
+      "url": "https://www.handelsblatt.com/politik/international/iran-krieg-israels-militaer-stellt-sich-auf-mehrtaegige-kaempfe-ein/100136895.html",
+      "image_url": "https://images.handelsblatt.com/ekBmsnWlMrQd/cover/900/506/0/0/416/0/0.5/0.5/08.06.2026-palaestinensische-gebiete-jericho-israelische-ultraorthodoxe-juedische-maenner-inspiziere.jpg",
+      "published_at": "2026-06-08T09:33:39+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 42.29999923706055,
+      "source_name": "handelsblatt",
+      "entities": [
+        {
+          "name": "US-Armee",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Army",
+          "mid": "/m/07wh1",
+          "salience": 0.014969737268984318,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "UN",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 0.007072798907756805,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Israels",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.006152747198939323,
+          "mention_count": 49,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.0038650960195809603,
+          "mention_count": 43,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Hisbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hezbollah",
+          "mid": "/m/03m7d",
+          "salience": 0.0018502339953556657,
+          "mention_count": 16,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 0.0017679216107353568,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Netanjahu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Netanyahu",
+          "mid": "/m/0fm2h",
+          "salience": 0.0013150132726877928,
+          "mention_count": 16,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Tyros",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tyre,_Lebanon",
+          "mid": "/m/07kx2",
+          "salience": 0.0012557657901197672,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Internationalen Strafgerichtshofes",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Criminal_Court",
+          "mid": "/m/03v8k",
+          "salience": 0.001094386214390397,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.0006462633609771729,
+          "mention_count": 17,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Khans",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Khan_(title)",
+          "mid": "/m/0198fr",
+          "salience": 0.00045028552995063365,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.00041522408719174564,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Libanons",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.0004086886183358729,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Danny Danon",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Danny_Danon",
+          "mid": "/m/03bz0xh",
+          "salience": 0.0003581774071790278,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Amir Saeid Iravani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amir-Saeid_Iravani",
+          "mid": "/g/11m5cth34q",
+          "salience": 0.00019900374172721058,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 0.00016516097821295261,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Pakistans.",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pakistan",
+          "mid": "/m/05sb1",
+          "salience": 0.00015197823813650757,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Axios.",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Axios_(website)",
+          "mid": "/g/11c73sdfjt",
+          "salience": 0.000122625773656182,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Joseph Aoun",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joseph_Aoun",
+          "mid": "/g/11f3f1r9l1",
+          "salience": 9.816890815272927e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Teheran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 9.816890815272927e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Jemen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yemen",
+          "mid": "/m/01z88t",
+          "salience": 8.605671609984711e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Mohammad Bagher Ghalibaf",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mohammad_Bagher_Ghalibaf",
+          "mid": "/m/0505j1",
+          "salience": 7.249830377986655e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Bab al-Mandab",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bab-el-Mandeb",
+          "mid": "/m/0gt80",
+          "salience": 6.845260941190645e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Esmail Kaani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Esmail_Qaani",
+          "mid": "/g/11hy9tmsgq",
+          "salience": 6.845260941190645e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Huthi",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houthis",
+          "mid": "/m/047vsxx",
+          "salience": 6.638311606366187e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Oman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oman",
+          "mid": "/m/05l8y",
+          "salience": 6.56092306599021e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Centcom",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Central_Command",
+          "mid": "/m/01xsrd",
+          "salience": 6.408700573956594e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Beirut",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beirut",
+          "mid": "/m/09bjv",
+          "salience": 5.8156365412287414e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Irak",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iraq",
+          "mid": "/m/0d05q4",
+          "salience": 5.1062706916127354e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "MarineTraffic",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/MarineTraffic",
+          "mid": "/g/11bwg7fpcb",
+          "salience": 5.071685882285237e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 4.3163716327399015e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Zypern",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cyprus",
+          "mid": "/m/01ppq",
+          "salience": 4.0184946556109935e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Frankreich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 3.6836223443970084e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Israel Katz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel_Katz",
+          "mid": "/m/04jcg09",
+          "salience": 3.502131221466698e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Tasnim",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tasnim_News_Agency",
+          "mid": "/m/010pczvr",
+          "salience": 3.077095971093513e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Nahen Osten",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Near_East",
+          "mid": "/m/01ffbn",
+          "salience": 2.800730726448819e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Neu-Delhi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Delhi",
+          "mid": "/m/0dlv0",
+          "salience": 2.600425068521872e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Catherine Vautrin",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Catherine_Vautrin",
+          "mid": "/m/04zzwzv",
+          "salience": 2.4681075956323184e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Vasilis Palmas.",
+          "type": "PERSON",
+          "wikipedia_url": "https://fr.wikipedia.org/wiki/Vasílis_Pálmas",
+          "mid": "/g/11fmdy5w4_",
+          "salience": 2.4681075956323184e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Unesco",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UNESCO",
+          "mid": "/m/05yg8kx",
+          "salience": 2.1627047317451797e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Akbarzadeh",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Masud_Akbarzadeh",
+          "mid": "/g/11d_8xmxfd",
+          "salience": 2.1358397134463303e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Islamischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islam",
+          "mid": "/m/0flw86",
+          "salience": 2.08628480322659e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Syrien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Syria",
+          "mid": "/m/06vbd",
+          "salience": 2.0545072402455844e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Nikosia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nicosia",
+          "mid": "/m/0fqg8",
+          "salience": 1.9279274056316353e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Emmanuel Macron",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emmanuel_Macron",
+          "mid": "/m/011ncr8c",
+          "salience": 1.9107546904706396e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Nawaf Salam",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nawaf_Salam",
+          "mid": "/m/05c0ylw",
+          "salience": 1.8138203813578002e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Irna",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islamic_Republic_News_Agency",
+          "mid": "/m/03g2w_",
+          "salience": 1.7876775018521585e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "IRGCN",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Islamic_Revolutionary_Guard_Corps_Navy",
+          "mid": "/m/0cgt16",
+          "salience": 1.6595027773291804e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 1.551520654174965e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.8748021125793457,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.5857232213020325,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.5271146893501282,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.32777243852615356,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Other",
+          "confidence": 0.21307584643363953,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Air Force",
+          "confidence": 0.11964497715234756,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.11929751932621002,
+          "analyzed_at": "2026-06-09T08:09:26.508915+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Deutschland-Liveblog: Bundesratspräsident Bovenschulte kritisiert Übermaß an Reformen",
+      "description": "Bremens Regierungschef fordert im „Spiegel“ Priorisierung +++ Unfälle mit Cannabis am Steuer sollen in Statistik erfasst werden +++ DGB-Chefin Fahimi für verpflichtende Betriebsrente +++ alle Entwicklungen im Liveblog",
+      "url": "https://www.faz.net/aktuell/politik/inland/liveblog-bundespolitik-bundesratspraesident-bovenschulte-kritisiert-uebermass-an-reformen-faz-110093143.html",
+      "image_url": "https://media0.faz.net/image/2bfb6407cd0c/w5330h2998x0y0/202605/43601.0.2063386480/andreas-bovenschulte-spd.webp",
+      "published_at": "2026-06-07T15:35:47+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 49.20000076293945,
+      "source_name": "faz",
+      "entities": [
+        {
+          "name": "Bundestag",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bundestag",
+          "mid": "/m/017xh",
+          "salience": 0.054607514292001724,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "SPD",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Social_Democratic_Party_of_Germany",
+          "mid": "/m/0gg6s",
+          "salience": 0.022783996537327766,
+          "mention_count": 15,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "CDU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Democratic_Union_of_Germany",
+          "mid": "/m/0gg68",
+          "salience": 0.009715327993035316,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "CSU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Social_Union_in_Bavaria",
+          "mid": "/m/01qf2",
+          "salience": 0.004445196129381657,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.0028309558983892202,
+          "mention_count": 31,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "deutsch",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_language",
+          "mid": "/m/04306rv",
+          "salience": 0.0017755579901859164,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "FCAS",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Future_Combat_Air_System",
+          "mid": "/m/03bgnc",
+          "salience": 0.001383705995976925,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.001294717425480485,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 0.0011101849377155304,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Spanien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spain",
+          "mid": "/m/06mkj",
+          "salience": 0.0009930555243045092,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "europäischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0008810324943624437,
+          "mention_count": 9,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Friedrich Merz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Friedrich_Merz",
+          "mid": "/m/069pky",
+          "salience": 0.0008640135638415813,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Frankreichs",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 0.000801290210802108,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Niederlanden",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Netherlands",
+          "mid": "/m/059j2",
+          "salience": 0.0007023118087090552,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Airbus",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Airbus",
+          "mid": "/g/11bc58lzpk",
+          "salience": 0.000700817967299372,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Emmanuel Macron",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Emmanuel_Macron",
+          "mid": "/m/011ncr8c",
+          "salience": 0.0005842738901264966,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "MBDA",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/MBDA",
+          "mid": "/m/01sfxz",
+          "salience": 0.0004739128053188324,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Liebherr",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Liebherr",
+          "mid": "/m/07_t2d",
+          "salience": 0.0004739128053188324,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "MTU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/MTU_Aero_Engines",
+          "mid": "/m/02rkbn",
+          "salience": 0.0004739128053188324,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Diehl",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Diehl_(Unternehmen)",
+          "mid": "/g/123601y6",
+          "salience": 0.0004739128053188324,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Financial Times",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Financial_Times",
+          "mid": "/m/0108kc",
+          "salience": 0.00042720400961115956,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Landesregierung",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Landesregierung_(Deutschland)",
+          "mid": "/g/1236shh8",
+          "salience": 0.00036655517760664225,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Amerikaner",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Black_and_white_cookie",
+          "mid": "/m/0ggw1_",
+          "salience": 0.00034477858571335673,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Höcke",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Björn_Höcke",
+          "mid": "/g/11b63dqkv3",
+          "salience": 0.0003336090303491801,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Margarita Robles",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Margarita_Robles",
+          "mid": "/g/121vfbby",
+          "salience": 0.0003234197210986167,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Korrespondent Steinmeier",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Correspondent",
+          "mid": "/g/120lql8_",
+          "salience": 0.0003055739216506481,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Frank-Walter Steinmeier",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Frank-Walter_Steinmeier",
+          "mid": "/m/089zlv",
+          "salience": 0.0003055739216506481,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 0.0002981620200444013,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Amsterdam",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amsterdam",
+          "mid": "/m/0k3p",
+          "salience": 0.00020663454779423773,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Zweiten Weltkrieg",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/World_War_II",
+          "mid": "/m/081pw",
+          "salience": 0.00018601769988890737,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Türkei",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Turkey",
+          "mid": "/m/01znc_",
+          "salience": 0.00017067139560822397,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Schweden",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sweden",
+          "mid": "/m/0d0vqn",
+          "salience": 0.00017067139560822397,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Schweizer",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Switzerland",
+          "mid": "/m/06mzp",
+          "salience": 0.0001693711819825694,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Dam",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dam_Square",
+          "mid": "/m/02zg9d",
+          "salience": 0.00016436494479421526,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Horst Köhler",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Horst_Köhler",
+          "mid": "/m/01b1gs",
+          "salience": 0.00015305541455745697,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Europäer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_people",
+          "mid": "/g/120ld8yn",
+          "salience": 0.00015033548697829247,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Nordrhein-Westfalen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/North_Rhine-Westphalia",
+          "mid": "/m/09ksp",
+          "salience": 0.0001273253292310983,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Weltwoche",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Die_Weltwoche",
+          "mid": "/m/04g5b3",
+          "salience": 0.00012694559700321406,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Femke Halsema",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Femke_Halsema",
+          "mid": "/m/04125c",
+          "salience": 0.0001233578659594059,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Elke Büdenbender",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Elke_Büdenbender",
+          "mid": "/g/11csq0rmnq",
+          "salience": 0.0001233578659594059,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Rob Jetten",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rob_Jetten",
+          "mid": "/g/11c6__vly7",
+          "salience": 0.0001233578659594059,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Hambacher Forst",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hambach_Forest",
+          "mid": "/g/12313v0_",
+          "salience": 0.0001074384999810718,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Thüringer",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Thuringia",
+          "mid": "/m/07nf6",
+          "salience": 0.00010331982048228383,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Niklas Waßmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Niklas_Waßmann",
+          "mid": "/g/11j_6g3km4",
+          "salience": 0.00010331982048228383,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Roger Köppel",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Roger_Köppel",
+          "mid": "/g/120pnch_",
+          "salience": 0.00010097714402945712,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Linksextremisten.",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Far-left_politics",
+          "mid": "/m/01g916",
+          "salience": 8.007133874343708e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Hambach",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hambach_surface_mine",
+          "mid": "/m/076vm6d",
+          "salience": 7.282922160811722e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Deutschen Landkreistags",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Deutscher_Landkreistag",
+          "mid": "/g/122v8dg0",
+          "salience": 7.247593748616055e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "RWE",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RWE",
+          "mid": "/m/03p3l_m",
+          "salience": 7.014100265223533e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Republik",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Republic",
+          "mid": "/m/06cx9",
+          "salience": 6.848626799182966e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Beatrix von Storch",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beatrix_von_Storch",
+          "mid": "/m/0127x90h",
+          "salience": 6.70627923682332e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Rheinland-Pfalz",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rhineland-Palatinate",
+          "mid": "/m/06jtd",
+          "salience": 5.447638613986783e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Lars Klingbeil",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lars_Klingbeil",
+          "mid": "/m/0c6bf23",
+          "salience": 5.134788079885766e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Rüdiger Lucassen",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rüdiger_Lucassen",
+          "mid": "/g/11f1jwwh3h",
+          "salience": 5.1215276471339166e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "SED",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Socialist_Unity_Party_of_Germany",
+          "mid": "/m/0gjqq",
+          "salience": 4.9250025767832994e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Ina Scharrenbach",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ina_Scharrenbach",
+          "mid": "/g/112yfj7jj",
+          "salience": 4.70284721814096e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Köln",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cologne",
+          "mid": "/m/01v8c",
+          "salience": 4.6569821279263124e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Aachen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aachen",
+          "mid": "/m/0qjd",
+          "salience": 4.6569821279263124e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Mona Neubaur",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mona_Neubaur",
+          "mid": "/g/1q63ykl27",
+          "salience": 3.9420770917786285e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Nationalen Sicherheitsrat",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Nationaler_Sicherheitsrat_(Deutschland)",
+          "mid": "/g/11xty1g63g",
+          "salience": 3.850163921015337e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Cem Özdemir",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cem_Özdemir",
+          "mid": "/m/054c7x",
+          "salience": 3.812561044469476e-05,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Hendrik Wüst",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hendrik_Wüst",
+          "mid": "/m/0c8g3rd",
+          "salience": 3.1213647162076086e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Stuttgart",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stuttgart",
+          "mid": "/m/0727_",
+          "salience": 2.9241547963465564e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Stuttgart 21",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stuttgart_21",
+          "mid": "/m/02vq7kp",
+          "salience": 2.9241547963465564e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Pistorius",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Boris_Pistorius",
+          "mid": "/m/0cg1xfw",
+          "salience": 2.8759546694345772e-05,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Achim Brötel",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Achim_Brötel",
+          "mid": "/m/06zrl2v",
+          "salience": 2.8031239708070643e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Industrie.",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Industrie",
+          "mid": "/g/121ymzyz",
+          "salience": 2.6794568839250132e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Alexander Dobrindt",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alexander_Dobrindt",
+          "mid": "/m/06zrvfz",
+          "salience": 2.465585021127481e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "SWR",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Südwestrundfunk",
+          "mid": "/m/04d9x4",
+          "salience": 2.450272222631611e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Baden-Württemberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Baden-Württemberg",
+          "mid": "/m/0hk4q",
+          "salience": 2.4242661311291158e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Dassault",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Dassault_Aviation",
+          "mid": "/m/0m0s_",
+          "salience": 2.3112648705136962e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Öhringen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Öhringen",
+          "mid": "/m/0b6hmc",
+          "salience": 2.2129146600491367e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Heilbronn",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Heilbronn",
+          "mid": "/m/01sl8w",
+          "salience": 2.2129146600491367e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Thorsten Frei",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Thorsten_Frei",
+          "mid": "/g/1226fz9g",
+          "salience": 2.1351761461119168e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Ina Blumenthal",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Ina_Blumenthal",
+          "mid": "/g/11t09krykt",
+          "salience": 2.130380380549468e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Holger Münch",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Holger_Münch",
+          "mid": "/g/121k385w",
+          "salience": 2.0960307665518485e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Herbert Reul",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Herbert_Reul",
+          "mid": "/m/054jmd",
+          "salience": 1.9776589397224598e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Deutschen Gewerkschaftsbunds",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Trade_Union_Confederation",
+          "mid": "/m/069_bk",
+          "salience": 1.8944569092127495e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Michaela Wiegel",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Michaela_Wiegel",
+          "mid": "/g/11b6vwb4w1",
+          "salience": 1.724608773656655e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Stefan Kornelius",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Stefan_Kornelius",
+          "mid": "/g/121lmhkt",
+          "salience": 1.6472900824737735e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Cansel Kiziltepe",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cansel_Kiziltepe",
+          "mid": "/g/1ywpnhz7y",
+          "salience": 1.634639920666814e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Belgien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Belgium",
+          "mid": "/m/0154j",
+          "salience": 1.5730976883787662e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "Kölner Stadt-Anzeiger",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kölner_Stadt-Anzeiger",
+          "mid": "/m/09gq66q",
+          "salience": 1.4253229892347008e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.8784886598587036,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Business Operations/Human Resources",
+          "confidence": 0.2770976424217224,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Other",
+          "confidence": 0.2572871446609497,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Legislative Branch",
+          "confidence": 0.2130577266216278,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        },
+        {
+          "name": "/Law & Government/Legal/Labor & Employment Law",
+          "confidence": 0.11112208664417267,
+          "analyzed_at": "2026-06-10T00:04:43.693438+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Fußball-Nationalmannschaft: Nach Karl-Schock: Sané sorgt für Sieg bei WM-Generalprobe",
+      "description": "Leroy Sané sorgt für den neunten DFB-Sieg in Serie. Der Erfolg bei der WM-Generalprobe gegen die USA ist nach dem Ausfall von Lennart Karl ein Signal. Der Bundestrainer hat aber noch eine To-Do-Liste.",
+      "url": "https://www.stern.de/news/fussball-nationalmannschaft--nach-karl-schock--san%C3%A9-sorgt-fuer-sieg-bei-wm-generalprobe-37504382.html",
+      "image_url": "https://image.stern.de/37504386/t/Bh/v3/w1440/r1.7778/-/06--fcdivkjltwv1axs2048jpeg---addad6da6f72dcc7.jpg",
+      "published_at": "2026-06-06T21:16:23+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.4000000059604645,
+      "sentiment_magnitude": 26.700000762939453,
+      "source_name": "stern",
+      "entities": [
+        {
+          "name": "USA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.01331449393182993,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "DFB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Football_Association",
+          "mid": "/m/03308v",
+          "salience": 0.003826261730864644,
+          "mention_count": 10,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Lennart Karl",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lennart_Karl",
+          "mid": "/g/11j_675ptd",
+          "salience": 0.0023922615218907595,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Julian Nagelsmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Julian_Nagelsmann",
+          "mid": "/g/11bwjbhzf8",
+          "salience": 0.002320166677236557,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Chicago",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chicago",
+          "mid": "/m/01_d4",
+          "salience": 0.001136563252657652,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "RTL",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RTL_(German_TV_channel)",
+          "mid": "/m/02_1h2",
+          "salience": 0.0006301107350736856,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Kai Havertz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kai_Havertz",
+          "mid": "/g/11c1wqbf40",
+          "salience": 0.0003232468443457037,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Joshua Kimmich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joshua_Kimmich",
+          "mid": "/m/0y4n_rn",
+          "salience": 0.0002474116045050323,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Soldier Field",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Soldier_Field",
+          "mid": "/m/02jw35",
+          "salience": 0.00021389640460256487,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "DFB-Auswahl",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.00021389640460256487,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Antonee Robinson",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Antonee_Robinson",
+          "mid": "/g/11fy2l429n",
+          "salience": 0.00016367454372812063,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Undav",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deniz_Undav",
+          "mid": "/g/11gk34yn1r",
+          "salience": 0.00015801869449205697,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Lake Michigan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lake_Michigan",
+          "mid": "/m/04kcn",
+          "salience": 0.0001383109629387036,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "USA WM",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FIFA_World_Cup",
+          "mid": "/m/030q7",
+          "salience": 0.00013191084144636989,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Miles Robinson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Miles_Robinson_(soccer)",
+          "mid": "/g/11g658yhx7",
+          "salience": 0.00011795220052590594,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Manuel Neuer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manuel_Neuer",
+          "mid": "/m/02899ft",
+          "salience": 0.00011560726125026122,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Baumann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bernd_Baumann",
+          "mid": "/g/11b75jz2bk",
+          "salience": 7.986946002347395e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Jamal Musiala",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jamal_Musiala",
+          "mid": "/g/11f5vr8pym",
+          "salience": 7.843595085432753e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Florian Wirtz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Florian_Wirtz",
+          "mid": "/g/11h01p_5qx",
+          "salience": 7.843595085432753e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Winston-Salem",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Winston-Salem,_North_Carolina",
+          "mid": "/m/0ygbf",
+          "salience": 6.892446253914386e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Houston",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houston",
+          "mid": "/m/03l2n",
+          "salience": 6.892446253914386e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Karibik",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Caribbean",
+          "mid": "/m/0261m",
+          "salience": 6.892446253914386e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Paris Saint-Germain",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Paris_Saint-Germain_FC",
+          "mid": "/m/01_1kk",
+          "salience": 6.790330371586606e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "FC Arsenal",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arsenal_F.C.",
+          "mid": "/m/0xbm",
+          "salience": 6.790330371586606e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Champions League",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UEFA_Champions_League",
+          "mid": "/m/0c1q0",
+          "salience": 6.790330371586606e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Christian Pulisic",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Christian_Pulisic",
+          "mid": "/g/11byz6rxk1",
+          "salience": 6.789852341171354e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Jonathan Tah",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jonathan_Tah",
+          "mid": "/m/0wkxv44",
+          "salience": 6.789852341171354e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Bernd Neuendorf",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bernd_Neuendorf",
+          "mid": "/g/11jgdwsy9",
+          "salience": 6.548623059643432e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Sergino Dest",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sergiño_Dest",
+          "mid": "/g/11fhr0ynxx",
+          "salience": 5.024964775657281e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Matt Freese",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Matt_Freese",
+          "mid": "/g/11h5_ty3cc",
+          "salience": 4.698002521763556e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Felix Nmecha",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Felix_Nmecha",
+          "mid": "/g/11fk8f4p23",
+          "salience": 4.698002521763556e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "American Football",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/American_football",
+          "mid": "/m/0jm_",
+          "salience": 4.5027070882497355e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Brenden Aaronson",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brenden_Aaronson",
+          "mid": "/g/11d_tcxnmr",
+          "salience": 4.2384519474580884e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "Tim Weah",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Timothy_Weah",
+          "mid": "/g/11d_8s3swc",
+          "salience": 4.157135117566213e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.9908483028411865,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.9809356927871704,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.7100750803947449,
+          "analyzed_at": "2026-06-10T00:05:58.916400+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Ranking 2026: Diese Unternehmen beraten ihre Kundschaft am besten",
+      "description": "Die Anforderungen an Unternehmen steigen. Neue Services und Erlebnisse  sind gefragt. Ein Ranking zeigt, wer die Kundinnen und Kunden überzeugt.",
+      "url": "https://www.handelsblatt.com/unternehmen/ranking-2026-diese-unternehmen-beraten-ihre-kundschaft-am-besten/100224117.html",
+      "image_url": "https://images.handelsblatt.com/UoXVVXnjbWte/cover/900/506/0/0/250/250/0.5/0.5/beratung-im-handel-neue-services-und-digitale-hilfen-sollen-stationaere-geschaefte-attraktiver-machen..jpg",
+      "published_at": "2026-06-10T05:50:34+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.5,
+      "sentiment_magnitude": 30.5,
+      "source_name": "handelsblatt",
+      "entities": [
+        {
+          "name": "Euronics",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Euronics",
+          "mid": "/m/02p_j8t",
+          "salience": 0.007724388036876917,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        },
+        {
+          "name": "Euronics Deutschland",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Euronics_Deutschland",
+          "mid": "/g/1233lkgd",
+          "salience": 0.002777193672955036,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        },
+        {
+          "name": "Claus Dethloff",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Claus_Dethloff",
+          "mid": "/m/04099h2",
+          "salience": 0.00010970977746183053,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        },
+        {
+          "name": "Point of Sale",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Point_of_sale",
+          "mid": "/m/01g70n",
+          "salience": 9.555844007991254e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 5.7594697864260525e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Retail Trade/Other",
+          "confidence": 0.41160261631011963,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.1549409031867981,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        },
+        {
+          "name": "/Shopping/Mass Merchants & Department Stores",
+          "confidence": 0.10616525262594223,
+          "analyzed_at": "2026-06-10T08:01:11.651313+00:00"
+        }
+      ]
+    },
+    {
+      "title": "WM-Tippspiel im Büro: Wann die Wette zur Steuerfrage wird",
+      "description": "WM-Tippspiel im Büro: Wann Gewinne steuerfrei bleiben – und wann Arbeitgeberpreise oder hohe Einsätze steuerlich heikel werden.",
+      "url": "https://www.focus.de/finanzen/wm-tippspiel-im-buero-wann-die-wette-zur-steuerfrage-wird_c2e4e5c9-450c-4423-a609-eddb96ecb296.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/41f0d26d-7ed5-4801-993d-8cd3f05dff28.24867f80-abff-49f5-9762-1788b037ff81.jpg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(609,400)&hash=bb2cc630d52475b42d32f80c8b0fc8ba187c7476f40a8410909de71791c390cc",
+      "published_at": "2026-06-09T11:41:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 22.899999618530273,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.006604557391256094,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "Ecuador",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ecuador",
+          "mid": "/m/02k1b",
+          "salience": 0.002136977156624198,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "Elfenbeinküste",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ivory_Coast_national_football_team",
+          "mid": "/m/040pyq",
+          "salience": 0.002136977156624198,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "Curaçao",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Curaçao",
+          "mid": "/m/0hbgh",
+          "salience": 0.002136977156624198,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.001821046113036573,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "Glücksspielstaatsvertrag Anders",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Glücksspielstaatsvertrag",
+          "mid": "/g/122pkn9_",
+          "salience": 0.00042036030208691955,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "RTL+",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RTL+",
+          "mid": "/g/11b7srw3ln",
+          "salience": 0.0002960576384793967,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.8431854248046875,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.8081008791923523,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "/Finance/Accounting & Auditing/Tax Preparation & Planning",
+          "confidence": 0.7637549042701721,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "/Games/Gambling/Sports Betting",
+          "confidence": 0.7139161229133606,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.21437253057956696,
+          "analyzed_at": "2026-06-09T16:03:12.276613+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Wer jung heiratet, kennt noch kein Leben ohne Partner",
+      "description": "Heiraten Paare in jungen Jahren, sind sie oft anpassungsfähiger und bringen weniger Altlasten mit. Gleichzeitig entwickeln sich Persönlichkeit und Lebensziele noch stark.",
+      "url": "https://www.focus.de/gesundheit/ratgeber/wer-jung-heiratet-kennt-noch-kein-leben-ohne-partner_189df773-e46f-4aa3-b6d2-1b00e61bb895.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/01ffb928-7f26-456c-b554-9c102178ae50.cc53c5e2-6625-442e-8665-3ff6ebcee843.jpg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(1276,1767)&hash=d2659f569ebc682ef01a3fcbf4713f9409d812e42d6abf759724962739043977",
+      "published_at": "2026-06-08T13:38:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.30000001192092896,
+      "sentiment_magnitude": 21.0,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "Lisa Müller",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Lisa_Müller_(Reiterin)",
+          "mid": "/g/11fps0v8mc",
+          "salience": 0.007621292024850845,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:20.887319+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.007621292024850845,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:20.887319+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/People & Society/Family & Relationships/Marriage",
+          "confidence": 0.7389286756515503,
+          "analyzed_at": "2026-06-09T08:13:20.887319+00:00"
+        },
+        {
+          "name": "/Hobbies & Leisure/Special Occasions/Weddings",
+          "confidence": 0.20054377615451813,
+          "analyzed_at": "2026-06-09T08:13:20.887319+00:00"
+        },
+        {
+          "name": "/People & Society/Family & Relationships/Romance",
+          "confidence": 0.14039181172847748,
+          "analyzed_at": "2026-06-09T08:13:20.887319+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Blinklichter für Fahrräder im Test: Systeme von Abus, Motogadget BLNK, Busch+Müller",
+      "description": "Blinker sollen das Radfahren bequemer machen. Doch fühlt man sich damit sicherer? Wir haben es getestet und sind mit gemischten Gefühlen abgebogen.",
+      "url": "https://www.spiegel.de/tests/fahrrad-zubehoer/blinklichter-fuer-fahrraeder-im-test-systeme-von-abus-motogadget-blnk-busch-mueller-a-765830e4-5817-4b4c-bf41-e0edfc2e7ef7",
+      "image_url": "https://cdn.prod.www.spiegel.de/images/b03b3587-c388-4d23-9265-c71551c39f28_w520_r2.08_fpx30.01_fpy52.98.jpg",
+      "published_at": "2026-06-07T16:28:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 49.20000076293945,
+      "source_name": "spiegel",
+      "entities": [
+        {
+          "name": "X.com",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://es.wikipedia.org/wiki/Twitter",
+          "mid": "/m/0289n8t",
+          "salience": 0.022255022078752518,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Facebook",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Facebook",
+          "mid": "/m/02y1vz",
+          "salience": 0.006970738060772419,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Busch+Müller",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Busch_&_Müller",
+          "mid": "/g/1z3t2vncr",
+          "salience": 0.005634130910038948,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0055469670332968235,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "WhatsApp",
+          "type": "CONSUMER_GOOD",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/WhatsApp",
+          "mid": "/m/0gwzvs1",
+          "salience": 0.0055469670332968235,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Karl Grünberg",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Karl_Grünberg_(writer)",
+          "mid": "/g/120mhp_k",
+          "salience": 0.0006384201697073877,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Allgemeinen Deutschen Fahrrad Club",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Allgemeiner_Deutscher_Fahrrad-Club",
+          "mid": "/m/0ch4_hl",
+          "salience": 0.0005078395479358733,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.00013717295951209962,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Markus Linden",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Markus_Linden",
+          "mid": "/g/122tph9x",
+          "salience": 7.632144843228161e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "Bosch",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bosch_(company)",
+          "mid": "/m/01hnkf",
+          "salience": 2.2706577510689385e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Autos & Vehicles/Vehicle Codes & Driving Laws/Other",
+          "confidence": 0.7277320623397827,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "/Autos & Vehicles/Bicycles & Accessories/Other",
+          "confidence": 0.4180249273777008,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "/Autos & Vehicles/Bicycles & Accessories/Bike Accessories",
+          "confidence": 0.29537233710289,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "/Sports/Individual Sports/Cycling",
+          "confidence": 0.16237543523311615,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        },
+        {
+          "name": "/Autos & Vehicles/Bicycles & Accessories/Electric Bicycles",
+          "confidence": 0.14516203105449677,
+          "analyzed_at": "2026-06-10T00:04:27.250125+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Start-up in der Baubranche baut Plattenbauten aus Holz",
+      "description": "Der Wohnungsbau in Deutschland lahmt, in den Städten steigen seit Jahren die Mietpreise. Ein junges Unternehmen verspricht, es kann schneller bauen als andere, und günstiger. Dank Serienproduktion - aus Holz. Von Andre Kartschall.",
+      "url": "https://www.tagesschau.de/wirtschaft/verbraucher/holz-hausbau-100.html",
+      "image_url": null,
+      "published_at": "2026-06-06T14:50:49+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.30000001192092896,
+      "sentiment_magnitude": 20.399999618530273,
+      "source_name": "tagesschau",
+      "entities": [
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.01263678353279829,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Bundeskabinett",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Federal_Government_of_Germany",
+          "mid": "/m/04t2sj",
+          "salience": 0.0007278044940903783,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Berlin-Charlottenburg-Wilmersdorf",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Charlottenburg-Wilmersdorf",
+          "mid": "/m/022n9w",
+          "salience": 0.0005916495574638247,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Sebastian Krüger",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Sebastian_Krüger",
+          "mid": "/m/02_gk6",
+          "salience": 0.00019019785395357758,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 0.0001455819292459637,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Baden-Württemberg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Baden-Württemberg",
+          "mid": "/m/0hk4q",
+          "salience": 0.000134899586555548,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.00011965406883973628,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Hubertz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Verena_Hubertz",
+          "mid": "/g/11gdwb77bl",
+          "salience": 0.000107908395875711,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "Das Erste",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Das_Erste",
+          "mid": "/m/02vsc6",
+          "salience": 9.189335105475038e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Business & Industrial/Construction & Maintenance/Building Materials & Supplies",
+          "confidence": 0.7430058717727661,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "/Business & Industrial/Construction & Maintenance/Other",
+          "confidence": 0.30684536695480347,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "/News/Business News/Other",
+          "confidence": 0.24427685141563416,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "/Real Estate/Property Development",
+          "confidence": 0.2007984220981598,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        },
+        {
+          "name": "/People & Society/Social Issues & Advocacy/Green Living & Environmental Issues",
+          "confidence": 0.1974303275346756,
+          "analyzed_at": "2026-06-10T08:04:00.686562+00:00"
+        }
+      ]
+    },
+    {
+      "title": "„Geduld des Bürgers ist mit Herrn Merz am Ende” – Leser sehen Infrastrukturstreit als Führungsversagen",
+      "description": "Streit um das Infrastrukturgesetz: Leser diskutieren Merz’ Führungsqualitäten, möglichen Koalitionsbruch und Kompromisse mit der SPD.",
+      "url": "https://www.focus.de/die-debatte/geduld-des-buergers-ist-mit-herrn-merz-am-ende-leser-sehen-infrastrukturstreit-als-fuehrungsversagen_e555d65b-0a49-4448-93af-fbfdc814917c.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/6ea7482a-b3ec-4ba9-8e10-32265103661f.1452c1b9-86d1-418a-98df-8b0f5ffd7ace.png?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(795,603)&hash=9babe06dcc9cabbcbcb6122ada843446382940955ac37fe2f078444f1d898a35",
+      "published_at": "2026-06-10T05:41:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 23.299999237060547,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "SPD",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Social_Democratic_Party_of_Germany",
+          "mid": "/m/0gg6s",
+          "salience": 0.019652916118502617,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "Merz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Friedrich_Merz",
+          "mid": "/m/069pky",
+          "salience": 0.014585568569600582,
+          "mention_count": 13,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0031332061626017094,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "sozialistischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Socialism",
+          "mid": "/m/06nsn",
+          "salience": 0.00018855027155950665,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 8.146680920617655e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.9025423526763916,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Executive Branch",
+          "confidence": 0.5325550436973572,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Other",
+          "confidence": 0.3213728964328766,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        },
+        {
+          "name": "/Law & Government/Government/Legislative Branch",
+          "confidence": 0.1324276626110077,
+          "analyzed_at": "2026-06-10T08:01:18.891393+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Fußball-Nationalmannschaft: Glückliche DFB-Fans und starke Zeichen mit Neuer im Tor",
+      "description": "Am Ankunftstag in Winston-Salem zeigen sich die DFB-Stars nahbar. 3.000 Zuschauer sind beim ersten Training. Wichtigste sportliche Nachricht: Manuel Neuer ist mit vollem Torwart-Einsatz dabei.",
+      "url": "https://www.stern.de/news/fussball-nationalmannschaft--glueckliche-dfb-fans-und-starke-zeichen-mit-neuer-im-tor-37514282.html",
+      "image_url": "https://image.stern.de/37514952/t/2M/v1/w1440/r1.7778/-/09--45uzxsknqiv6axs2048jpeg---1dba759573209cd7.jpg",
+      "published_at": "2026-06-09T05:38:13+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.4000000059604645,
+      "sentiment_magnitude": 21.799999237060547,
+      "source_name": "stern",
+      "entities": [
+        {
+          "name": "Manuel Neuer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manuel_Neuer",
+          "mid": "/m/02899ft",
+          "salience": 0.029592158272862434,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "DFB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Football_Association",
+          "mid": "/m/03308v",
+          "salience": 0.022748230025172234,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Winston-Salem",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Winston-Salem,_North_Carolina",
+          "mid": "/m/0ygbf",
+          "salience": 0.003757663769647479,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Julian Nagelsmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Julian_Nagelsmann",
+          "mid": "/g/11bwjbhzf8",
+          "salience": 0.0013057334581390023,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Joshua Kimmich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joshua_Kimmich",
+          "mid": "/m/0y4n_rn",
+          "salience": 0.0008096691453829408,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Lennart Karl",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lennart_Karl",
+          "mid": "/g/11j_675ptd",
+          "salience": 0.0006619180203415453,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Leipziger",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leipzig",
+          "mid": "/m/04kf4",
+          "salience": 0.0005265355575829744,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Jonas Urbig",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jonas_Urbig",
+          "mid": "/g/11h3j63fnc",
+          "salience": 0.00011429783626226708,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Houston",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houston",
+          "mid": "/m/03l2n",
+          "salience": 0.00010250067862216383,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Bernd Neuendorf",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bernd_Neuendorf",
+          "mid": "/g/11jgdwsy9",
+          "salience": 9.319707896793261e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 8.726207306608558e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Assan Ouedraogo",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Assan_Ouédraogo",
+          "mid": "/g/11p110xb4n",
+          "salience": 8.544838783564046e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Brasilien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Brazil",
+          "mid": "/m/015fr",
+          "salience": 8.241258910857141e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Bayern",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FC_Bayern_Munich",
+          "mid": "/m/0175rc",
+          "salience": 7.912377623142675e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "USA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 7.60876719141379e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Wake Forest University",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Wake_Forest_University",
+          "mid": "/m/01jq4b",
+          "salience": 7.413257844746113e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Englisch",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/English_language",
+          "mid": "/m/02h40lc",
+          "salience": 7.413257844746113e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Kai Havertz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kai_Havertz",
+          "mid": "/g/11c1wqbf40",
+          "salience": 6.94116170052439e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Deniz Undav",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deniz_Undav",
+          "mid": "/g/11gk34yn1r",
+          "salience": 6.94116170052439e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "Germany",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany",
+          "mid": "/m/0345h",
+          "salience": 6.777346425224096e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.9968501925468445,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.9864202737808228,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.4500235915184021,
+          "analyzed_at": "2026-06-09T06:14:01.671148+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Im spanischen Parlament: Papst Leo warnt vor Aufrüstung und KI: „Besorgniserregend“",
+      "description": "Der Papst hält in Spanien eine Rede, die mit Standing Ovations endet und als „historisch“ bezeichnet wird. Zu Aufrüstung und Migration spricht er Klartext - und nimmt dabei auch Europa ins Visier.",
+      "url": "https://www.stern.de/politik/ausland/im-spanischen-parlament--papst-leo-warnt-vor-aufruestung-und-ki---besorgniserregend--37510380.html",
+      "image_url": "https://image.stern.de/37510382/t/-1/v2/w1440/r1.7778/-/08--r45t3auzzav5axs2048jpeg---114dd8656bb3c0d2.jpg",
+      "published_at": "2026-06-08T19:43:03+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.4000000059604645,
+      "sentiment_magnitude": 19.0,
+      "source_name": "stern",
+      "entities": [
+        {
+          "name": "Pontifex",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Pontifex",
+          "mid": "/g/1235qjgy",
+          "salience": 0.009638726711273193,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "EUROPA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europa_Press",
+          "mid": "/m/0g57m4y",
+          "salience": 0.008100960403680801,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Spanien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Spain",
+          "mid": "/m/06mkj",
+          "salience": 0.004239329602569342,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Standing Ovations",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Standing_ovation",
+          "mid": "/m/038z44",
+          "salience": 0.002867957344278693,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Europa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0027120737358927727,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Leo XIV.",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pope_Leo_XIV",
+          "mid": "/m/09g9hkq",
+          "salience": 0.0010871366830542684,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Amerikaner",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Black_and_white_cookie",
+          "mid": "/m/0ggw1_",
+          "salience": 0.000640791142359376,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "US-Amerikaner",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Americans",
+          "mid": "/m/04q7gbh",
+          "salience": 0.0004304552567191422,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "katholischen Kirche",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Catholic_Church",
+          "mid": "/m/02vxy_",
+          "salience": 0.00019219709793105721,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Madrid",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Madrid",
+          "mid": "/m/056_y",
+          "salience": 0.00017143128206953406,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Leonor",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leonor,_Princess_of_Asturias",
+          "mid": "/m/08mmxj",
+          "salience": 0.00012164778308942914,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Felipe",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Felipe_VI",
+          "mid": "/m/0p9gy",
+          "salience": 0.00012164778308942914,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Letizia",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Queen_Letizia_of_Spain",
+          "mid": "/m/02l0nk",
+          "salience": 0.00012164778308942914,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "USA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.00011824710963992402,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Kanarischen Inseln",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canary_Islands",
+          "mid": "/m/01qtt",
+          "salience": 0.00010725874017225578,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "RTVE",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RTVE",
+          "mid": "/m/03z9d0",
+          "salience": 8.132230141200125e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "Barcelona",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Barcelona",
+          "mid": "/m/01f62",
+          "salience": 7.937351620057598e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/People & Society/Religion & Belief",
+          "confidence": 0.8416546583175659,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.46507972478866577,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.3385487198829651,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Other",
+          "confidence": 0.247474804520607,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.14999160170555115,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.13249751925468445,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        },
+        {
+          "name": "/Books & Literature/Other",
+          "confidence": 0.12145012617111206,
+          "analyzed_at": "2026-06-09T08:13:51.882496+00:00"
+        }
+      ]
+    },
+    {
+      "title": "+++ Iran-Krieg +++: Iran feuert Raketen auf Israel",
+      "description": "USA fordern vom Iran Zugang für die IAEA zu Atomanlagen +++ Pakistans Innenminister reist nach Teheran +++ Der Newsblog.",
+      "url": "https://www.handelsblatt.com/politik/international/iran-krieg-iran-feuert-raketen-auf-israel/100136895.html",
+      "image_url": "https://images.handelsblatt.com/lXNW2taJgPjr/cover/900/506/603/665/435/695/0.5/0.5/archiv-13.06.2025-israel-tel-aviv-das-israelische-luftabwehrsystem-iron-dome-feuert-am-freitag.jpg",
+      "published_at": "2026-06-07T19:53:17+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 37.70000076293945,
+      "source_name": "handelsblatt",
+      "entities": [
+        {
+          "name": "Irans",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.02321511320769787,
+          "mention_count": 46,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.010214583948254585,
+          "mention_count": 41,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Abbas Araghtschi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Abbas_Araghchi",
+          "mid": "/m/05nztn6",
+          "salience": 0.005187035538256168,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Teheran",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.003057310590520501,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Centcom",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Central_Command",
+          "mid": "/m/01xsrd",
+          "salience": 0.001541304518468678,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.0010381076717749238,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Angelika Ahrens",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Angelika_Ahrens",
+          "mid": "/g/11btzxzxyc",
+          "salience": 0.0008291769190691411,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Israels",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.000558186904527247,
+          "mention_count": 33,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Netanjahu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Netanyahu",
+          "mid": "/m/0fm2h",
+          "salience": 0.0005364756798371673,
+          "mention_count": 17,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "CBS News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/CBS_News",
+          "mid": "/m/01_8w2",
+          "salience": 0.0004153065092395991,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Hafenstadt Sirik",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Hafenstadt",
+          "mid": "/g/113qbwl3h",
+          "salience": 0.0002192063839174807,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Oman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oman",
+          "mid": "/m/05l8y",
+          "salience": 0.00017436602502129972,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Apache",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Apache",
+          "mid": "/m/01_5cg",
+          "salience": 0.00014759950863663107,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Hisbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hezbollah",
+          "mid": "/m/03m7d",
+          "salience": 0.0001326639176113531,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "i24News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/I24NEWS_(Israeli_TV_channel)",
+          "mid": "/m/0w5y6lr",
+          "salience": 0.00011279506725259125,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "libanesischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.0001127800642279908,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Truth Social",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Truth_Social",
+          "mid": "/g/11p6w0djqy",
+          "salience": 9.980938193621114e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "UN",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 8.532945503247902e-05,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Tyros",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tyre,_Lebanon",
+          "mid": "/m/07kx2",
+          "salience": 8.392547897528857e-05,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Frankreich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 8.18119733594358e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Kanada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 5.532241630135104e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Jean-Noel Barrot",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Noël_Barrot",
+          "mid": "/g/11d_805t3_",
+          "salience": 5.374545798986219e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Internationalen Strafgerichtshofes",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Criminal_Court",
+          "mid": "/m/03v8k",
+          "salience": 4.8316764150513336e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "US-Armee",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Army",
+          "mid": "/m/07wh1",
+          "salience": 4.696088581113145e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Neuseeland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Zealand",
+          "mid": "/m/0ctw_b",
+          "salience": 4.400544275995344e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Norwegen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Norway",
+          "mid": "/m/05b4w",
+          "salience": 4.400544275995344e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Australien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Australia",
+          "mid": "/m/0chghy",
+          "salience": 4.400544275995344e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Bezalel Smotrich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bezalel_Smotrich",
+          "mid": "/m/0130rl5j",
+          "salience": 4.044552406412549e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Amir Saeid Iravani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amir-Saeid_Iravani",
+          "mid": "/g/11m5cth34q",
+          "salience": 2.6568373868940398e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Joseph Aoun",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joseph_Aoun",
+          "mid": "/g/11f3f1r9l1",
+          "salience": 2.4306576960952953e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Axios.",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Axios_(website)",
+          "mid": "/g/11c73sdfjt",
+          "salience": 2.3917486032587476e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Jemen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yemen",
+          "mid": "/m/01z88t",
+          "salience": 2.358140227443073e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Pakistans.",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pakistan",
+          "mid": "/m/05sb1",
+          "salience": 2.0803972802241333e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Beirut",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beirut",
+          "mid": "/m/09bjv",
+          "salience": 2.0197301637381315e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Khans",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Khan_(title)",
+          "mid": "/m/0198fr",
+          "salience": 1.9891544070560485e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Esmail Kaani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Esmail_Qaani",
+          "mid": "/g/11hy9tmsgq",
+          "salience": 1.8757467842078768e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Bab al-Mandab",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bab-el-Mandeb",
+          "mid": "/m/0gt80",
+          "salience": 1.8757467842078768e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Huthi",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houthis",
+          "mid": "/m/047vsxx",
+          "salience": 1.8497559722163714e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "MarineTraffic",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/MarineTraffic",
+          "mid": "/g/11bwg7fpcb",
+          "salience": 1.847492421802599e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 1.845277802203782e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Israel Katz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel_Katz",
+          "mid": "/m/04jcg09",
+          "salience": 1.6855718058650382e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Irak",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iraq",
+          "mid": "/m/0d05q4",
+          "salience": 1.6702844732208177e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Tasnim",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tasnim_News_Agency",
+          "mid": "/m/010pczvr",
+          "salience": 1.5878766134846956e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Danny Danon",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Danny_Danon",
+          "mid": "/m/03bz0xh",
+          "salience": 1.5822424757061526e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Mohammad Bagher Ghalibaf",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mohammad_Bagher_Ghalibaf",
+          "mid": "/m/0505j1",
+          "salience": 1.537151911179535e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Unesco",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UNESCO",
+          "mid": "/m/05yg8kx",
+          "salience": 1.4758576071471907e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 1.4294651919044554e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Neu-Delhi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Delhi",
+          "mid": "/m/0dlv0",
+          "salience": 1.2820924894185737e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 1.1982127034571022e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.9662272930145264,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.7616360187530518,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.5663569569587708,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.3273507356643677,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Other",
+          "confidence": 0.3136169910430908,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.26013341546058655,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.1557294726371765,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Accidents & Disasters",
+          "confidence": 0.14264850318431854,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Air Force",
+          "confidence": 0.1032392606139183,
+          "analyzed_at": "2026-06-10T00:02:46.187080+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Deutsche WM-Startelf steht (fast), bei der Form bleiben Zweifel",
+      "description": "Deutschland besiegt die USA und zeigt sich bereit für die WM. Wie bereit genau? Das kann erst das Turnier zeigen. Die Startelf steht praktisch, Zweifel bleiben.",
+      "url": "https://www.focus.de/sport/fussball/deutsche-wm-startelf-steht-fast-bei-der-form-bleiben-zweifel_c730dcf1-7517-4c59-aec9-3a91e66e84ab.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/dfa61446-84f3-4d8a-979b-3686e8a8a276.c99ae85a-03fd-4537-be9e-769d657ea1b4.jpeg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(1011,518)&hash=75bd0f20cfc562042a5ded18c44c5fb15389adcc922661149fe1acdd03788d95",
+      "published_at": "2026-06-06T22:19:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 20.299999237060547,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "USA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.05466322973370552,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Leroy Sané",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leroy_Sané",
+          "mid": "/m/010fksk0",
+          "salience": 0.01104371901601553,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Kai Havertz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kai_Havertz",
+          "mid": "/g/11c1wqbf40",
+          "salience": 0.010407038033008575,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.008280651643872261,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "DFB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Football_Association",
+          "mid": "/m/03308v",
+          "salience": 0.008229123428463936,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Julian Nagelsmann",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Julian_Nagelsmann",
+          "mid": "/g/11bwjbhzf8",
+          "salience": 0.007531912066042423,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.005566753447055817,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "RTL",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RTL_(German_TV_channel)",
+          "mid": "/m/02_1h2",
+          "salience": 0.004670652560889721,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Lothar Matthäus",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lothar_Matthäus",
+          "mid": "/m/01ttk9t",
+          "salience": 0.0029375527519732714,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Antonee Robinson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Antonee_Robinson",
+          "mid": "/g/11fy2l429n",
+          "salience": 0.002568434691056609,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Finnland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Finland",
+          "mid": "/m/02vzc",
+          "salience": 0.0015843763248994946,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Chicago",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chicago",
+          "mid": "/m/01_d4",
+          "salience": 0.0015462045557796955,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Aleksandar Pavlovic",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aleksandar_Pavlović_(footballer)",
+          "mid": "/g/11hsv4dwq1",
+          "salience": 0.001250972505658865,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Manuel Neuer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manuel_Neuer",
+          "mid": "/m/02899ft",
+          "salience": 0.001250972505658865,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Jonathan Tah",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jonathan_Tah",
+          "mid": "/m/0wkxv44",
+          "salience": 0.000995102571323514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Joshua Kimmich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joshua_Kimmich",
+          "mid": "/m/0y4n_rn",
+          "salience": 0.000995102571323514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Nico Schlotterbeck",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nico_Schlotterbeck",
+          "mid": "/g/11fk8znc2n",
+          "salience": 0.000995102571323514,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Felix Nmecha",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Felix_Nmecha",
+          "mid": "/g/11fk8f4p23",
+          "salience": 0.0008479221723973751,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Jamal Musiala",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jamal_Musiala",
+          "mid": "/g/11f5vr8pym",
+          "salience": 0.0008479221723973751,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Florian Wirtz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Florian_Wirtz",
+          "mid": "/g/11h01p_5qx",
+          "salience": 0.0007208441966213286,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Nathaniel Brown",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nathaniel_Brown_(footballer)",
+          "mid": "/g/11h4_q2_ft",
+          "salience": 0.0006779106915928423,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Karl",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lennart_Karl",
+          "mid": "/g/11j_675ptd",
+          "salience": 0.0006738004740327597,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "David Raum",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/David_Raum",
+          "mid": "/g/11g6b3_7jg",
+          "salience": 0.0005352596053853631,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Goretzka",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leon_Goretzka",
+          "mid": "/m/0knvk1z",
+          "salience": 0.0005262220511212945,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Assan Ouédraogo",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Assan_Ouédraogo",
+          "mid": "/g/11p110xb4n",
+          "salience": 0.00030211915145628154,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Jamie Leweling",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jamie_Leweling",
+          "mid": "/g/11hzlfmj96",
+          "salience": 0.0002987398183904588,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Hoffenheimer",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/TSG_1899_Hoffenheim",
+          "mid": "/m/0bg4f9",
+          "salience": 0.00025517918402329087,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Mittelfeld",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Midfielder",
+          "mid": "/m/02nzb8",
+          "salience": 0.00021894500241614878,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "MagentaTV",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/MagentaTV",
+          "mid": "/g/121qm1lk",
+          "salience": 0.00021483690943568945,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Arsenal",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arsenal_F.C.",
+          "mid": "/m/0xbm",
+          "salience": 0.0002067036257358268,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Ghana",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ghana_national_football_team",
+          "mid": "/m/03_qrp",
+          "salience": 0.0002067036257358268,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Bastian Schweinsteiger",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bastian_Schweinsteiger",
+          "mid": "/m/06n0nr",
+          "salience": 0.0002054087963188067,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Deniz Undav",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deniz_Undav",
+          "mid": "/g/11gk34yn1r",
+          "salience": 0.00019811106903944165,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Nick Woltemade",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nick_Woltemade",
+          "mid": "/g/11fjwv9lkv",
+          "salience": 0.00019811106903944165,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "Houston",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houston",
+          "mid": "/m/03l2n",
+          "salience": 0.0001568697189213708,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "RTL+",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RTL+",
+          "mid": "/g/11b7srw3ln",
+          "salience": 0.0001480108330724761,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.9948249459266663,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.9617358446121216,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.682768702507019,
+          "analyzed_at": "2026-06-10T00:05:45.021659+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Rentensplitting als Pflicht stellt Spitzenverdiener besser",
+      "description": "Rentensplitting statt Witwenrente: Wer profitiert, wer verliert und ab welchem Einkommen das neue Modell mehr bringt.",
+      "url": "https://www.focus.de/finanzen/reformen/rentensplitting-als-pflicht-stellt-spitzenverdiener-besser_d2a66e88-23c4-480f-b317-6164fd31be4d.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/7a0d4697-5334-4f4f-9ca1-e829b0911df0.163711e8-fc0f-4a9a-88c5-fa90ef0eb1d2.jpg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(193,134)&hash=121b9e20fe341a1eed59a1809782a7bc59b900096d408ed6970234c93ea3ac8f",
+      "published_at": "2026-06-10T07:47:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 19.100000381469727,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.0032516284845769405,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:00:43.938499+00:00"
+        },
+        {
+          "name": "Wirtschaftsweisen",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Council_of_Economic_Experts",
+          "mid": "/m/02pzwgr",
+          "salience": 5.9326983318896964e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:00:43.938499+00:00"
+        },
+        {
+          "name": "Franz Ruland",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Franz_Ruland_(Jurist)",
+          "mid": "/g/122tbt8d",
+          "salience": 5.735403101425618e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T08:00:43.938499+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Finance/Financial Planning & Management/Retirement & Pension",
+          "confidence": 0.9675391316413879,
+          "analyzed_at": "2026-06-10T08:00:43.938499+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.1036830022931099,
+          "analyzed_at": "2026-06-10T08:00:43.938499+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Handball-Champions-League: Warum ein Deutscher deutsche Titelträume zerstören kann",
+      "description": "Vom Fan auf dem Rang zum Star auf dem Parkett: DHB-Profi Juri Knorr kämpft am Wochenende mit Aalborg Handbold um die Champions-League-Krone. Zwei Bundesliga-Clubs stehen im Weg.",
+      "url": "https://www.stern.de/gesellschaft/regional/berlin-brandenburg/handball-champions-league--warum-ein-deutscher-deutsche-titeltraeume-zerstoeren-kann-37514942.html",
+      "image_url": "https://image.stern.de/37514944/t/6k/v1/w1440/r1.7778/-/09--dupfj3lvctv5axs2048jpeg---d981e86924d5d3c6.jpg",
+      "published_at": "2026-06-09T05:36:05+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.5,
+      "sentiment_magnitude": 19.700000762939453,
+      "source_name": "stern",
+      "entities": [
+        {
+          "name": "Juri Knorr",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Juri_Knorr",
+          "mid": "/g/11h2g20z8y",
+          "salience": 0.04453003779053688,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Handball-Champions-League",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/EHF_Champions_League",
+          "mid": "/m/0d4m65",
+          "salience": 0.030223799869418144,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Aalborg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aalborg",
+          "mid": "/m/0dnntf",
+          "salience": 0.030223799869418144,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Aalborg Handbold",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aalborg_Håndbold",
+          "mid": "/m/0479pyk",
+          "salience": 0.004557628184556961,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "DHB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Handball_Association",
+          "mid": "/m/075zj05",
+          "salience": 0.004130819346755743,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Champions-League",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UEFA_Champions_League",
+          "mid": "/m/0c1q0",
+          "salience": 0.003808524925261736,
+          "mention_count": 4,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Magdeburg",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Magdeburg",
+          "mid": "/m/0577d",
+          "salience": 0.0010426108492538333,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Berlin",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Berlin",
+          "mid": "/m/0156q",
+          "salience": 0.0007795030251145363,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "SC Magdeburg",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/SC_Magdeburg",
+          "mid": "/m/084n5h",
+          "salience": 0.000649318506475538,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Europas",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Europe",
+          "mid": "/m/02j9z",
+          "salience": 0.0005271419649943709,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "FC Barcelona",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/FC_Barcelona",
+          "mid": "/m/0hvgt",
+          "salience": 0.0005271419649943709,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Mathias Gidsel",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mathias_Gidsel",
+          "mid": "/g/11n5x9f16l",
+          "salience": 0.00048668941599316895,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Gregor Peter Schmitz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Gregor_Peter_Schmitz",
+          "mid": "/g/11dd_vzgmq",
+          "salience": 0.000312583870254457,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.0002673805574886501,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Final Four",
+          "type": "EVENT",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Final_four",
+          "mid": "/m/05fcbjt",
+          "salience": 0.00022796964913140982,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Rhein-Neckar",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Rhein-Neckar-Kreis",
+          "mid": "/m/01c5z2",
+          "salience": 0.00020014244364574552,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Nicolej Krickau",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nicolej_Krickau",
+          "mid": "/g/11pkcyfw05",
+          "salience": 0.00018189274123869836,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Alfred Gislason",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Alfreð_Gíslason",
+          "mid": "/m/0280gxs",
+          "salience": 0.00017541188572067767,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "Kopenhagen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Copenhagen",
+          "mid": "/m/01lfy",
+          "salience": 0.0001445240923203528,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Handball",
+          "confidence": 0.9711965918540955,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.9643299579620361,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.2643613815307617,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.15796954929828644,
+          "analyzed_at": "2026-06-09T06:15:02.488991+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Neue gegenseitige Angriffe zwischen Iran und Israel",
+      "description": "Nach einem iranischen Raketenangriff reagiert Israel mit Luftschlägen auf Ziele im Iran. Trotz diplomatischer Bemühungen von US-Präsident Donald Trump eskaliert der Konflikt weiter.",
+      "url": "https://www.dw.com/de/neue-gegenseitige-angriffe-zwischen-iran-und-israel/a-77453795",
+      "image_url": null,
+      "published_at": "2026-06-08T08:41:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.10000000149011612,
+      "sentiment_magnitude": 15.800000190734863,
+      "source_name": "dw",
+      "entities": [
+        {
+          "name": "Iran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.04156382754445076,
+          "mention_count": 33,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "israelischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.029793519526720047,
+          "mention_count": 24,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Benjamin Netanjahu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Netanyahu",
+          "mid": "/m/0fm2h",
+          "salience": 0.01873214915394783,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Teheran",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.010831059888005257,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Ronen Zvulun",
+          "type": "PERSON",
+          "wikipedia_url": "https://he.wikipedia.org/wiki/רונן_זבולון",
+          "mid": "/g/11vzfy_k69",
+          "salience": 0.009256361052393913,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Jerusalem",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jerusalem",
+          "mid": "/m/0430_",
+          "salience": 0.009256361052393913,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Iron Dome",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iron_Dome",
+          "mid": "/m/04f1_lb",
+          "salience": 0.009256361052393913,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.006682086735963821,
+          "mention_count": 12,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.005431175697594881,
+          "mention_count": 16,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "ynet",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ynet",
+          "mid": "/m/08p7vd",
+          "salience": 0.002686396474018693,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Luftwaffe",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Luftwaffe",
+          "mid": "/m/04jtj",
+          "salience": 0.002234150655567646,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Libanons",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.0016729847993701696,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Massud Peseschkian",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Masoud_Pezeshkian",
+          "mid": "/m/07vchh",
+          "salience": 0.0010357924038544297,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Nahost",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Near_East",
+          "mid": "/m/01ffbn",
+          "salience": 0.00048467409214936197,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Mahschahr",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bandar-e_Mahshahr",
+          "mid": "/m/060_by",
+          "salience": 0.00041559242527000606,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Fars",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fars_News_Agency",
+          "mid": "/m/0cz72k",
+          "salience": 0.00038795178988948464,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Haifa",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Haifa",
+          "mid": "/m/0fg1g",
+          "salience": 0.0003637621412053704,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Isfahan",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Isfahan",
+          "mid": "/m/01gk3x",
+          "salience": 0.00032343686325475574,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Täbris",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tabriz",
+          "mid": "/m/028q7m",
+          "salience": 0.00032343686325475574,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Mehrabad",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mehrabad_International_Airport",
+          "mid": "/m/06fzzb",
+          "salience": 0.0001525535190012306,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "JavaScript",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/JavaScript",
+          "mid": "/m/02p97",
+          "salience": 0.00015205600357148796,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Kermanschah",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kermanshah",
+          "mid": "/m/055d0y",
+          "salience": 0.00014593626838177443,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Maschhad",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mashhad",
+          "mid": "/m/024hh1",
+          "salience": 0.0001342881005257368,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Kallas",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kaja_Kallas",
+          "mid": "/m/012tvcbp",
+          "salience": 0.00010226941958535463,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 9.374715591548011e-05,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Straße von Hormus",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Strait_of_Hormuz",
+          "mid": "/m/075t9",
+          "salience": 7.968756108311936e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Financial Times",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Financial_Times",
+          "mid": "/m/0108kc",
+          "salience": 6.946433131815866e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Hisbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hezbollah",
+          "mid": "/m/03m7d",
+          "salience": 6.408157787518576e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Truth Social",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Truth_Social",
+          "mid": "/g/11p6w0djqy",
+          "salience": 6.209401180967689e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Mike Huckabee",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mike_Huckabee",
+          "mid": "/m/01rxqd",
+          "salience": 6.0182184824952856e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Maxar Technologies",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maxar_Technologies",
+          "mid": "/g/11fzffq6pp",
+          "salience": 5.372376836021431e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Ramat David",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Ramat_David_Airbase",
+          "mid": "/g/11cm_86sbq",
+          "salience": 5.231098475633189e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Nazareth",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nazareth",
+          "mid": "/m/05fz3",
+          "salience": 5.231098475633189e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Iswestija",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Izvestia",
+          "mid": "/m/032kz9",
+          "salience": 5.202222382649779e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Russland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Russia",
+          "mid": "/m/06bnz",
+          "salience": 5.202222382649779e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Oman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oman",
+          "mid": "/m/05l8y",
+          "salience": 5.121127833263017e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Beirut",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beirut",
+          "mid": "/m/09bjv",
+          "salience": 5.097281245980412e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Nikosia",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nicosia",
+          "mid": "/m/0fqg8",
+          "salience": 4.9663034587865695e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Zypern",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Cyprus",
+          "mid": "/m/01ppq",
+          "salience": 4.9663034587865695e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Virginia Mayo",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Virginia_Mayo",
+          "mid": "/m/03y66q",
+          "salience": 4.820576941710897e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "NBC",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/NBC",
+          "mid": "/m/05gnf",
+          "salience": 4.5793349272571504e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Fox News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Fox_News",
+          "mid": "/m/02z_b",
+          "salience": 4.501900548348203e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "Europäer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_people",
+          "mid": "/g/120ld8yn",
+          "salience": 2.4645012672408484e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.9730478525161743,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.5910666584968567,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.4990309178829193,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.3553530275821686,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Other",
+          "confidence": 0.18241000175476074,
+          "analyzed_at": "2026-06-09T08:08:52.660679+00:00"
+        }
+      ]
+    },
+    {
+      "title": "+++ Iran-Krieg +++: Erstmals seit April: Iran feuert Raketen auf Israel",
+      "description": "Iran: Könnten Israel noch vernichtendere Schläge zufügen +++ USA fordern vom Iran Zugang für die IAEA zu Atomanlagen +++ Pakistans Innenminister reist nach Teheran +++ Der Newsblog.",
+      "url": "https://www.handelsblatt.com/politik/international/iran-krieg-erstmals-seit-april-iran-feuert-raketen-auf-israel/100136895.html",
+      "image_url": "https://images.handelsblatt.com/SgDA1Ww5cxoC/cover/900/506/0/0/209/208/0.5/0.5/archivbild-ueber-israel-sind-wieder-raketen-abgewehrt-worden..jpg",
+      "published_at": "2026-06-07T20:18:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "business",
+      "sentiment_label": "neutral",
+      "sentiment_score": 0.20000000298023224,
+      "sentiment_magnitude": 37.70000076293945,
+      "source_name": "handelsblatt",
+      "entities": [
+        {
+          "name": "Irans",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iran",
+          "mid": "/m/03shp",
+          "salience": 0.02321511320769787,
+          "mention_count": 46,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "US",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.010214583948254585,
+          "mention_count": 41,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Abbas Araghtschi",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Abbas_Araghchi",
+          "mid": "/m/05nztn6",
+          "salience": 0.005187035538256168,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Teheran",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tehran",
+          "mid": "/m/0ftlx",
+          "salience": 0.003057310590520501,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Centcom",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Central_Command",
+          "mid": "/m/01xsrd",
+          "salience": 0.001541304518468678,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Donald Trump",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+          "mid": "/m/0cqt90",
+          "salience": 0.0010381076717749238,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Angelika Ahrens",
+          "type": "PERSON",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Angelika_Ahrens",
+          "mid": "/g/11btzxzxyc",
+          "salience": 0.0008291769190691411,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Israels",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel",
+          "mid": "/m/03spz",
+          "salience": 0.000558186904527247,
+          "mention_count": 33,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Netanjahu",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Benjamin_Netanyahu",
+          "mid": "/m/0fm2h",
+          "salience": 0.0005364756798371673,
+          "mention_count": 17,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "CBS News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/CBS_News",
+          "mid": "/m/01_8w2",
+          "salience": 0.0004153065092395991,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Hafenstadt Sirik",
+          "type": "LOCATION",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/Hafenstadt",
+          "mid": "/g/113qbwl3h",
+          "salience": 0.0002192063839174807,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Oman",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Oman",
+          "mid": "/m/05l8y",
+          "salience": 0.00017436602502129972,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Apache",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Apache",
+          "mid": "/m/01_5cg",
+          "salience": 0.00014759950863663107,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Hisbollah",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Hezbollah",
+          "mid": "/m/03m7d",
+          "salience": 0.0001326639176113531,
+          "mention_count": 11,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "i24News",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/I24NEWS_(Israeli_TV_channel)",
+          "mid": "/m/0w5y6lr",
+          "salience": 0.00011279506725259125,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "libanesischen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lebanon",
+          "mid": "/m/04hqz",
+          "salience": 0.0001127800642279908,
+          "mention_count": 6,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Truth Social",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Truth_Social",
+          "mid": "/g/11p6w0djqy",
+          "salience": 9.980938193621114e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "UN",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_Nations",
+          "mid": "/m/07t65",
+          "salience": 8.532945503247902e-05,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Tyros",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tyre,_Lebanon",
+          "mid": "/m/07kx2",
+          "salience": 8.392547897528857e-05,
+          "mention_count": 7,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Frankreich",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/France",
+          "mid": "/m/0f8l9c",
+          "salience": 8.18119733594358e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Kanada",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Canada",
+          "mid": "/m/0d060g",
+          "salience": 5.532241630135104e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Jean-Noel Barrot",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Noël_Barrot",
+          "mid": "/g/11d_805t3_",
+          "salience": 5.374545798986219e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Internationalen Strafgerichtshofes",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/International_Criminal_Court",
+          "mid": "/m/03v8k",
+          "salience": 4.8316764150513336e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "US-Armee",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States_Army",
+          "mid": "/m/07wh1",
+          "salience": 4.696088581113145e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Neuseeland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Zealand",
+          "mid": "/m/0ctw_b",
+          "salience": 4.400544275995344e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Norwegen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Norway",
+          "mid": "/m/05b4w",
+          "salience": 4.400544275995344e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Australien",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Australia",
+          "mid": "/m/0chghy",
+          "salience": 4.400544275995344e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Bezalel Smotrich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bezalel_Smotrich",
+          "mid": "/m/0130rl5j",
+          "salience": 4.044552406412549e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Amir Saeid Iravani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Amir-Saeid_Iravani",
+          "mid": "/g/11m5cth34q",
+          "salience": 2.6568373868940398e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Joseph Aoun",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joseph_Aoun",
+          "mid": "/g/11f3f1r9l1",
+          "salience": 2.4306576960952953e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Axios.",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Axios_(website)",
+          "mid": "/g/11c73sdfjt",
+          "salience": 2.3917486032587476e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Jemen",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Yemen",
+          "mid": "/m/01z88t",
+          "salience": 2.358140227443073e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Pakistans.",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Pakistan",
+          "mid": "/m/05sb1",
+          "salience": 2.0803972802241333e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Beirut",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Beirut",
+          "mid": "/m/09bjv",
+          "salience": 2.0197301637381315e-05,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Khans",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Khan_(title)",
+          "mid": "/m/0198fr",
+          "salience": 1.9891544070560485e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Esmail Kaani",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Esmail_Qaani",
+          "mid": "/g/11hy9tmsgq",
+          "salience": 1.8757467842078768e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Bab al-Mandab",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Bab-el-Mandeb",
+          "mid": "/m/0gt80",
+          "salience": 1.8757467842078768e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Huthi",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Houthis",
+          "mid": "/m/047vsxx",
+          "salience": 1.8497559722163714e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "MarineTraffic",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/MarineTraffic",
+          "mid": "/g/11bwg7fpcb",
+          "salience": 1.847492421802599e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "EU",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/European_Union",
+          "mid": "/m/0_6t_z8",
+          "salience": 1.845277802203782e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Israel Katz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Israel_Katz",
+          "mid": "/m/04jcg09",
+          "salience": 1.6855718058650382e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Irak",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Iraq",
+          "mid": "/m/0d05q4",
+          "salience": 1.6702844732208177e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Tasnim",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Tasnim_News_Agency",
+          "mid": "/m/010pczvr",
+          "salience": 1.5878766134846956e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Danny Danon",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Danny_Danon",
+          "mid": "/m/03bz0xh",
+          "salience": 1.5822424757061526e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Mohammad Bagher Ghalibaf",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Mohammad_Bagher_Ghalibaf",
+          "mid": "/m/0505j1",
+          "salience": 1.537151911179535e-05,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Unesco",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/UNESCO",
+          "mid": "/m/05yg8kx",
+          "salience": 1.4758576071471907e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "New York",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_York_City",
+          "mid": "/m/02_286",
+          "salience": 1.4294651919044554e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Neu-Delhi",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/New_Delhi",
+          "mid": "/m/0dlv0",
+          "salience": 1.2820924894185737e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 1.1982127034571022e-05,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sensitive Subjects/War & Conflict",
+          "confidence": 0.9662272930145264,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/News/World News",
+          "confidence": 0.7616360187530518,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/News/Politics/Other",
+          "confidence": 0.5663569569587708,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/People & Society/Social Sciences/Political Science",
+          "confidence": 0.3273507356643677,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Other",
+          "confidence": 0.3136169910430908,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/News/Other",
+          "confidence": 0.26013341546058655,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Death & Tragedy",
+          "confidence": 0.1557294726371765,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/Sensitive Subjects/Accidents & Disasters",
+          "confidence": 0.14264850318431854,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        },
+        {
+          "name": "/Law & Government/Military/Air Force",
+          "confidence": 0.1032392606139183,
+          "analyzed_at": "2026-06-10T00:02:26.246187+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Deutsche Noten gegen USA: Vier Deutsche mit Note 2, Musiala und Wirtz schwach",
+      "description": "Gegen die USA treffen Kai Havertz und Leroy Sané für Deutschland. Oliver Baumann überzeugt, Jamal Musiala und Florian Wirtz enttäuschen. Die Einzelkritik.",
+      "url": "https://www.focus.de/sport/fussball/deutsche-noten-gegen-usa-vier-deutsche-mit-note-2-musiala-und-wirtz-schwach_d357f823-0254-4c48-a2a1-26d095bd66bb.html",
+      "image_url": "https://quadro.burda-forward.de/ctf/59db56cc-dbf1-486c-9a0a-cf3f16db493a.fbc97e56-87c0-4d5b-bffa-fdc205b32913.jpeg?im=RegionOfInterestCrop=(1200,675),regionOfInterest=(965,729)&hash=1395f606a246ac2181d6bf06a85c87391c38671e8c6de1906190ace36e873024",
+      "published_at": "2026-06-06T21:03:00+00:00",
+      "language": "de",
+      "country": "de",
+      "category": "general",
+      "sentiment_label": "positive",
+      "sentiment_score": 0.30000001192092896,
+      "sentiment_magnitude": 19.299999237060547,
+      "source_name": "focus",
+      "entities": [
+        {
+          "name": "Leroy Sané",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leroy_Sané",
+          "mid": "/m/010fksk0",
+          "salience": 0.06736429780721664,
+          "mention_count": 8,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Kai Havertz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Kai_Havertz",
+          "mid": "/g/11c1wqbf40",
+          "salience": 0.0527498759329319,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "USA",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/United_States",
+          "mid": "/m/09c7w0",
+          "salience": 0.04278871417045593,
+          "mention_count": 5,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Deutschland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Germany_national_football_team",
+          "mid": "/m/01l3wr",
+          "salience": 0.03641199693083763,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Jamal Musiala",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jamal_Musiala",
+          "mid": "/g/11f5vr8pym",
+          "salience": 0.020614398643374443,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Florian Wirtz",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Florian_Wirtz",
+          "mid": "/g/11h01p_5qx",
+          "salience": 0.01221530232578516,
+          "mention_count": 3,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Antonee Robinson",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Antonee_Robinson",
+          "mid": "/g/11fy2l429n",
+          "salience": 0.007343631703406572,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "DFB",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/German_Football_Association",
+          "mid": "/m/03308v",
+          "salience": 0.007297932635992765,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Google",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Google",
+          "mid": "/m/045c7b",
+          "salience": 0.005842752289026976,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Manuel Neuer",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Manuel_Neuer",
+          "mid": "/m/02899ft",
+          "salience": 0.005842752289026976,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Joshua Kimmich",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Joshua_Kimmich",
+          "mid": "/m/0y4n_rn",
+          "salience": 0.0036570215597748756,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Tah",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jonathan_Tah",
+          "mid": "/m/0wkxv44",
+          "salience": 0.0026989553589373827,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Felix Nmecha",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Felix_Nmecha",
+          "mid": "/g/11fk8f4p23",
+          "salience": 0.0020865066908299923,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Balogun",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Folarin_Balogun",
+          "mid": "/g/11fy4prf88",
+          "salience": 0.0015218184562399983,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Nico Schlotterbeck",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nico_Schlotterbeck",
+          "mid": "/g/11fk8znc2n",
+          "salience": 0.001405046321451664,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Mittelfeld",
+          "type": "OTHER",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Midfielder",
+          "mid": "/m/02nzb8",
+          "salience": 0.0008690741960890591,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Dortmunder",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Borussia_Dortmund",
+          "mid": "/m/01w_d6",
+          "salience": 0.0006970649701543152,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Nathaniel Brown",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Nathaniel_Brown_(footballer)",
+          "mid": "/g/11h4_q2_ft",
+          "salience": 0.0006581695633940399,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Stuttgarter",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Stuttgart",
+          "mid": "/m/0727_",
+          "salience": 0.0003231111913919449,
+          "mention_count": 2,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "David Raum",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/David_Raum",
+          "mid": "/g/11g6b3_7jg",
+          "salience": 0.00030776101630181074,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Schach",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Chess",
+          "mid": "/m/01lb5",
+          "salience": 0.00029290938982740045,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "MagentaTV",
+          "type": "OTHER",
+          "wikipedia_url": "https://de.wikipedia.org/wiki/MagentaTV",
+          "mid": "/g/121qm1lk",
+          "salience": 0.00029255106346681714,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Aleksandar Pavlovic",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Aleksandar_Pavlović_(footballer)",
+          "mid": "/g/11hsv4dwq1",
+          "salience": 0.0002833666803780943,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Lennart Karl",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Lennart_Karl",
+          "mid": "/g/11j_675ptd",
+          "salience": 0.0002598069841042161,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Finnland",
+          "type": "LOCATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Finland",
+          "mid": "/m/02vzc",
+          "salience": 0.00025701624690555036,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Leipziger",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leipzig",
+          "mid": "/m/04kf4",
+          "salience": 0.0002448059676680714,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Jamie Leweling",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Jamie_Leweling",
+          "mid": "/g/11hzlfmj96",
+          "salience": 0.00023370444250758737,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Arsenal",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Arsenal_F.C.",
+          "mid": "/m/0xbm",
+          "salience": 0.00023141791461966932,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Waldemar Anton",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Waldemar_Anton",
+          "mid": "/g/11clyfm0mg",
+          "salience": 0.00021926638146396726,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Maximilian Beier",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Maximilian_Beier",
+          "mid": "/g/11gmx6zd_5",
+          "salience": 0.0002188216894865036,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Leon Goretzka",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Leon_Goretzka",
+          "mid": "/m/0knvk1z",
+          "salience": 0.0002188216894865036,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Angelo Stiller",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Angelo_Stiller",
+          "mid": "/g/11h5mkdv7t",
+          "salience": 0.0002188216894865036,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "Deniz Undav",
+          "type": "PERSON",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/Deniz_Undav",
+          "mid": "/g/11gk34yn1r",
+          "salience": 0.0002083285799017176,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "RTL+",
+          "type": "ORGANIZATION",
+          "wikipedia_url": "https://en.wikipedia.org/wiki/RTL+",
+          "mid": "/g/11b7srw3ln",
+          "salience": 0.00020169852359686047,
+          "mention_count": 1,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        }
+      ],
+      "categories": [
+        {
+          "name": "/Sports/Team Sports/Soccer",
+          "confidence": 0.9959020018577576,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "/News/Sports News",
+          "confidence": 0.9598404765129089,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        },
+        {
+          "name": "/Sports/International Sports Competitions/Other",
+          "confidence": 0.36334550380706787,
+          "analyzed_at": "2026-06-10T00:06:05.334765+00:00"
+        }
+      ]
     }
   ]
 }

--- a/app/seeds/seed_db.py
+++ b/app/seeds/seed_db.py
@@ -38,7 +38,10 @@ from typing import Any, Optional
 from sqlalchemy.orm import Session
 
 from app.models.article import Article
+from app.models.article_category import ArticleCategory
+from app.models.article_entity import ArticleEntity
 from app.models.crawl_job import CrawlJob, CrawlStatus
+from app.models.entity import Entity
 from app.models.source import Source
 
 DEFAULT_SEED_PATH = Path(__file__).resolve().parent / "seed_data.json"
@@ -63,6 +66,25 @@ def _parse_published_at(value: Any) -> datetime:
     if dt.tzinfo is not None:
         dt = dt.replace(tzinfo=None)
     return dt
+
+
+def _parse_analyzed_at(
+    value: Any, *, offset: timedelta, fallback: datetime
+) -> datetime:
+    """Resolve an entity/category ``analyzed_at`` into a re-anchored datetime.
+
+    Entity/category rows carry ``analyzed_at`` (when our pipeline extracted them).
+    It must be shifted by the **same recency ``offset``** as the article's
+    ``published_at`` — the momentum / trending-names windows key off
+    ``analyzed_at``, so if it isn't shifted forward the seeded mentions fall
+    outside the recent window and the charts read empty.
+
+    When ``analyzed_at`` is missing we use ``fallback`` (the already-shifted
+    ``published_at``) so the row still lands inside the re-anchored window.
+    """
+    if value is None:
+        return fallback
+    return _parse_published_at(value) + offset
 
 
 def _compute_recency_offset(articles: list[dict[str, Any]]) -> timedelta:
@@ -98,19 +120,49 @@ def _reset_seed_rows(db: Session, data: dict[str, Any]) -> None:
     """Delete seed-derived articles and sources before re-inserting.
 
     Works on any backend: we use ORM-level deletes by URL/name so we don't
-    rely on Postgres-specific syntax. Bookmark cascade is handled by the
-    FK ON DELETE CASCADE on ``articles -> bookmarks`` and
-    ``sources -> articles``.
+    rely on Postgres-specific syntax. Child rows (``article_entities``,
+    ``article_categories``, ``bookmarks``) are removed explicitly by article id
+    first, since ``synchronize_session=False`` bulk deletes don't fire the ORM
+    cascade and SQLite doesn't enforce ``ON DELETE CASCADE`` by default.
+
+    ``entities`` are globally deduplicated (no article FK), so deleting articles
+    leaves them behind; we sweep entities that no longer have any mention.
     """
     seed_urls = [a["url"] for a in data["articles"]]
     seed_source_names = [s["name"] for s in data["sources"]]
 
     if seed_urls:
+        article_ids = [
+            row[0]
+            for row in db.query(Article.id).filter(Article.url.in_(seed_urls)).all()
+        ]
+        if article_ids:
+            db.query(ArticleEntity).filter(
+                ArticleEntity.article_id.in_(article_ids)
+            ).delete(synchronize_session=False)
+            db.query(ArticleCategory).filter(
+                ArticleCategory.article_id.in_(article_ids)
+            ).delete(synchronize_session=False)
         db.query(Article).filter(Article.url.in_(seed_urls)).delete(
             synchronize_session=False
         )
+
     if seed_source_names:
         db.query(Source).filter(Source.name.in_(seed_source_names)).delete(
+            synchronize_session=False
+        )
+
+    # Sweep now-orphaned entities (no remaining mentions).
+    db.flush()
+    orphan_ids = [
+        row[0]
+        for row in db.query(Entity.id)
+        .outerjoin(ArticleEntity, ArticleEntity.entity_id == Entity.id)
+        .filter(ArticleEntity.id.is_(None))
+        .all()
+    ]
+    if orphan_ids:
+        db.query(Entity).filter(Entity.id.in_(orphan_ids)).delete(
             synchronize_session=False
         )
 
@@ -133,11 +185,21 @@ def seed_database(
             "sources_skipped": int,
             "articles_inserted": int,
             "articles_skipped": int,
+            "entities_inserted": int,
+            "entity_links_inserted": int,
+            "categories_inserted": int,
             "crawl_jobs_inserted": int,
         }
 
     On ``dry_run=True``, no INSERT/DELETE is committed; counts reflect what
     *would* have been inserted.
+
+    Each article carries its enrichment inline: ``sentiment_magnitude`` plus a
+    list of ``entities`` (deduplicated into the shared ``entities`` table, linked
+    via ``article_entities``) and ``categories`` (``article_categories``). Entity
+    and category ``analyzed_at`` timestamps are shifted by the same recency
+    offset as ``published_at`` so the trending-names / momentum windows — which
+    key off ``analyzed_at`` — stay valid for the re-anchored seed.
 
     When ``queue_crawl_jobs=True``, a PENDING ``crawl_jobs`` row is created
     for every seeded article that does not already have one. The worker
@@ -183,7 +245,13 @@ def seed_database(
 
     articles_inserted = 0
     articles_skipped = 0
+    entities_inserted = 0
+    entity_links_inserted = 0
+    categories_inserted = 0
     seen_urls_in_batch: set[str] = set()
+    # Cache for the globally-deduplicated entities table: (name, type) -> id.
+    # Entities are shared across articles, so we upsert each (name, type) once.
+    entity_id_by_key: dict[tuple[str, str], int] = {}
 
     for art in data["articles"]:
         url = art["url"]
@@ -211,23 +279,82 @@ def seed_database(
                 source_id = existing_src.id
             source_id_by_name[source_name] = source_id
 
-        db.add(
-            Article(
-                title=art["title"],
-                description=art["description"],
-                url=url,
-                image_url=art["image_url"],
-                published_at=_parse_published_at(art["published_at"]) + date_offset,
-                language=art["language"],
-                country=art["country"],
-                category=art["category"],
-                sentiment_label=art["sentiment_label"],
-                sentiment_score=art["sentiment_score"],
-                source_id=source_id,
-            )
+        published_at = _parse_published_at(art["published_at"]) + date_offset
+        article = Article(
+            title=art["title"],
+            description=art["description"],
+            url=url,
+            image_url=art["image_url"],
+            published_at=published_at,
+            language=art["language"],
+            country=art["country"],
+            category=art["category"],
+            sentiment_label=art["sentiment_label"],
+            sentiment_score=art["sentiment_score"],
+            sentiment_magnitude=art.get("sentiment_magnitude"),
+            source_id=source_id,
         )
+        db.add(article)
+        db.flush()  # populate article.id for the entity/category links
         seen_urls_in_batch.add(url)
         articles_inserted += 1
+
+        # Relational enrichment: entities (deduped) + per-article links + categories.
+        # analyzed_at is shifted by the SAME offset as published_at so the
+        # entity-momentum / trending-names recent window stays valid for the seed.
+        for ent in art.get("entities", []):
+            key = (ent["name"], ent["type"])
+            entity_id = entity_id_by_key.get(key)
+            if entity_id is None:
+                existing_entity = (
+                    db.query(Entity)
+                    .filter_by(name=ent["name"], type=ent["type"])
+                    .first()
+                )
+                if existing_entity is not None:
+                    entity_id = existing_entity.id
+                else:
+                    new_entity = Entity(
+                        name=ent["name"],
+                        type=ent["type"],
+                        wikipedia_url=ent.get("wikipedia_url"),
+                        mid=ent.get("mid"),
+                    )
+                    db.add(new_entity)
+                    db.flush()
+                    entity_id = new_entity.id
+                    entities_inserted += 1
+                entity_id_by_key[key] = entity_id
+
+            db.add(
+                ArticleEntity(
+                    article_id=article.id,
+                    entity_id=entity_id,
+                    salience=ent.get("salience", 0.0),
+                    mention_count=ent.get("mention_count", 1),
+                    analyzed_at=_parse_analyzed_at(
+                        ent.get("analyzed_at"),
+                        offset=date_offset,
+                        fallback=published_at,
+                    ),
+                )
+            )
+            entity_links_inserted += 1
+
+        for cat in art.get("categories", []):
+            db.add(
+                ArticleCategory(
+                    article_id=article.id,
+                    name=cat["name"],
+                    confidence=cat.get("confidence", 0.0),
+                    analyzed_at=_parse_analyzed_at(
+                        cat.get("analyzed_at"),
+                        offset=date_offset,
+                        fallback=published_at,
+                    ),
+                )
+            )
+            categories_inserted += 1
 
     crawl_jobs_inserted = 0
     if queue_crawl_jobs:
@@ -254,6 +381,9 @@ def seed_database(
         "sources_skipped": sources_skipped,
         "articles_inserted": articles_inserted,
         "articles_skipped": articles_skipped,
+        "entities_inserted": entities_inserted,
+        "entity_links_inserted": entity_links_inserted,
+        "categories_inserted": categories_inserted,
         "crawl_jobs_inserted": crawl_jobs_inserted,
     }
 
@@ -338,6 +468,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         f"{prefix}Seeded {summary['sources_inserted']} new sources, "
         f"{summary['articles_inserted']} new articles. "
         f"{summary['articles_skipped']} articles already present (skipped)."
+    )
+    print(
+        f"{prefix}Enriched with {summary['entities_inserted']} new entities, "
+        f"{summary['entity_links_inserted']} entity mentions, "
+        f"{summary['categories_inserted']} category labels."
     )
     if args.queue_crawl_jobs:
         print(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,12 @@ services:
       - .:/app  # For development hot reload
     command: ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload"]
 
-  # Background Worker Service
+  # Background Worker Service — opt-in via the `pipeline` profile.
+  # Excluded from the default `docker compose up` so a plain bring-up yields a
+  # clean, deterministic demo (db + web + the bundled seed only). Start it with
+  # `docker compose --profile pipeline up` to exercise the live crawl pipeline.
   worker:
+    profiles: ["pipeline"]
     build:
       context: .
       dockerfile: docker/Dockerfile.worker
@@ -44,8 +48,13 @@ services:
       - .:/app  # For development
     restart: unless-stopped
 
-  # Scheduled Ingestion Service
+  # Scheduled Ingestion Service — opt-in via the `pipeline` profile.
+  # Locally this runs an hourly `run_ingestion` loop (the Dockerfile CMD); in
+  # production ingestion is driven by Cloud Scheduler over HTTP every 8h, not by
+  # this container. Gated out of the default bring-up so it doesn't pull live
+  # Mediastack articles (non-deterministic) over the seeded demo data.
   scheduler:
+    profiles: ["pipeline"]
     build:
       context: .
       dockerfile: docker/Dockerfile.scheduler

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -20,34 +20,39 @@ The supported local path is **Docker Compose**. The migration chain uses Postgre
 #    ingestion and bookmark/auth flows respectively.
 cp .env.example .env
 
-# 2. Bring up the full stack (Postgres 14, FastAPI web, worker, scheduler).
-#    First boot builds the images (~2-3 min); subsequent boots are seconds.
-docker-compose up --build
+# 2. One-command clean demo: build + start Postgres 14 and the FastAPI web
+#    service, wait for health, and load the bundled enriched seed. The worker
+#    and scheduler are NOT started (they sit behind the `pipeline` compose
+#    profile), so the dataset stays deterministic. First boot ~2-3 min.
+make demo
 
-# 3. Seed the database with the bundled 50-article snapshot so the UI has
-#    something to render. Run this in a second terminal once `web` is up.
-docker-compose exec web python -m app.seeds.seed_db
+#    Equivalent raw Compose, if you'd rather not use make:
+#    docker compose up --build -d db web
+#    docker compose exec web python -m app.seeds.seed_db
 
-# 4. (Optional) Exercise the full ingestion pipeline. Adds PENDING crawl
-#    jobs for every seeded article; the worker picks them up and crawls
-#    the live article URLs (robots.txt-respecting, rate-limited).
-docker-compose exec web python -m app.seeds.seed_db --queue-crawl-jobs
-docker-compose logs -f worker
+# 3. (Optional) Exercise the full ingestion pipeline. The worker + scheduler
+#    live behind the `pipeline` profile; start them, then queue crawl jobs for
+#    the seeded article URLs (robots.txt-respecting, rate-limited).
+docker compose --profile pipeline up -d worker   # or: make pipeline-up
+docker compose exec web python -m app.seeds.seed_db --queue-crawl-jobs
+docker compose logs -f worker
 
-# 5. (Optional) run the test suite inside the web container.
-docker-compose exec web pytest -v
+# 4. (Optional) run the test suite inside the web container.
+docker compose exec web pytest -v
 ```
 
 The API is then served at `http://localhost:8002` on the host — the container itself runs on `:8080` internally, but docker-compose publishes it on host port `:8002` to avoid the local Apache/XAMPP that commonly squats on `:8080` on Windows dev boxes (e.g. `GET /articles/?limit=5`). The frontend in `frontend/` is run separately with `npm run dev` — see [README.md § Development Setup](../README.md#development-setup).
 
 ### What's running
 
-| Service | Image | Purpose |
-|---------|-------|---------|
-| `db` | `postgres:14` | Database; persists in a Docker volume |
-| `web` | `aifeelnews-web` | FastAPI app; runs migrations on start |
-| `worker` | `aifeelnews-worker` | Background crawler — fetches article body content for jobs in the `crawl_jobs` queue |
-| `scheduler` | `aifeelnews-scheduler` | Hourly Mediastack ingestion loop (when `MEDIASTACK_API_KEY` is set) |
+| Service | Image | Profile | Purpose |
+|---------|-------|---------|---------|
+| `db` | `postgres:14` | default | Database; persists in a Docker volume |
+| `web` | `aifeelnews-web` | default | FastAPI app; runs migrations on start |
+| `worker` | `aifeelnews-worker` | `pipeline` | Background crawler — fetches article body content for jobs in the `crawl_jobs` queue |
+| `scheduler` | `aifeelnews-scheduler` | `pipeline` | Hourly Mediastack ingestion loop (when `MEDIASTACK_API_KEY` is set) |
+
+`db` + `web` start on a plain `docker compose up` (or `make demo`); `worker` + `scheduler` only start with `--profile pipeline` (or `make pipeline-up`), so the default bring-up is a clean, reproducible seed-only demo with no live ingestion racing the data.
 
 ### Running without Docker
 
@@ -344,7 +349,7 @@ Production runs an active ingestion pipeline that pulls article metadata from Me
 
 **Bilingual (EN/DE) ingestion** was added later: `MEDIASTACK_LANGUAGES=en,de` ([app/config/ingestion.py](../app/config/ingestion.py)) fetches both languages, and **10 German national outlets** (`dw`, `spiegel`, `zeit`, `faz`, `sueddeutsche`, `die-welt`, `handelsblatt`, `tagesschau`, `stern`, `focus`) join the source list ([app/jobs/sources_list.py](../app/jobs/sources_list.py), 31 sources total). Each article's `language` (ISO 639-1) drives per-language NLP and the EN/DE feed + dashboard filter; German sentiment/entities/categories come from GCP NL (categories via its V2 classification model). A one-time historical backfill job, [app/jobs/backfill_german.py](../app/jobs/backfill_german.py), seeds ~30 days of German articles via the live pipeline (capped per source/day, idempotent by URL).
 
-For local development a static seed dataset is included at [`app/seeds/seed_data.json`](../app/seeds/seed_data.json) — **50 articles spanning 10 sources** (BBC, Reuters/Independent, Guardian, NYTimes, Bloomberg, CNBC, FinancialPost, Phys, DW, Google News), sampled from the production database with PII removed (no `users`, no `bookmarks`). Load it with:
+For local development a static, **fully enriched bilingual** seed dataset is included at [`app/seeds/seed_data.json`](../app/seeds/seed_data.json) — **75 articles (50 English + 25 German) spanning 15 sources** (BBC, NYTimes, CNBC, Independent, FinancialPost, Time, Phys, plus the German outlets Spiegel, Zeit, Handelsblatt, Stern, Focus, Tagesschau), sampled from the production database with PII removed (no `users`, no `bookmarks`). Unlike a metadata-only snapshot, each article carries its `sentiment_magnitude` plus the relational **entities / `article_entities`** (quality-gated — only Knowledge-Graph-resolved, non-publisher names, so they survive the chart filters) and **categories**, so the PostgreSQL-backed analytics charts — including trending-names (entity momentum) — populate offline without BigQuery or a GCP project. The sample spans several days and the loader shifts every date (including entity/category `analyzed_at`) by one offset, so the trend and momentum windows stay valid. Load it with:
 
 ```bash
 alembic upgrade head

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -15,8 +15,9 @@ aifeelnews/
 ├── tests/                      # pytest test suite
 ├── .pre-commit-config.yaml     # Pre-commit hooks (ruff, mypy)
 ├── alembic.ini                 # Alembic migration config
-├── docker-compose.yml          # Local development stack
+├── docker-compose.yml          # Local development stack (worker/scheduler behind the `pipeline` profile)
 ├── docker-compose.prod.yml     # Production-like stack
+├── Makefile                    # Dev shortcuts: `make demo` / `demo-full` / `seed` / `pipeline-up`
 ├── pyproject.toml              # Python metadata, ruff, mypy config
 ├── pytest.ini                  # Test configuration
 └── requirements.txt            # Python dependencies

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -187,14 +187,14 @@ Source of truth if offline: `infra/main.tf` (backup config, deletion protection,
 
 ## What's worth showing against PRODUCTION vs the local seed
 
-The local seed is ~50 articles, VADER-only, **no** `article_entities` / `article_categories` rows (VADER produces neither). So anything that needs volume, time-spread, GCP-NL output, or "real" numbers is more convincing live.
+The local seed is now a **fully enriched bilingual sample**: 75 articles (50 EN + 25 DE) across 15 sources, with `sentiment_magnitude`, quality-gated `article_entities`, and `article_categories` — spread across several days and date-anchored to "now". So every chart and view **renders the right shape locally**, including the entity/category/momentum ones that used to come up empty. What production still wins on is **scale and real time-spread**: 75 rows over ~5 days is a populated demo, but ~35k rows over months of real calendar time is where the numbers and trend lines become *convincing* rather than merely present.
 
-**Show against production (~35k articles, real time-spread, GCP NL data):**
-- **Window-function analytics** — `sentiment/rolling`, `sources/ranked`, `entities/momentum`, `categories/daily`. A rolling average over 50 seed rows from one ingest is noise; over ~35k rows across real calendar time it actually *looks* like a trend. Momentum needs two adjacent populated windows — the seed barely has one.
-- **`v_trending_entities`, `fn_source_performance`, anything touching entities/categories** — empty or trivial on the seed (no entity/category rows); meaningful in prod where GCP NL `annotateText` populated them.
-- **`v_source_stats` / `v_daily_sentiment`** — 31 real sources with months of history vs. a handful of seed rows. The roll-up is the point; it needs rows to roll up.
-- **`EXPLAIN ANALYZE` on the filtered article query** — the Seq-Scan-vs-Index-Scan difference is visible at ~35k rows; at 50 rows the planner may Seq Scan *anyway* (it's cheaper) and you can't show the win. Run this live for a real plan.
-- **`/metrics`** — "34,xxx articles, 31 sources" is a one-line credibility anchor; the seed says "50".
+**Show against production (~35k articles, real time-spread, full GCP NL data at scale):**
+- **Window-function analytics at scale** — `sentiment/rolling`, `sources/ranked`, `entities/momentum`, `categories/daily` all populate locally now, but a rolling average over ~35k rows across real calendar time *looks* like a genuine trend; over 75 seed rows it's a short, tidy line. Use local to show the **chart works**, prod to show it **means something**.
+- **BigQuery-backed "AI-Enriched Insights" (Top Entities / topic classification)** — these stream from BigQuery and are gated on a GCP project, so they're **empty in the local demo regardless** of the enriched seed (the same entity data lives in Postgres, which is why the Postgres-backed trending-names chart *does* render locally). Show the AI-Enriched row live.
+- **`v_source_stats` / `v_daily_sentiment`** — 31 real sources with months of history vs. 15 seed sources over a few days. The roll-up is the point; it needs rows to roll up.
+- **`EXPLAIN ANALYZE` on the filtered article query** — the Seq-Scan-vs-Index-Scan difference is visible at ~35k rows; at 75 rows the planner may Seq Scan *anyway* (it's cheaper) and you can't show the win. Run this live for a real plan.
+- **`/metrics`** — "34,xxx articles, 31 sources" is a one-line credibility anchor; the seed says "75".
 - **Backup / PITR config** — `gcloud sql instances describe` only means anything against the real Cloud SQL instance.
 - **`alembic current` on prod** — shows the prod DB is actually at `head`, migrations really run on deploy.
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -212,12 +212,13 @@
   }
 
   // React to auth-state changes: hydrate / reset the bookmark store, and
-  // bounce away from auth-only pages on sign-out.
+  // bounce away from auth-only pages on sign-out. Analytics is public (it reads
+  // only unauthenticated endpoints), so only Bookmarks bounces back.
   $: if ($userStore) {
     void hydrateBookmarks();
   } else {
     bookmarkStore.reset();
-    if (currentPage === "analytics" || currentPage === "bookmarks") {
+    if (currentPage === "bookmarks") {
       currentPage = "articles";
     }
   }
@@ -368,6 +369,18 @@
       >
         Articles
       </button>
+      <!-- Analytics reads only public, unauthenticated endpoints (the Postgres
+           db-analytics + BigQuery analytics routes), so it's available to
+           everyone — including the credential-free demo. Bookmarks stays gated
+           below: it's per-user and needs a signed-in Firebase identity. -->
+      <button
+        on:click={() => (currentPage = "analytics")}
+        class="nav-button"
+        class:nav-button-active={currentPage === "analytics"}
+        aria-current={currentPage === "analytics" ? "page" : undefined}
+      >
+        Analytics
+      </button>
       {#if $userStore}
         <button
           on:click={() => (currentPage = "bookmarks")}
@@ -376,14 +389,6 @@
           aria-current={currentPage === "bookmarks" ? "page" : undefined}
         >
           Bookmarks
-        </button>
-        <button
-          on:click={() => (currentPage = "analytics")}
-          class="nav-button"
-          class:nav-button-active={currentPage === "analytics"}
-          aria-current={currentPage === "analytics" ? "page" : undefined}
-        >
-          Analytics
         </button>
       {/if}
     </nav>
@@ -504,7 +509,7 @@
     {/if}
   {:else if currentPage === "bookmarks" && $userStore}
     <BookmarksView />
-  {:else if currentPage === "analytics" && $userStore}
+  {:else if currentPage === "analytics"}
     <Dashboard {language} />
   {:else if currentPage === "privacy"}
     <Privacy />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,12 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  server: {
+    // Pin the dev server to 5173 and fail loudly if it's taken, instead of
+    // silently drifting to 5174/5175. The backend CORS allowlist only includes
+    // :5173 (app/main.py), so a drifted port would break every API call with an
+    // opaque CORS error. strictPort surfaces the conflict immediately.
+    port: 5173,
+    strictPort: true,
+  },
 })

--- a/tests/test_seed_db.py
+++ b/tests/test_seed_db.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from app.models.article import Article
+from app.models.article_category import ArticleCategory
+from app.models.article_entity import ArticleEntity
 from app.models.crawl_job import CrawlJob, CrawlStatus
+from app.models.entity import Entity
 from app.models.source import Source
 from app.seeds.seed_db import DEFAULT_SEED_PATH, seed_database
 
@@ -124,3 +127,178 @@ def test_seed_queue_crawl_jobs_skips_articles_with_existing_jobs(test_db, seed_p
     # Articles already had jobs from the first run — second run enqueues nothing.
     assert second["crawl_jobs_inserted"] == 0
     assert test_db.query(CrawlJob).count() == len(seed_payload["articles"])
+
+
+# --------------------------------------------------------------------------- #
+# Enrichment (sentiment_magnitude + entities + categories)
+# --------------------------------------------------------------------------- #
+
+
+def _enriched_payload() -> dict:
+    """A small bilingual seed with magnitude + shared entities + categories.
+
+    Two articles reference the SAME entity ("Donald Trump", PERSON) so the
+    loader's global dedup is exercised: one Entity row, two ArticleEntity links.
+    Dates are old on purpose so the recency anchor must shift them forward.
+    """
+    return {
+        "_metadata": {"article_count": 2},
+        "sources": [
+            {"name": "bbc", "country": "gb", "language": "en"},
+            {"name": "tagesschau", "country": "de", "language": "de"},
+        ],
+        "articles": [
+            {
+                "title": "EN headline",
+                "description": "english body",
+                "url": "https://example.com/en-1",
+                "image_url": None,
+                "published_at": "2025-01-01T12:00:00+00:00",
+                "language": "en",
+                "country": "gb",
+                "category": "general",
+                "sentiment_label": "positive",
+                "sentiment_score": 0.4,
+                "sentiment_magnitude": 9.2,
+                "source_name": "bbc",
+                "entities": [
+                    {
+                        "name": "Donald Trump",
+                        "type": "PERSON",
+                        "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+                        "mid": "/m/0cqt90",
+                        "salience": 0.8,
+                        "mention_count": 3,
+                        "analyzed_at": "2025-01-02T08:00:00+00:00",
+                    }
+                ],
+                "categories": [
+                    {
+                        "name": "/News/Politics",
+                        "confidence": 0.91,
+                        "analyzed_at": "2025-01-02T08:00:00+00:00",
+                    }
+                ],
+            },
+            {
+                "title": "DE headline",
+                "description": "deutscher text",
+                "url": "https://example.com/de-1",
+                "image_url": None,
+                "published_at": "2025-01-03T12:00:00+00:00",
+                "language": "de",
+                "country": "de",
+                "category": "general",
+                "sentiment_label": "negative",
+                "sentiment_score": -0.3,
+                "sentiment_magnitude": 14.7,
+                "source_name": "tagesschau",
+                "entities": [
+                    {
+                        "name": "Donald Trump",
+                        "type": "PERSON",
+                        "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Trump",
+                        "mid": "/m/0cqt90",
+                        "salience": 0.5,
+                        "mention_count": 1,
+                        "analyzed_at": "2025-01-04T08:00:00+00:00",
+                    }
+                ],
+                "categories": [],
+            },
+        ],
+    }
+
+
+@pytest.fixture()
+def enriched_seed_file(tmp_path: Path) -> Path:
+    path = tmp_path / "enriched_seed.json"
+    path.write_text(json.dumps(_enriched_payload()), encoding="utf-8")
+    return path
+
+
+def test_seed_loads_magnitude(test_db, enriched_seed_file):
+    """sentiment_magnitude is loaded onto the denormalized article column."""
+    seed_database(test_db, json_path=enriched_seed_file)
+    en = test_db.query(Article).filter_by(url="https://example.com/en-1").one()
+    de = test_db.query(Article).filter_by(url="https://example.com/de-1").one()
+    assert en.sentiment_magnitude == pytest.approx(9.2)
+    assert de.sentiment_magnitude == pytest.approx(14.7)
+
+
+def test_seed_dedupes_entities_and_links(test_db, enriched_seed_file):
+    """The shared entity is created once; each article gets its own link."""
+    summary = seed_database(test_db, json_path=enriched_seed_file)
+
+    # One canonical entity, two mention links.
+    assert summary["entities_inserted"] == 1
+    assert summary["entity_links_inserted"] == 2
+    assert test_db.query(Entity).count() == 1
+    assert test_db.query(ArticleEntity).count() == 2
+
+    entity = test_db.query(Entity).one()
+    assert entity.name == "Donald Trump"
+    assert entity.wikipedia_url is not None  # survives the chart quality gate
+
+
+def test_seed_loads_categories(test_db, enriched_seed_file):
+    """Categories are attached to the right article."""
+    summary = seed_database(test_db, json_path=enriched_seed_file)
+    assert summary["categories_inserted"] == 1
+    cat = test_db.query(ArticleCategory).one()
+    en = test_db.query(Article).filter_by(url="https://example.com/en-1").one()
+    assert cat.article_id == en.id
+    assert cat.name == "/News/Politics"
+
+
+def test_seed_shifts_analyzed_at_with_recency_anchor(test_db, enriched_seed_file):
+    """analyzed_at is shifted by the same offset as published_at.
+
+    The momentum / trending-names windows key off analyzed_at, so it must move
+    forward with the article dates — otherwise the seeded mentions fall outside
+    the recent window and the charts read empty.
+    """
+    seed_database(test_db, json_path=enriched_seed_file)
+
+    # Newest published_at in the fixture is 2025-01-03; anchored to ~1 day ago.
+    en = test_db.query(Article).filter_by(url="https://example.com/en-1").one()
+    link = test_db.query(ArticleEntity).filter_by(article_id=en.id).one()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    # analyzed_at (orig 2025-01-02) should now be recent, not 2025.
+    assert link.analyzed_at > now - timedelta(days=40)
+    # And it stays BEFORE now (pipeline can't analyze the future).
+    assert link.analyzed_at <= now
+
+
+def test_seed_literal_dates_keeps_original_analyzed_at(test_db, enriched_seed_file):
+    """With anchor_recent=False, analyzed_at keeps its literal snapshot value."""
+    seed_database(test_db, json_path=enriched_seed_file, anchor_recent=False)
+    en = test_db.query(Article).filter_by(url="https://example.com/en-1").one()
+    link = test_db.query(ArticleEntity).filter_by(article_id=en.id).one()
+    assert link.analyzed_at == datetime(2025, 1, 2, 8, 0, 0)
+
+
+def test_seed_reset_sweeps_orphaned_entities(test_db, enriched_seed_file):
+    """--reset removes articles, links, categories AND now-orphaned entities."""
+    seed_database(test_db, json_path=enriched_seed_file)
+    assert test_db.query(Entity).count() == 1
+
+    # Reset + reload: should not accumulate duplicate entities/links.
+    seed_database(test_db, json_path=enriched_seed_file, reset=True)
+    assert test_db.query(Article).count() == 2
+    assert test_db.query(Entity).count() == 1
+    assert test_db.query(ArticleEntity).count() == 2
+    assert test_db.query(ArticleCategory).count() == 1
+
+
+def test_seed_enrichment_is_idempotent(test_db, enriched_seed_file):
+    """Re-running without --reset adds no duplicate links or entities."""
+    seed_database(test_db, json_path=enriched_seed_file)
+    second = seed_database(test_db, json_path=enriched_seed_file)
+    assert second["articles_inserted"] == 0
+    assert second["entities_inserted"] == 0
+    assert second["entity_links_inserted"] == 0
+    assert second["categories_inserted"] == 0
+    assert test_db.query(Entity).count() == 1
+    assert test_db.query(ArticleEntity).count() == 2
+    assert test_db.query(ArticleCategory).count() == 1


### PR DESCRIPTION
Makes a local demo spin up cleanly and deterministically without credentials, and tidies a few developer-facing rough edges. No production behaviour changes.

## Seed

The bundled seed was 50 English-only articles with no entities, categories, or magnitude, so demo mode showed empty charts. Regenerated it from production as a fully enriched bilingual sample: 75 articles (50 EN + 25 DE), 15 sources, with sentiment, magnitude, entities, and categories, spread across several days.

The loader now creates the entity/category rows and shifts their `analyzed_at` by the same recency offset as `published_at`, so the trending-names and momentum charts populate offline (those windows key off `analyzed_at`). Adds tests for entity dedup, magnitude loading, the date-offset, and the reset/orphan sweep.

## Deterministic stack

A default `docker compose up` was starting the scheduler, which immediately pulled live Mediastack articles over the seed — the dataset came up different every run. Moved the worker and scheduler behind a `pipeline` Compose profile, so the default bring-up is seed-only. Live ingestion is opt-in with `--profile pipeline` (or `make pipeline-up`).

Added Makefile targets: `make demo` (db + web + seed), `make demo-full` (+ frontend), `make seed` / `seed-reset` / `pipeline-up`.

## Frontend

The Analytics dashboard was gated behind Google sign-in even though its endpoints are public, so a credential-free reviewer saw none of the charts. Moved the gate to per-user bookmarks only; Analytics is now visible without signing in.

Pinned the Vite dev server to 5173 (`strictPort`) so it fails loudly if the port is taken rather than drifting to one the backend CORS allowlist doesn't include.

## API docs and repo hygiene

- Cleaned up the auto-generated `/docs`: removed doubled tag labels, fixed the lowercase `sentiment` tag, added an API description, and tagged the probe/ops endpoints. Metadata only, no route changes.
- Added `.gitattributes` enforcing LF on shell scripts, the Makefile, and Dockerfiles so a Windows checkout can't introduce CRLF.

## Docs

README, DATABASE, PROJECT_STRUCTURE, and demo-guide updated for the `make demo` flow, the compose profile, and the enriched bilingual seed.

## Notes

- The big diff is `app/seeds/seed_data.json` (the regenerated seed embeds the entity/category rows).
- Branched off develop before #187 merged; touches a disjoint set of files, so it merges cleanly.
