### PR TITLE
Release: frontend unit-test suite + CI gate (#192)

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -1,10 +1,12 @@
-# Type-checks the Svelte frontend. `vite build` transpiles with esbuild,
-# which strips TypeScript types WITHOUT checking them, so a type error
+# Type-checks AND unit-tests the Svelte frontend. `vite build` transpiles with
+# esbuild, which strips TypeScript types WITHOUT checking them, so a type error
 # never fails the build/preview job. This workflow runs the project's
 # `npm run check` (svelte-check + tsc) to close that gap — notably so
 # Dependabot bumps of typescript / @types/* are verified against real
-# type-checking before merge.
-name: Frontend Type Check
+# type-checking before merge — and `npm test` (Vitest) to guard the frontend
+# logic layer (api.ts contract, sentiment, bookmark store, theme) and component
+# rendering against regressions.
+name: Frontend Checks
 
 on:
   push:
@@ -18,7 +20,7 @@ permissions:
 
 jobs:
   check:
-    name: svelte-check + tsc
+    name: svelte-check + tsc + vitest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,4 +37,8 @@ jobs:
 
       - name: Type-check (svelte-check + tsc)
         run: npm run check
+        working-directory: frontend
+
+      - name: Unit tests (Vitest)
+        run: npm test
         working-directory: frontend

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: reset-db ingest pipeline migrate env-init \
-        demo demo-full frontend up down logs seed seed-reset pipeline-up
+        demo demo-full frontend frontend-test up down logs seed seed-reset pipeline-up
 
 # --------------------------------------------------------------------------- #
 # Docker demo (recommended for a clean, reproducible local run)
@@ -42,6 +42,11 @@ frontend:
 	cd frontend && { [ -f .env ] || cp .env.example .env; } && npm install
 	@echo "🚀 Starting the Svelte dev server → http://localhost:5173 (Ctrl-C to stop)"
 	cd frontend && npm run dev
+
+# Run the frontend unit tests once (Vitest) — the same suite the
+# frontend-check.yml CI gate runs. npm install is a fast no-op once cached.
+frontend-test:
+	cd frontend && npm install && npm test
 
 # Start only db + web (the default compose profile excludes worker/scheduler).
 up:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ python -m app.seeds.seed_db
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-SQLite is **not** a supported substitute for Postgres at the migration layer — the test suite uses SQLite via `Base.metadata.create_all` (which sidesteps migrations), but `alembic upgrade head` against SQLite will fail on the views/functions/triggers DDL.
+SQLite is **not** a supported substitute for Postgres at the migration layer — the backend test suite uses SQLite via `Base.metadata.create_all` (which sidesteps migrations), but `alembic upgrade head` against SQLite will fail on the views/functions/triggers DDL.
 
 ### Database Setup
 
@@ -198,8 +198,16 @@ This is the recommended path for local development and demos — no Mediastack k
 ruff check app/                   # Lint
 ruff format app/                  # Format
 mypy app/                         # Type check
-pytest tests/ -v                  # Tests
+pytest tests/ -v                  # Backend tests
 pre-commit run --all-files        # All hooks
+```
+
+Frontend (mirrors the `frontend-check.yml` CI gate):
+
+```bash
+cd frontend
+npm run check                     # Type check (svelte-check + tsc)
+npm test                          # Unit tests (Vitest + Testing Library)
 ```
 
 ## Documentation

--- a/docs/CICD_PIPELINE.md
+++ b/docs/CICD_PIPELINE.md
@@ -65,6 +65,10 @@ flowchart TB
         fb_build_preview["Build & Preview<br/>───────────<br/>npm ci + npm run build<br/>Firebase deploy → preview"]
     end
 
+    subgraph frontend_check["Frontend Checks (frontend-check.yml)"]
+        fc_check["Check & Test<br/>───────────<br/>svelte-check + tsc<br/>vitest (unit tests)"]
+    end
+
     subgraph review["Auto Review (auto-review.yml)"]
         copilot["Request Copilot Review"]
     end
@@ -82,6 +86,11 @@ flowchart TB
     push_main --> fb_build_live
     pr_any --> fb_build_preview
     pr_any --> copilot
+
+    push_main --> fc_check
+    push_develop --> fc_check
+    pr_develop --> fc_check
+    pr_main --> fc_check
 ```
 
 ## Workflow Details
@@ -124,9 +133,12 @@ test (merge policy gate → lint + type-check + unit tests)
         └── Create failure issue (if failed)
 ```
 
-> Note: there is no Cloud Run PR-preview job. The backend `deploy.yml` only
-> runs on push to `main`; PR previews exist for the **frontend** (Firebase
-> Hosting preview channels) — see below.
+> Note: there is no Cloud Run PR-preview job. `deploy.yml` runs its test job on
+> every PR, but the `build-and-deploy` job is gated to push-to-`main`; PR
+> previews exist for the **frontend** only (Firebase Hosting preview channels) —
+> see below. A backend preview-per-PR mechanism was tried and deliberately
+> removed; the rationale is documented in
+> [MULTI_ENVIRONMENT_STRATEGY.md](MULTI_ENVIRONMENT_STRATEGY.md#cloud-run-pr-previews-removed-by-design).
 
 ### 2. Frontend Deploy (`firebase-hosting-merge.yml`)
 
@@ -163,13 +175,13 @@ test (merge policy gate → lint + type-check + unit tests)
 | **`pip-audit`** | Scans pinned `requirements.txt` for known CVEs; `--strict` fails CI on any advisory |
 | **`gitleaks`** | Full-history secret-leak scan; posts a summary comment on PRs |
 
-### 6. Frontend Type Check (`frontend-check.yml`)
+### 6. Frontend Checks (`frontend-check.yml`)
 
 | Property | Value |
 |----------|-------|
 | **Trigger** | Push/PR to `main` or `develop`, manual dispatch |
-| **Action** | Runs `npm run check` (`svelte-check` + `tsc`) |
-| **Why** | `vite build` strips TypeScript types without checking them, so type errors never failed the build/preview job. Unlike `firebase-hosting-pull-request.yml`, this workflow has no Dependabot exclusion, so `typescript` / `@types/*` bumps are verified against real type-checking before merge. |
+| **Action** | Runs `npm run check` (`svelte-check` + `tsc`), then `npm test` (Vitest unit tests) |
+| **Why** | `vite build` strips TypeScript types without checking them, so type errors never failed the build/preview job. Unlike `firebase-hosting-pull-request.yml`, this workflow has no Dependabot exclusion, so `typescript` / `@types/*` bumps are verified against real type-checking before merge. The Vitest suite (jsdom + Testing Library) guards the frontend logic layer — the `api.ts` backend contract (query assembly, status-code semantics), sentiment descriptions, bookmark store, theme persistence — and component rendering, so a behavioural regression fails CI even though it would still build cleanly. |
 
 ### CodeQL SAST (GitHub default setup)
 
@@ -209,6 +221,7 @@ CodeQL static analysis runs via **GitHub Advanced Security default setup** — c
 Feature branch created from develop
   └── PR to develop
         ├── Backend tests run (merge policy + ruff + mypy + pytest)
+        ├── Frontend checks run (svelte-check + tsc + vitest)
         ├── Frontend preview deployed (Firebase preview channel)
         └── Copilot review requested
 
@@ -220,6 +233,7 @@ PR develop → main (release)
 
 Push to main (after merge)
   ├── Backend: test → build → push → migrate → deploy → verify → rollback/notify
+  ├── Frontend: checks re-run (svelte-check + tsc + vitest)
   └── Frontend: build → deploy to Firebase Hosting live channel
 ```
 

--- a/docs/CLOUD_SERVICE_CODE_MAP.md
+++ b/docs/CLOUD_SERVICE_CODE_MAP.md
@@ -34,6 +34,7 @@
 | **Backend deploy** | Push to `main` | Ruff lint -> mypy -> pytest -> Docker build -> AR push -> Cloud Run deploy -> health check | `.github/workflows/deploy.yml` |
 | **Frontend merge** | Push to `main` | npm build -> Firebase Hosting deploy (live) | `.github/workflows/firebase-hosting-merge.yml` |
 | **Frontend PR preview** | Pull request | npm build -> Firebase Hosting deploy (preview channel) | `.github/workflows/firebase-hosting-pull-request.yml` |
+| **Frontend checks** | Push/PR to `main`/`develop` | svelte-check + tsc -> Vitest unit tests (no deploy) | `.github/workflows/frontend-check.yml` |
 
 ## External Integrations
 

--- a/docs/MULTI_ENVIRONMENT_STRATEGY.md
+++ b/docs/MULTI_ENVIRONMENT_STRATEGY.md
@@ -5,15 +5,15 @@
 aiFeelNews implements environment separation through two complementary mechanisms:
 
 1. **Terraform variable files** (`tfvars`) — infrastructure-level environment isolation (production vs staging)
-2. **Git branching + Cloud Run tagged revisions** — cost-free preview environments for every PR
+2. **Git branching + CI quality gates + Firebase Hosting PR previews** — pre-production validation on every PR
 
-A dedicated staging environment is not deployed due to cost (~$7-9/month for Cloud SQL alone). Instead, the project uses **PR preview deploys** on Cloud Run as a zero-cost staging alternative.
+A dedicated staging environment is not deployed due to cost (~$7-9/month for Cloud SQL alone). Pre-merge validation comes from the CI gates (backend: ruff + mypy + pytest incl. a real-Postgres job; frontend: svelte-check + tsc + Vitest) plus Firebase Hosting preview channels for frontend changes. A Cloud Run PR-preview mechanism was implemented, found unworkable without dedicated preview infrastructure, and deliberately removed — see [Cloud Run PR Previews (Removed by Design)](#cloud-run-pr-previews-removed-by-design).
 
 ## Branching Strategy (Simplified Git Flow)
 
 ```
 feature/phase-b-db  ──┐
-feature/phase-c-cyber ─┤── PR into: develop (CI tests + PR preview)
+feature/phase-c-cyber ─┤── PR into: develop (CI tests + frontend preview)
 feature/phase-d-auth  ─┘
                            │
                            └── when deploy-ready: PR develop → main (production deploy)
@@ -25,28 +25,25 @@ fix/critical-bug  ────────── PR directly to main (hotfix esc
 |--------|--------|----------|--------|
 | `main` | Yes | Yes — production Cloud Run + Firebase | Production |
 | `develop` | Yes | No — integration only | None |
-| `feature/*` | Yes (on PR) | PR preview (Cloud Run tagged revision) | Preview URL |
+| `feature/*` | Yes (on PR) | Frontend only — Firebase Hosting preview channel (PRs touching `frontend/`) | Preview URL (frontend) |
 | `fix/*` | Yes | Yes — direct to production (emergency) | Production |
 
 **CI-enforced merge policy:** A CI gate in the `test` job blocks PRs from feature branches directly to `main`. Only `develop` and `fix/*` branches are allowed. This is enforced without GitHub Enterprise — purely through a workflow step that exits with an error.
 
-## PR Preview Deploys (Zero-Cost Staging Alternative)
+## Cloud Run PR Previews (Removed by Design)
 
-When a PR targets `develop`, the CI pipeline:
+A zero-cost backend preview-per-PR mechanism was implemented in the deployment-hardening pass (PR #28, 2026-03-17): build an image tagged `pr-<number>`, deploy it with `--tag --no-traffic` (tagged revisions with `min-instances=0` cost nothing when idle), post the revision URL as a PR comment, clean up on PR close.
 
-1. Builds a Docker image tagged `pr-<number>`
-2. Deploys it to Cloud Run with `--tag=pr-<number> --no-traffic`
-3. The revision gets its own URL: `pr-42---aifeelnews-web-xxxxx.run.app`
-4. Posts the preview URL as a PR comment
-5. Cleans up the tagged revision when the PR is closed
+It was **removed on 2026-04-29** (commit `e2bfd77`) after failing on every PR since introduction. Beyond a wrong `gcloud` flag, the design had an unfixable flaw at this project's scale: the preview revision needs a database, and both options were unacceptable —
 
-**Why this is free:** Cloud Run charges per request. Tagged revisions with `--no-traffic` and `min-instances=0` cost nothing when idle. They share the same Cloud SQL instance, Secret Manager secrets, and service account — no duplicate infrastructure.
+1. **Pass the production `DATABASE_URL`** — a security risk: PR-tagged revisions are publicly reachable, so un-reviewed code could mutate production data.
+2. **Stand up a separate preview Cloud SQL** — duplicate always-on infrastructure cost, defeating the "zero-cost" premise.
 
-**What this validates:**
-- Docker image builds successfully
-- Application starts and passes health checks
-- Database connectivity works (same Cloud SQL)
-- API endpoints respond correctly
+The jobs were deleted rather than left half-working. Pre-merge validation is covered instead by:
+
+- **Backend:** ruff + mypy + pytest on every PR (`deploy.yml` test job), including the views/functions/triggers exercised against a real Postgres service container
+- **Frontend:** svelte-check + tsc + Vitest unit tests (`frontend-check.yml`), plus a **Firebase Hosting preview channel** for every frontend-touching PR (`firebase-hosting-pull-request.yml`); the preview build points at the production API
+- **Post-deploy:** multi-endpoint smoke tests with automated traffic rollback (production deploys only happen on push to `main`)
 
 ## Terraform Multi-Environment Support
 
@@ -93,7 +90,7 @@ terraform apply -var-file=envs/staging.tfvars
 The staging configuration exists as a **design artifact** demonstrating multi-environment capability. It is not actively deployed because:
 
 1. **Cost**: Cloud SQL alone costs ~$7-9/month (always-on, no free tier). Deploying staging would double the infrastructure cost with no production benefit.
-2. **Scale**: For a student project with <10 users, PR previews + proper CI testing gates provide sufficient pre-production validation.
+2. **Scale**: For a student project with <10 users, the CI quality gates (backend tests incl. real Postgres, frontend type-check + unit tests) and Firebase frontend previews provide sufficient pre-production validation.
 3. **Risk mitigation**: The backend pipeline runs full tests (lint + type-check + unit tests), multi-endpoint smoke tests, and automated rollback — catching issues before and after deployment.
 
 **This is a deliberate cost/value trade-off**, not a limitation. The architecture supports staging activation with a single `terraform apply`.
@@ -107,11 +104,10 @@ The staging configuration exists as a **design artifact** demonstrating multi-en
 - Shared IAM service accounts (single GCP project, isolated by service name)
 - Same region (`europe-west1`)
 
-**PR preview revisions:**
-- Isolated application code (separate Docker image tag per PR)
-- Shared database (same Cloud SQL — acceptable for previews)
-- No production traffic (enforced by `--no-traffic` flag)
-- Automatic cleanup on PR close
+**Firebase Hosting PR previews:**
+- Isolated, auto-expiring preview channel per frontend-touching PR
+- Frontend only — backend changes are validated by CI tests, not a preview deploy (see [Cloud Run PR Previews (Removed by Design)](#cloud-run-pr-previews-removed-by-design))
+- The preview build points at the production API; no per-PR backend exists
 
 ## Deployment Safety Chain
 
@@ -119,8 +115,8 @@ The staging configuration exists as a **design artifact** demonstrating multi-en
 Feature branch
   │
   ├── PR to develop
-  │     ├── CI: ruff + mypy + pytest (quality gate)
-  │     ├── Cloud Run PR preview (functional validation)
+  │     ├── CI: ruff + mypy + pytest (backend quality gate)
+  │     ├── CI: svelte-check + tsc + vitest (frontend quality gate)
   │     └── Firebase Hosting preview (frontend validation)
   │
   ├── Merged to develop (batched with other features)

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -12,7 +12,7 @@ aifeelnews/
 ├── frontend/                   # Svelte 5 SPA (Firebase Hosting)
 ├── infra/                      # Terraform IaC
 ├── scripts/                    # Utility and setup scripts
-├── tests/                      # pytest test suite
+├── tests/                      # Backend test suite (pytest); frontend tests live in frontend/src/lib/
 ├── .pre-commit-config.yaml     # Pre-commit hooks (ruff, mypy)
 ├── alembic.ini                 # Alembic migration config
 ├── docker-compose.yml          # Local development stack (worker/scheduler behind the `pipeline` profile)
@@ -111,10 +111,13 @@ frontend/
 │   ├── app.css                 # Global styles
 │   └── lib/
 │       ├── api.ts              # Backend API client (fetch wrapper)
-│       └── firebase.ts         # Firebase Auth initialization
+│       ├── firebase.ts         # Firebase Auth initialization
+│       └── *.test.ts           # Vitest unit tests, co-located with the modules they cover
 ├── index.html                  # SPA entry HTML
 ├── firebase.json               # Firebase Hosting config
 ├── vite.config.ts              # Vite build configuration
+├── vitest.config.ts            # Vitest config (extends vite.config.ts; jsdom environment)
+├── vitest-setup.ts             # Test setup (jest-dom matchers)
 ├── svelte.config.js            # Svelte compiler options
 └── package.json                # Node dependencies
 ```
@@ -138,7 +141,7 @@ infra/
 | `deploy.yml` | Push/PR to `main` or `develop` | Lint (ruff) → type-check (mypy) → test (pytest, with a Postgres service) → build Docker → deploy Cloud Run (deploy step gated to `main`) |
 | `firebase-hosting-merge.yml` | Push to `main` | Build frontend → deploy to Firebase Hosting (live) |
 | `firebase-hosting-pull-request.yml` | Any PR | Build frontend → deploy to Firebase Hosting (preview) |
-| `frontend-check.yml` | Push/PR to `main` or `develop` | Frontend type-check (`svelte-check` + `tsc`) |
+| `frontend-check.yml` | Push/PR to `main` or `develop` | Frontend checks: type-check (`svelte-check` + `tsc`) + unit tests (Vitest) |
 | `security.yml` | Push/PR to `main` or `develop`, weekly cron | `pip-audit` (CVE scan) + `gitleaks` (secret scan) |
 | `auto-review.yml` | PR opened | Request GitHub Copilot review |
 
@@ -157,15 +160,44 @@ docker/
 
 17 migration files tracking schema evolution from initial tables through entity extraction, Firebase auth, and full-text search (English + German `tsvector` columns). See [docs/DATABASE.md § 2](DATABASE.md#2-migrations) for the full inventory.
 
-## Tests (`tests/`)
+## Tests
+
+### Backend (`tests/`, pytest)
 
 ```
 tests/
-├── conftest.py                 # Fixtures: SQLite test DB, mock config
-├── test_bigquery.py            # BigQuery service: config, buffering, graceful degradation
-├── test_crawl_worker.py        # Crawl pipeline unit tests
-├── test_ingestion.py           # Ingestion pipeline tests
-└── test_new_models.py          # ORM model relationship tests
+├── conftest.py                    # Fixtures: SQLite test DB (default), real-Postgres fixtures, mock config
+├── test_articles_filters.py      # Filter / search / pagination contract on /api/v1/articles
+├── test_articles_search_fts.py   # Full-text search endpoint (Postgres-only)
+├── test_articles_search_pg.py    # Trigram-accelerated title search (Postgres-only)
+├── test_auth_security.py         # Auth, OIDC, CORS and rate-limit assertions
+├── test_backfill_magnitude.py    # Sentiment-magnitude backfill logic
+├── test_bigquery.py              # BigQuery service: config, buffering, graceful degradation
+├── test_crawl_worker.py          # Crawl pipeline branch tests
+├── test_db_analytics.py          # Advanced-SQL analytics (window fns, CTEs, GROUPING SETS; real Postgres)
+├── test_db_analytics_routes.py   # /api/v1/db-analytics HTTP layer
+├── test_db_views.py              # PostgreSQL views and stored functions (real Postgres)
+├── test_entities_routes.py       # GET /api/v1/entities/ quality gate
+├── test_ingestion.py             # Ingestion pipeline tests
+├── test_new_models.py            # ORM model relationship tests
+├── test_robots.py                # robots.txt compliance edge cases
+├── test_seed_db.py               # Local-development seed loader
+└── test_sources_routes.py        # GET /api/v1/sources/ language filtering
+```
+
+### Frontend (`frontend/src/lib/*.test.ts`, Vitest)
+
+72 tests in 5 files (Vitest + jsdom + Testing Library), co-located with the
+modules they cover. Run with `npm test` / `npm run test:watch`; CI runs them in
+`frontend-check.yml` after the type-check.
+
+```
+frontend/src/lib/
+├── api.test.ts           # Backend contract: query-string assembly, status-code semantics (409/401/404), numeric coercion
+├── sentiment.test.ts     # describeSentiment / magnitudeTier branches incl. calibrated magnitude thresholds
+├── bookmarkStore.test.ts # Set/Map consistency across add, remove, hydrate, reset
+├── theme.test.ts         # Dark-first default, localStorage persistence, data-theme application
+└── Pagination.test.ts    # Component rendering: page math, prev/next enablement
 ```
 
 ## Code Quality
@@ -175,7 +207,8 @@ tests/
 | **Ruff** | Linting + formatting (replaces Black, isort, flake8) | `pyproject.toml` |
 | **mypy** | Static type checking | `pyproject.toml` |
 | **pre-commit** | Git hooks (ruff, mypy, trailing whitespace) | `.pre-commit-config.yaml` |
-| **pytest** | Test runner | `pytest.ini` |
+| **pytest** | Backend test runner | `pytest.ini` |
+| **Vitest** | Frontend test runner (jsdom + Testing Library) | `frontend/vitest.config.ts` |
 
 ## Key Architectural Patterns
 

--- a/docs/SECURITY_MEASURES.md
+++ b/docs/SECURITY_MEASURES.md
@@ -465,13 +465,17 @@ as Code Scanning alerts. Has caught stack-trace exposure
 - **Threats:** [1.I1](THREAT_MODEL.md#1-cloud-run-web-service),
   [5.T2](THREAT_MODEL.md#5-cicd-pipeline)
 
-### 7.9 Frontend type-check (CI)
+### 7.9 Frontend checks (CI)
 
-`npm run check` (`svelte-check` + `tsc`) runs on every push/PR via
-`frontend-check.yml`. `vite build` strips TypeScript types without
-checking them, so this is the only gate that fails CI on a frontend
-type error — and unlike the preview workflow it is not skipped for
-Dependabot, so `typescript` / `@types/*` bumps are verified.
+`npm run check` (`svelte-check` + `tsc`) and `npm test` (Vitest unit
+tests) run on every push/PR via `frontend-check.yml`. `vite build`
+strips TypeScript types without checking them, so this is the only gate
+that fails CI on a frontend type error — and unlike the preview workflow
+it is not skipped for Dependabot, so `typescript` / `@types/*` bumps are
+verified. The Vitest suite extends the gate to behavioural regressions
+in the frontend logic layer (the `api.ts` backend contract incl.
+auth-error handling, sentiment mapping, bookmark store, theme
+persistence), which would otherwise build and deploy cleanly.
 
 - **Config:** [.github/workflows/frontend-check.yml](../.github/workflows/frontend-check.yml)
 - **Threats:** code-quality side-effect on

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,11 +13,16 @@ This is the frontend for aiFeelNews, built with Svelte, TypeScript, and Vite. It
    ```bash
    npm run dev
    ```
-4. Build for production:
+4. Run the unit tests:
+   ```bash
+   npm test            # single run (what CI runs)
+   npm run test:watch  # watch mode
+   ```
+5. Build for production:
    ```bash
    npm run build
    ```
-5. Deploy to Firebase Hosting:
+6. Deploy to Firebase Hosting:
    ```bash
    npx firebase deploy --only hosting
    ```
@@ -38,11 +43,31 @@ See `.env.example` for required variables:
 - **Privacy by design, no cookies.** Firebase stores its auth token in `localStorage`/IndexedDB, not cookies, and the app sets no tracking cookies — so there is no cookie banner. The footer states this and links to an in-app **Privacy** page (`src/lib/Privacy.svelte`) that describes what data the platform handles.
 - **3-page SPA.** A lightweight state machine (`articles | analytics | bookmarks`, plus the public privacy page) — no SvelteKit/router. The wordmark is a home link.
 
+## 🧪 Testing
+
+Unit tests run on Vitest + jsdom + Testing Library, co-located with the
+modules they cover (`src/lib/*.test.ts`):
+
+- `api.test.ts` — the backend contract: query-string assembly and status-code
+  semantics (409 → silent success, 401 → `AuthExpiredError`, 404 → silent
+  delete), plus the Postgres `Decimal`-string → `number` coercion
+- `sentiment.test.ts` — `describeSentiment` / `magnitudeTier` branches,
+  including the calibrated magnitude thresholds
+- `bookmarkStore.test.ts` — Set/Map consistency across add, remove, hydrate, reset
+- `theme.test.ts` — dark-first default, `localStorage` persistence, `data-theme`
+- `Pagination.test.ts` — component rendering: page math, prev/next enablement
+
+`npm test` runs the suite once — CI does the same in `frontend-check.yml`
+after the type-check. Config lives in `vitest.config.ts` (extends
+`vite.config.ts` so components compile exactly as in the real build) and
+`vitest-setup.ts` (jest-dom matchers).
+
 ## 🛠️ Project Structure
 
-- `src/` — Svelte app source code
+- `src/` — Svelte app source code (tests co-located as `src/lib/*.test.ts`)
 - `public/` — Static assets
 - `firebase.json` — Firebase Hosting config
+- `vitest.config.ts`, `vitest-setup.ts` — test configuration
 
 ## 📝 Documentation
 - See the root `README.md` and `docs/PROJECT_STRUCTURE.md` for backend and deployment details.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,12 +13,262 @@
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/svelte": "^5.3.1",
         "@tsconfig/svelte": "^5.0.8",
         "@types/node": "^25.8.0",
+        "jsdom": "^29.1.1",
         "svelte": "^5.56.3",
         "svelte-check": "^4.3.4",
         "typescript": "~6.0.3",
-        "vite": "^8.0.13"
+        "vite": "^8.0.13",
+        "vitest": "^4.1.8"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.2.tgz",
+      "integrity": "sha512-n6Zd8mpVhObnaOqq6TC/lBCKgYncAGfFwuvJGQZTDRAwEoxwXIZu9kXBQeXkcqHsE6Sp6LyxDMrvXj5gOxnryw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -53,6 +303,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/ai": {
@@ -1109,6 +1377,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
@@ -1149,6 +1424,103 @@
         "vite": "^8.0.0-beta.7 || ^8.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
     "node_modules/@tsconfig/svelte": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
@@ -1166,6 +1538,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1189,6 +1586,119 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1237,6 +1747,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1245,6 +1765,26 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chart.js": {
@@ -1317,6 +1857,55 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1325,6 +1914,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1344,10 +1943,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escalade": {
@@ -1382,6 +2008,26 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/faye-websocket": {
@@ -1474,6 +2120,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -1486,6 +2145,16 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1495,6 +2164,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1503,6 +2179,54 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -1785,6 +2509,26 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1793,6 +2537,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mri": {
@@ -1837,6 +2598,26 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1887,6 +2668,34 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
@@ -1911,6 +2720,23 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1925,10 +2751,34 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2001,6 +2851,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2010,6 +2880,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2032,6 +2916,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -2090,6 +2987,30 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2105,6 +3026,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -2125,6 +3102,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -2231,11 +3218,124 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
@@ -2260,6 +3360,48 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -2276,6 +3418,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,16 +7,22 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
     "@tsconfig/svelte": "^5.0.8",
     "@types/node": "^25.8.0",
+    "jsdom": "^29.1.1",
     "svelte": "^5.56.3",
     "svelte-check": "^4.3.4",
     "typescript": "~6.0.3",
-    "vite": "^8.0.13"
+    "vite": "^8.0.13",
+    "vitest": "^4.1.8"
   },
   "dependencies": {
     "chart.js": "^4.5.1",

--- a/frontend/src/lib/Pagination.test.ts
+++ b/frontend/src/lib/Pagination.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import Pagination from "./Pagination.svelte";
+
+// A focused component test: proves Svelte render harness works end-to-end
+// and pins the component's derived logic (page number, prev/next enablement),
+// which is the only real logic Pagination owns.
+describe("Pagination", () => {
+  const prev = () => screen.getByRole("button", { name: "Previous page" });
+  const next = () => screen.getByRole("button", { name: "Next page" });
+
+  it("shows page 1 and disables Prev at the start of the feed", () => {
+    render(Pagination, { current: 0, pageSize: 20, hasMore: true });
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+    expect(prev()).toBeDisabled();
+    expect(next()).toBeEnabled();
+  });
+
+  it("computes the page number from skip/pageSize", () => {
+    render(Pagination, { current: 40, pageSize: 20, hasMore: true });
+    expect(screen.getByText("Page 3")).toBeInTheDocument();
+    expect(prev()).toBeEnabled();
+    expect(next()).toBeEnabled();
+  });
+
+  it("disables Next when there are no more results", () => {
+    render(Pagination, { current: 40, pageSize: 20, hasMore: false });
+    expect(next()).toBeDisabled();
+    expect(prev()).toBeEnabled();
+  });
+
+  it("uses pageSize as the divisor (page 2 at one full page in)", () => {
+    render(Pagination, { current: 10, pageSize: 10, hasMore: false });
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  fetchArticles,
+  searchArticles,
+  fetchArticleById,
+  fetchSources,
+  createBookmark,
+  listBookmarks,
+  deleteBookmark,
+  AuthExpiredError,
+  fetchSentimentTrends,
+  fetchSentimentRolling,
+  fetchSourcesRanked,
+} from "./api";
+
+// vitest.config.ts pins VITE_API_BASE_URL to this value.
+const BASE = "http://test.local";
+
+/** Build a minimal fetch Response stand-in. */
+function res(
+  data: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {},
+): Response {
+  return {
+    ok,
+    status,
+    json: async () => data,
+    text: async () => (typeof data === "string" ? data : JSON.stringify(data)),
+  } as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** URL string passed to the Nth fetch call. */
+function calledUrl(n = 0): string {
+  return fetchMock.mock.calls[n][0] as string;
+}
+
+/** RequestInit passed to the Nth fetch call. */
+function calledInit(n = 0): RequestInit | undefined {
+  return fetchMock.mock.calls[n][1] as RequestInit | undefined;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  // api.ts logs to console.error on non-ok responses; keep test output clean.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fetchArticles — query-string assembly", () => {
+  it("hits the canonical endpoint with no query string when no params given", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchArticles();
+    expect(calledUrl()).toBe(`${BASE}/api/v1/articles/`);
+  });
+
+  it("keeps skip=0 (it is a meaningful offset, not 'unset')", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchArticles({ skip: 0, limit: 20 });
+    const url = new URL(calledUrl());
+    expect(url.searchParams.get("skip")).toBe("0");
+    expect(url.searchParams.get("limit")).toBe("20");
+  });
+
+  it("keeps source_id=0 but drops it when null/undefined", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchArticles({ source_id: 0 });
+    expect(new URL(calledUrl()).searchParams.get("source_id")).toBe("0");
+
+    fetchMock.mockClear();
+    await fetchArticles({ source_id: null as unknown as number });
+    expect(new URL(calledUrl()).searchParams.has("source_id")).toBe(false);
+  });
+
+  it("drops empty-string text filters (falsy)", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchArticles({ search: "", category: "", sentiment_label: "" });
+    expect(calledUrl()).toBe(`${BASE}/api/v1/articles/`);
+  });
+
+  it("serialises every supported filter", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchArticles({
+      sentiment_label: "positive",
+      category: "tech",
+      search: "ai",
+      published_after: "2026-01-01T00:00:00Z",
+      published_before: "2026-02-01T00:00:00Z",
+      language: "de",
+    });
+    const p = new URL(calledUrl()).searchParams;
+    expect(p.get("sentiment_label")).toBe("positive");
+    expect(p.get("category")).toBe("tech");
+    expect(p.get("search")).toBe("ai");
+    expect(p.get("published_after")).toBe("2026-01-01T00:00:00Z");
+    expect(p.get("published_before")).toBe("2026-02-01T00:00:00Z");
+    expect(p.get("language")).toBe("de");
+  });
+
+  it("throws with status + body on a non-ok response", async () => {
+    fetchMock.mockResolvedValue(res("boom", { ok: false, status: 500 }));
+    await expect(fetchArticles()).rejects.toThrow(/500/);
+  });
+});
+
+describe("searchArticles", () => {
+  it("always sends q and targets the /search endpoint", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await searchArticles({ q: '"climate" or energy', language: "en" });
+    const url = new URL(calledUrl());
+    expect(url.pathname).toBe("/api/v1/articles/search");
+    expect(url.searchParams.get("q")).toBe('"climate" or energy');
+    expect(url.searchParams.get("language")).toBe("en");
+  });
+});
+
+describe("fetchArticleById", () => {
+  it("targets the by-id path", async () => {
+    fetchMock.mockResolvedValue(res({ id: 42 }));
+    await fetchArticleById(42);
+    expect(calledUrl()).toBe(`${BASE}/api/v1/articles/42`);
+  });
+});
+
+describe("fetchSources", () => {
+  it("appends an encoded language filter when given", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchSources("de");
+    expect(calledUrl()).toBe(`${BASE}/api/v1/sources/?language=de`);
+  });
+
+  it("omits the query string when no language given", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchSources();
+    expect(calledUrl()).toBe(`${BASE}/api/v1/sources/`);
+  });
+});
+
+describe("createBookmark — status-code contract", () => {
+  it("POSTs with the bearer token and JSON body, returning the created bookmark", async () => {
+    const bm = { id: 7, user_id: 1, article_id: 99 };
+    fetchMock.mockResolvedValue(res(bm, { status: 201 }));
+    const out = await createBookmark(99, "tok-abc");
+    expect(out).toEqual(bm);
+
+    const init = calledInit();
+    expect(init?.method).toBe("POST");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok-abc");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init?.body as string)).toEqual({ article_id: 99 });
+  });
+
+  it("treats 409 (already bookmarked) as silent success → null", async () => {
+    fetchMock.mockResolvedValue(res("conflict", { ok: false, status: 409 }));
+    await expect(createBookmark(99, "tok")).resolves.toBeNull();
+  });
+
+  it("throws AuthExpiredError on 401", async () => {
+    fetchMock.mockResolvedValue(res("unauth", { ok: false, status: 401 }));
+    await expect(createBookmark(99, "tok")).rejects.toBeInstanceOf(
+      AuthExpiredError,
+    );
+  });
+
+  it("throws a generic error on other failures", async () => {
+    fetchMock.mockResolvedValue(res("nope", { ok: false, status: 500 }));
+    await expect(createBookmark(99, "tok")).rejects.toThrow(/500/);
+  });
+});
+
+describe("listBookmarks", () => {
+  it("sends the bearer token and returns the array", async () => {
+    fetchMock.mockResolvedValue(res([{ id: 1, user_id: 1, article_id: 2 }]));
+    const out = await listBookmarks("tok-xyz");
+    expect(out).toHaveLength(1);
+    const headers = calledInit()?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok-xyz");
+  });
+
+  it("throws AuthExpiredError on 401", async () => {
+    fetchMock.mockResolvedValue(res("", { ok: false, status: 401 }));
+    await expect(listBookmarks("tok")).rejects.toBeInstanceOf(AuthExpiredError);
+  });
+});
+
+describe("deleteBookmark — status-code contract", () => {
+  it("resolves on success", async () => {
+    fetchMock.mockResolvedValue(res(null, { status: 204 }));
+    await expect(deleteBookmark(5, "tok")).resolves.toBeUndefined();
+    expect(calledInit()?.method).toBe("DELETE");
+  });
+
+  it("treats 404 (already gone) as silent success", async () => {
+    fetchMock.mockResolvedValue(res("", { ok: false, status: 404 }));
+    await expect(deleteBookmark(5, "tok")).resolves.toBeUndefined();
+  });
+
+  it("throws AuthExpiredError on 401", async () => {
+    fetchMock.mockResolvedValue(res("", { ok: false, status: 401 }));
+    await expect(deleteBookmark(5, "tok")).rejects.toBeInstanceOf(
+      AuthExpiredError,
+    );
+  });
+
+  it("throws a generic error on other failures", async () => {
+    fetchMock.mockResolvedValue(res("err", { ok: false, status: 500 }));
+    await expect(deleteBookmark(5, "tok")).rejects.toThrow(/500/);
+  });
+});
+
+describe("analytics fetchers", () => {
+  it("fetchSentimentTrends builds days + optional source params", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchSentimentTrends(7, "bbc");
+    const url = new URL(calledUrl());
+    expect(url.pathname).toBe("/api/v1/analytics/trends");
+    expect(url.searchParams.get("days")).toBe("7");
+    expect(url.searchParams.get("source")).toBe("bbc");
+  });
+
+  it("returns [] when BigQuery is disabled (response is an object, not an array)", async () => {
+    fetchMock.mockResolvedValue(res({ message: "BigQuery disabled" }));
+    await expect(fetchSentimentTrends()).resolves.toEqual([]);
+  });
+
+  it("throws when the analytics request fails", async () => {
+    fetchMock.mockResolvedValue(res("", { ok: false, status: 503 }));
+    await expect(fetchSentimentTrends()).rejects.toThrow(/503/);
+  });
+});
+
+describe("DB-analytics numeric coercion (Postgres Decimal → string)", () => {
+  it("coerces declared decimal fields from string to number, null-safe", async () => {
+    // psycopg2 renders ROUND(numeric) as a JSON *string*; api.ts must coerce.
+    fetchMock.mockResolvedValue(
+      res([
+        { day: "2026-06-01", article_count: 3, avg_sentiment: "0.14", rolling_avg: "0.20" },
+        { day: "2026-06-02", article_count: 0, avg_sentiment: null, rolling_avg: null },
+      ]),
+    );
+    const rows = await fetchSentimentRolling(30, 7);
+    expect(rows[0].avg_sentiment).toBe(0.14);
+    expect(typeof rows[0].avg_sentiment).toBe("number");
+    expect(rows[0].rolling_avg).toBe(0.2);
+    // null stays null (not coerced to 0)
+    expect(rows[1].avg_sentiment).toBeNull();
+    expect(rows[1].rolling_avg).toBeNull();
+  });
+
+  it("appends the language suffix only when a language is selected", async () => {
+    fetchMock.mockResolvedValue(res([]));
+    await fetchSourcesRanked(30, "de");
+    expect(calledUrl()).toContain("&language=de");
+
+    fetchMock.mockClear();
+    await fetchSourcesRanked(30);
+    expect(calledUrl()).not.toContain("language=");
+  });
+
+  it("returns [] when the DB-analytics response is not an array", async () => {
+    fetchMock.mockResolvedValue(res({ detail: "nope" }));
+    await expect(fetchSourcesRanked()).resolves.toEqual([]);
+  });
+});

