### PR TITLE
fix(sources): scope the source filter to the selected language

### DIFF
--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.deps.auth import require_admin
+from app.models.article import Article as ArticleModel
 from app.models.source import Source as SourceModel
 from app.models.user import User
 from app.schemas.source import SourceCreate, SourceRead
@@ -29,5 +30,27 @@ def create_source(
 
 
 @router.get("/", response_model=List[SourceRead])
-def list_sources(db: Session = Depends(get_db)) -> List[SourceRead]:
-    return db.query(SourceModel).all()  # type: ignore[return-value,no-any-return]
+def list_sources(
+    db: Session = Depends(get_db),
+    language: Optional[str] = Query(
+        None,
+        max_length=2,
+        description="ISO 639-1 code (e.g. 'en', 'de'). Returns only sources that "
+        "have at least one article in that language.",
+    ),
+) -> List[SourceRead]:
+    """List news sources.
+
+    A source has no intrinsic language — its *articles* do — so the optional
+    ``language`` filter is derived via a JOIN on ``articles`` rather than a
+    stored column (no drift, single source of truth). Without it, all sources
+    are returned.
+    """
+    query = db.query(SourceModel)
+    if language:
+        query = (
+            query.join(ArticleModel, ArticleModel.source_id == SourceModel.id)
+            .filter(ArticleModel.language == language)
+            .distinct()
+        )
+    return query.order_by(SourceModel.name).all()  # type: ignore[return-value,no-any-return]

--- a/docs/PERSONAS_AND_USE_CASES.md
+++ b/docs/PERSONAS_AND_USE_CASES.md
@@ -61,11 +61,11 @@ Each use case has two status columns — backend (the API/data layer) and UI (wh
 | UC-02 | View article detail with sentiment + entities | ✅ | 🔲 | `GET /api/v1/articles/{id}` | Detail page deferred — feed cards already show sentiment badge |
 | UC-03 | Filter articles by sentiment label | ✅ | ✅ | `GET /api/v1/articles/?sentiment_label=...` | |
 | UC-04 | Filter articles by category | ✅ | ✅ | `GET /api/v1/articles/?category=...` | UI uses static mediastack enum; categories endpoint deferred |
-| UC-05 | Filter articles by source | ✅ | ✅ | `GET /api/v1/articles/?source_id=...` | UI populates dropdown from `GET /api/v1/sources/` |
+| UC-05 | Filter articles by source | ✅ | ✅ | `GET /api/v1/articles/?source_id=...` | UI populates the dropdown from `GET /api/v1/sources/?language=<en\|de>`, which returns only sources that have articles in the current language (derived via a JOIN, not a stored column) so the filter can't offer a source that yields an empty feed |
 | UC-06 | Paginate article feed | ✅ | ✅ | `GET /api/v1/articles/?skip=...&limit=...` | |
 | UC-07 | Search articles by keyword | ✅ | ✅ | `GET /api/v1/articles/?search=...` | ILIKE substring on title, **pg_trgm GIN-indexed** + `similarity()` ranking on Postgres (shipped — DATABASE.md § 4.4) |
 | UC-26 | Full-text search (phrases, boolean, ranked) | ✅ | ✅ | `GET /api/v1/articles/search?q=...` | `tsvector` + `ts_rank`; `websearch_to_tsquery` grammar (quoted phrases, `or`, leading `-`); language-aware stemming (EN/DE) |
-| UC-27 | Filter the feed + dashboard by language (EN/DE toggle) | ✅ | ✅ | `GET /api/v1/articles/?language=de` | Header flag toggle switches the whole feed **and** the analytics dashboard; persisted to the URL (`?lang=de`) |
+| UC-27 | Filter the feed + dashboard by language (EN/DE toggle) | ✅ | ✅ | `GET /api/v1/articles/?language=de` | Header flag toggle switches the whole feed, the analytics dashboard, **and** the source-filter dropdown (which re-scopes to the language's sources); persisted to the URL (`?lang=de`) |
 | UC-28 | Date-range filter on the feed | ✅ | ✅ | `GET /api/v1/articles/?published_after=...&published_before=...` | Preset + custom ranges in the FilterBar |
 
 ### Registered Reader (P2)

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -163,7 +163,13 @@
 
   async function loadSources() {
     try {
-      sources = await fetchSources();
+      // Sources are language-scoped: only those with articles in the current
+      // language, so the dropdown can't offer a source that yields an empty feed.
+      sources = await fetchSources(language || undefined);
+      // Drop a selected source that isn't in the new language's list.
+      if (sourceId !== "" && !sources.some((s) => s.id === sourceId)) {
+        sourceId = "";
+      }
     } catch (e) {
       console.warn("Failed to load sources, continuing with empty list:", e);
       sources = [];
@@ -261,10 +267,13 @@
 
   // Switch the content language (EN/DE). Drives the feed + dashboard via the
   // reactive block; resets pagination since the result set changes entirely.
+  // Also re-loads the source list so the filter only offers sources that
+  // publish in the new language.
   function setLanguage(lang: string) {
     if (lang === language) return;
     language = lang;
     skip = 0;
+    void loadSources();
   }
 
   function handlePrevPage() {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -177,8 +177,9 @@ export type SourceDto = {
   name: string;
 };
 
-export async function fetchSources(): Promise<SourceDto[]> {
-  const res = await fetch(`${API_BASE}/api/v1/sources/`);
+export async function fetchSources(language?: string): Promise<SourceDto[]> {
+  const qs = language ? `?language=${encodeURIComponent(language)}` : "";
+  const res = await fetch(`${API_BASE}/api/v1/sources/${qs}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch sources: ${res.status}`);
   }

--- a/tests/test_sources_routes.py
+++ b/tests/test_sources_routes.py
@@ -1,0 +1,90 @@
+"""Language filtering for GET /api/v1/sources/.
+
+A source has no intrinsic language; the filter is derived from the languages of
+its articles via a JOIN. ``?language=de`` must return only sources that have at
+least one German article, so the dropdown can't offer a source that would yield
+an empty feed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.main import app
+from app.models.article import Article
+from app.models.source import Source
+
+
+@pytest.fixture
+def client(test_db) -> Iterator[TestClient]:
+    def _override_get_db() -> Iterator[object]:
+        yield test_db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _article(db, *, source_id: int, language: str, slug: str) -> None:
+    db.add(
+        Article(
+            source_id=source_id,
+            title=slug,
+            url=f"https://example.com/{slug}",
+            published_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            language=language,
+        )
+    )
+
+
+@pytest.fixture
+def seeded(test_db):
+    # bbc: EN only · tagesschau: DE only · reuters: both
+    test_db.add_all(
+        [
+            Source(id=1, name="bbc"),
+            Source(id=2, name="tagesschau"),
+            Source(id=3, name="reuters"),
+        ]
+    )
+    test_db.flush()
+    _article(test_db, source_id=1, language="en", slug="bbc-en")
+    _article(test_db, source_id=2, language="de", slug="tag-de")
+    _article(test_db, source_id=3, language="en", slug="reu-en")
+    _article(test_db, source_id=3, language="de", slug="reu-de")
+    test_db.commit()
+
+
+def test_no_language_returns_all_sources(client, seeded):
+    resp = client.get("/api/v1/sources/")
+    assert resp.status_code == 200
+    assert {s["name"] for s in resp.json()} == {"bbc", "tagesschau", "reuters"}
+
+
+def test_language_de_filters_to_sources_with_de_articles(client, seeded):
+    resp = client.get("/api/v1/sources/?language=de")
+    assert resp.status_code == 200
+    # tagesschau (DE) + reuters (both) — bbc (EN only) excluded.
+    assert {s["name"] for s in resp.json()} == {"tagesschau", "reuters"}
+
+
+def test_language_en_filters_to_sources_with_en_articles(client, seeded):
+    resp = client.get("/api/v1/sources/?language=en")
+    assert resp.status_code == 200
+    assert {s["name"] for s in resp.json()} == {"bbc", "reuters"}
+
+
+def test_language_filter_is_distinct(client, seeded):
+    # reuters has two EN... add a second so a non-distinct JOIN would dupe it.
+    # (reuters already has one EN; the both-languages row set guarantees the
+    # JOIN could fan out — assert each source appears at most once.)
+    resp = client.get("/api/v1/sources/?language=en")
+    names = [s["name"] for s in resp.json()]
+    assert len(names) == len(set(names))


### PR DESCRIPTION
The source-filter dropdown listed every source regardless of the EN/DE language toggle. Picking an English-only source while viewing German (or the reverse) produced an empty feed.

## Approach

A source has no intrinsic language — its articles do — so I derived the filter rather than adding a column. `GET /api/v1/sources/` gains an optional `?language=` that returns only sources with at least one article in that language, via a `DISTINCT` JOIN on `articles`.

Deliberately not a stored `sources.language` column: that would denormalize a fact that can change and drift (a source like Deutsche Welle publishes in both languages, and DW correctly shows up under both `en` and `de` with the JOIN). The JOIN keeps a single source of truth (`articles.language`, set at ingestion) and stays correct automatically. `/sources/` is a low-frequency call and `articles.language` / `source_id` are both indexed, so the cost is negligible.

The frontend re-loads the source list when the language toggles and clears a selected source that isn't in the new language's set.

## Verified locally

Against the running demo with the bundled seed:
- no filter → 15 sources
- `?language=en` → 8
- `?language=de` → 8 (Deutsche Welle in both)

## Tests

`test_sources_routes.py`: no language returns all; `en`/`de` return only matching sources; results are distinct.

`ruff`, `mypy`, full suite (118 passed), and the frontend build are green.

## Docs

UC-05 and UC-27 in `PERSONAS_AND_USE_CASES.md` updated to reflect the language-scoped source list.