--- a/frontend/src/lib/bookmarkStore.test.ts
+++ b/frontend/src/lib/bookmarkStore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { bookmarkStore } from "./bookmarkStore";
+import type { BookmarkDto } from "./api";
+
+function bm(id: number, articleId: number): BookmarkDto {
+  return { id, user_id: 1, article_id: articleId };
+}
+
+// The store keeps two parallel structures (a Set of article ids + a Map of
+// article_id → bookmark.id). These tests pin that they stay consistent — the
+// classic place a state bug hides.
+beforeEach(() => {
+  bookmarkStore.reset();
+});
+
+describe("add", () => {
+  it("marks the article bookmarked; bookmark id is unknown until provided", () => {
+    bookmarkStore.add(99);
+    expect(bookmarkStore.has(99)).toBe(true);
+    // optimistic add before the POST returns → no server id yet
+    expect(bookmarkStore.getBookmarkId(99)).toBeNull();
+  });
+
+  it("records the server bookmark id when supplied", () => {
+    bookmarkStore.add(99, 7);
+    expect(bookmarkStore.has(99)).toBe(true);
+    expect(bookmarkStore.getBookmarkId(99)).toBe(7);
+  });
+
+  it("resolves the id on a second add (optimistic-add → POST-resolved)", () => {
+    bookmarkStore.add(99); // optimistic
+    bookmarkStore.add(99, 7); // resolved with server id
+    expect(bookmarkStore.getBookmarkId(99)).toBe(7);
+    expect(bookmarkStore.has(99)).toBe(true);
+  });
+
+  it("reflects into subscribers", () => {
+    bookmarkStore.add(99, 7);
+    const state = get(bookmarkStore);
+    expect(state.bookmarkedIds.has(99)).toBe(true);
+    expect(state.byArticleId.get(99)).toBe(7);
+  });
+});
+
+describe("remove", () => {
+  it("clears both the membership and the id mapping", () => {
+    bookmarkStore.add(99, 7);
+    bookmarkStore.remove(99);
+    expect(bookmarkStore.has(99)).toBe(false);
+    expect(bookmarkStore.getBookmarkId(99)).toBeNull();
+  });
+
+  it("is a no-op for an unknown article", () => {
+    expect(() => bookmarkStore.remove(12345)).not.toThrow();
+    expect(bookmarkStore.has(12345)).toBe(false);
+  });
+});
+
+describe("has / getBookmarkId on unknown ids", () => {
+  it("returns false / null", () => {
+    expect(bookmarkStore.has(404)).toBe(false);
+    expect(bookmarkStore.getBookmarkId(404)).toBeNull();
+  });
+});
+
+describe("hydrate", () => {
+  it("rebuilds both structures from a bookmark list", () => {
+    bookmarkStore.hydrate([bm(7, 99), bm(8, 100)]);
+    expect(bookmarkStore.has(99)).toBe(true);
+    expect(bookmarkStore.has(100)).toBe(true);
+    expect(bookmarkStore.getBookmarkId(99)).toBe(7);
+    expect(bookmarkStore.getBookmarkId(100)).toBe(8);
+  });
+
+  it("replaces prior state rather than merging", () => {
+    bookmarkStore.add(1, 1);
+    bookmarkStore.hydrate([bm(8, 100)]);
+    expect(bookmarkStore.has(1)).toBe(false); // gone after re-hydrate
+    expect(bookmarkStore.has(100)).toBe(true);
+  });
+
+  it("hydrating an empty list clears the store", () => {
+    bookmarkStore.add(1, 1);
+    bookmarkStore.hydrate([]);
+    expect(get(bookmarkStore).bookmarkedIds.size).toBe(0);
+  });
+});
+
+describe("reset", () => {
+  it("empties both structures (used on sign-out)", () => {
+    bookmarkStore.hydrate([bm(7, 99), bm(8, 100)]);
+    bookmarkStore.reset();
+    const state = get(bookmarkStore);
+    expect(state.bookmarkedIds.size).toBe(0);
+    expect(state.byArticleId.size).toBe(0);
+  });
+});

--- a/frontend/src/lib/sentiment.test.ts
+++ b/frontend/src/lib/sentiment.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { describeSentiment, magnitudeTier } from "./sentiment";
+
+// The magnitude cut-points are calibrated production percentiles (33rd = 7.8,
+// 66th = 15.4). The tests pin the boundary behaviour so a future re-calibration
+// is a deliberate, visible change rather than a silent drift.
+const MAG_LOW = 7.8;
+const MAG_HIGH = 15.4;
+
+describe("describeSentiment", () => {
+  describe("missing / unanalyzed input degrades to empty string", () => {
+    it("returns '' when label is absent", () => {
+      expect(describeSentiment({ score: 0.5 })).toBe("");
+    });
+
+    it("returns '' when score is null", () => {
+      expect(describeSentiment({ label: "positive", score: null })).toBe("");
+    });
+
+    it("returns '' when score is undefined", () => {
+      expect(describeSentiment({ label: "positive" })).toBe("");
+    });
+
+    it("treats score 0 as present (not missing)", () => {
+      // 0 is a valid neutral score and must NOT be coerced to "no data".
+      expect(describeSentiment({ label: "neutral", score: 0 })).toBe(
+        "Balanced, neutral tone",
+      );
+    });
+  });
+
+  describe("neutral label uses magnitude to disambiguate", () => {
+    it("high magnitude → mixed/polarizing, not truly neutral", () => {
+      expect(
+        describeSentiment({ label: "neutral", score: 0, magnitude: MAG_HIGH }),
+      ).toBe("Mixed tone — strong feeling on both sides, not truly neutral");
+    });
+
+    it("low magnitude → largely factual", () => {
+      expect(
+        describeSentiment({ label: "neutral", score: 0, magnitude: 1.0 }),
+      ).toBe("Largely factual, with little emotional language");
+    });
+
+    it("mid magnitude → balanced", () => {
+      expect(
+        describeSentiment({ label: "neutral", score: 0, magnitude: 10 }),
+      ).toBe("Balanced, neutral tone");
+    });
+
+    it("null magnitude (VADER) → balanced, no crash", () => {
+      expect(
+        describeSentiment({ label: "neutral", score: 0, magnitude: null }),
+      ).toBe("Balanced, neutral tone");
+    });
+
+    it("MAG_LOW is inclusive of medium (not 'factual') at the boundary", () => {
+      // branch is `magnitude < MAG_LOW` → exactly MAG_LOW is medium → balanced
+      expect(
+        describeSentiment({ label: "neutral", score: 0, magnitude: MAG_LOW }),
+      ).toBe("Balanced, neutral tone");
+    });
+  });
+
+  describe("intensity buckets (|score|)", () => {
+    it("|score| > 0.6 → strongly", () => {
+      expect(describeSentiment({ label: "positive", score: 0.8 })).toBe(
+        "Strongly positive (0.80)",
+      );
+    });
+
+    it("|score| == 0.6 → moderately (boundary is exclusive)", () => {
+      expect(describeSentiment({ label: "positive", score: 0.6 })).toBe(
+        "Moderately positive (0.60)",
+      );
+    });
+
+    it("0.25 < |score| <= 0.6 → moderately", () => {
+      expect(describeSentiment({ label: "negative", score: -0.4 })).toBe(
+        "Moderately negative (-0.40)",
+      );
+    });
+
+    it("|score| == 0.25 → slightly (boundary is exclusive)", () => {
+      expect(describeSentiment({ label: "positive", score: 0.25 })).toBe(
+        "Slightly positive (0.25)",
+      );
+    });
+
+    it("|score| < 0.25 → slightly", () => {
+      expect(describeSentiment({ label: "negative", score: -0.1 })).toBe(
+        "Slightly negative (-0.10)",
+      );
+    });
+  });
+
+  describe("direction, formatting, entities and emotional-charge suffix", () => {
+    it("label is case-insensitive", () => {
+      expect(describeSentiment({ label: "POSITIVE", score: 0.8 })).toBe(
+        "Strongly positive (0.80)",
+      );
+    });
+
+    it("score is always rendered to 2 decimals", () => {
+      expect(describeSentiment({ label: "positive", score: 0.5 })).toContain(
+        "(0.50)",
+      );
+    });
+
+    it("appends the top two entities, salience-ordered", () => {
+      expect(
+        describeSentiment({
+          label: "negative",
+          score: -0.5,
+          topEntities: ["Ukraine", "NATO"],
+        }),
+      ).toBe("Moderately negative (-0.50), centred on Ukraine and NATO");
+    });
+
+    it("caps the entity focus at two even when more are supplied", () => {
+      const out = describeSentiment({
+        label: "positive",
+        score: 0.7,
+        topEntities: ["A", "B", "C", "D"],
+      });
+      expect(out).toContain("centred on A and B");
+      expect(out).not.toContain("C");
+    });
+
+    it("omits the focus clause when no entities are present", () => {
+      expect(describeSentiment({ label: "positive", score: 0.7 })).not.toContain(
+        "centred on",
+      );
+    });
+
+    it("appends '— emotionally charged' when magnitude is high", () => {
+      expect(
+        describeSentiment({
+          label: "positive",
+          score: 0.7,
+          magnitude: MAG_HIGH,
+        }),
+      ).toBe("Strongly positive (0.70) — emotionally charged");
+    });
+
+    it("does NOT append the charge suffix when magnitude is null (VADER)", () => {
+      expect(
+        describeSentiment({ label: "positive", score: 0.7, magnitude: null }),
+      ).not.toContain("emotionally charged");
+    });
+
+    it("combines entity focus and the charge suffix", () => {
+      expect(
+        describeSentiment({
+          label: "negative",
+          score: -0.9,
+          magnitude: 30,
+          topEntities: ["Gaza"],
+        }),
+      ).toBe("Strongly negative (-0.90), centred on Gaza — emotionally charged");
+    });
+  });
+});
+
+describe("magnitudeTier", () => {
+  it("returns null when magnitude is unavailable (VADER-only)", () => {
+    expect(magnitudeTier(null)).toBeNull();
+    expect(magnitudeTier(undefined)).toBeNull();
+  });
+
+  it("classifies high (>= MAG_HIGH, inclusive)", () => {
+    expect(magnitudeTier(MAG_HIGH)).toBe("high");
+    expect(magnitudeTier(196.1)).toBe("high");
+  });
+
+  it("classifies low (< MAG_LOW, exclusive)", () => {
+    expect(magnitudeTier(0)).toBe("low");
+    expect(magnitudeTier(7.79)).toBe("low");
+  });
+
+  it("classifies medium in between (MAG_LOW inclusive, MAG_HIGH exclusive)", () => {
+    expect(magnitudeTier(MAG_LOW)).toBe("medium");
+    expect(magnitudeTier(10)).toBe("medium");
+    expect(magnitudeTier(15.39)).toBe("medium");
+  });
+});

--- a/frontend/src/lib/theme.test.ts
+++ b/frontend/src/lib/theme.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+
+const STORAGE_KEY = "aifeelnews-theme";
+
+// theme.ts runs side effects (read storage, apply data-theme, subscribe-persist)
+// at module-load. To exercise the initial-read branches under different
+// preconditions we reset the module registry and re-import per test.
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  vi.resetModules();
+});
+
+describe("initial theme", () => {
+  it("defaults to dark when nothing is stored (dark-first by design)", async () => {
+    const { theme } = await import("./theme");
+    expect(get(theme)).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("restores an explicit 'light' choice from localStorage", async () => {
+    localStorage.setItem(STORAGE_KEY, "light");
+    const { theme } = await import("./theme");
+    expect(get(theme)).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("falls back to dark for any non-'light' stored value", async () => {
+    localStorage.setItem(STORAGE_KEY, "garbage");
+    const { theme } = await import("./theme");
+    expect(get(theme)).toBe("dark");
+  });
+});
+
+describe("toggleTheme", () => {
+  it("flips dark → light, persisting and applying the DOM attribute", async () => {
+    const { theme, toggleTheme } = await import("./theme");
+    toggleTheme();
+    expect(get(theme)).toBe("light");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("flips back to dark on a second toggle", async () => {
+    const { theme, toggleTheme } = await import("./theme");
+    toggleTheme();
+    toggleTheme();
+    expect(get(theme)).toBe("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,5 +17,9 @@
     "checkJs": true,
     "moduleDetection": "force"
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
+  // vitest-setup.ts must be part of this project: its side-effect import of
+  // `@testing-library/jest-dom/vitest` augments Vitest's Assertion interface,
+  // which is what gives *.test.ts files typed jest-dom matchers
+  // (toBeInTheDocument, toBeDisabled, …) in both the editor and svelte-check.
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "vitest-setup.ts"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest-setup.ts
+++ b/frontend/vitest-setup.ts
@@ -1,0 +1,5 @@
+// Vitest global setup. Registers the jest-dom matchers (toBeDisabled,
+// toHaveTextContent, …) on `expect` for component tests. Auto-cleanup of
+// rendered Svelte components is handled by the `svelteTesting()` plugin in
+// vitest.config.ts, so it is not repeated here.
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,30 @@
+import { mergeConfig, defineConfig } from "vitest/config";
+import { svelteTesting } from "@testing-library/svelte/vite";
+import viteConfig from "./vite.config";
+
+// Test config is kept separate from vite.config.ts on purpose: the production
+// build (`vite build` → Firebase Hosting) must never pull in test-only tooling
+// (vitest, jsdom, testing-library). Vitest auto-prefers this file over
+// vite.config.ts, and we re-use the base config (svelte plugin, etc.) via
+// mergeConfig so component compilation matches the real build.
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    plugins: [
+      // Resolves the browser build of Svelte and auto-cleans rendered
+      // components between tests.
+      svelteTesting(),
+    ],
+    test: {
+      environment: "jsdom",
+      include: ["src/**/*.{test,spec}.ts"],
+      setupFiles: ["./vitest-setup.ts"],
+      // Pin a deterministic API base so api.ts URL assertions don't depend on
+      // the host the tests run on. Without this, jsdom reports hostname
+      // "localhost" and api.ts would select the local-dev base instead.
+      env: {
+        VITE_API_BASE_URL: "http://test.local",
+      },
+    },
+  }),
+);


### PR DESCRIPTION
## Release: frontend unit-test suite + CI gate

Ships PR #192 to production. Frontend and docs only — no backend code, no database migration, no environment-variable changes.

### What's included
- **Vitest unit-test suite** — 72 tests across 5 files covering the API client, sentiment thresholds, bookmark store, pagination, and theme logic.
- **CI gate** — `frontend-check.yml` now runs the suite on every frontend PR alongside `svelte-check` + `tsc`.
- **Documentation sync** — testing and CI/CD docs updated to match the shipped pipeline (`PROJECT_STRUCTURE`, `CICD_PIPELINE`, `SECURITY_MEASURES`, `MULTI_ENVIRONMENT_STRATEGY`, READMEs, Makefile).

### Verification (local, pre-release)
- `npm test` — 72/72 pass
- `npm run check` — svelte-check + tsc, 0 errors, 0 warnings

Prod baseline before this release: `fb6b5d1` (revision `00111-2qv`).
